### PR TITLE
Fix #457: remove limits from camel controller manager

### DIFF
--- a/contrib/camel/config/500-controller.yaml
+++ b/contrib/camel/config/500-controller.yaml
@@ -32,5 +32,9 @@ spec:
       containers:
       - image: github.com/knative/eventing-contrib/contrib/camel/cmd/controller
         name: manager
+        resources:
+          requests:
+            cpu: 20m
+            memory: 20Mi
       serviceAccount: camel-controller-manager
       terminationGracePeriodSeconds: 10

--- a/contrib/camel/config/500-controller.yaml
+++ b/contrib/camel/config/500-controller.yaml
@@ -32,12 +32,5 @@ spec:
       containers:
       - image: github.com/knative/eventing-contrib/contrib/camel/cmd/controller
         name: manager
-        resources:
-          limits:
-            cpu: 100m
-            memory: 30Mi
-          requests:
-            cpu: 20m
-            memory: 20Mi
       serviceAccount: camel-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Fixes #457

Removing limits prevent the controller to crash sporadically on startup. Increasing them would be another option, but the controller does not require so many resources.
