### PR TITLE
golang format tools

### DIFF
--- a/contrib/kafka/pkg/reconciler/resources/receive_adapter_test.go
+++ b/contrib/kafka/pkg/reconciler/resources/receive_adapter_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/knative/eventing-contrib/contrib/kafka/pkg/apis/sources/v1alpha1"
 	"github.com/knative/pkg/kmp"
-	"k8s.io/api/apps/v1"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
