### PR TITLE
golang format tools

### DIFF
--- a/camel/source/pkg/reconciler/camelsource.go
+++ b/camel/source/pkg/reconciler/camelsource.go
@@ -143,10 +143,10 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) error
 func (r *reconciler) reconcileIntegration(ctx context.Context, source *v1alpha1.CamelSource, deprecatedIntegrationContext string, sinkURI string) (*camelv1alpha1.Integration, error) {
 	logger := logging.FromContext(ctx)
 	args := &resources.CamelArguments{
-		Name:      source.Name,
-		Namespace: source.Namespace,
-		Source:    source.Spec.Source,
-		Sink:      sinkURI,
+		Name:                         source.Name,
+		Namespace:                    source.Namespace,
+		Source:                       source.Spec.Source,
+		Sink:                         sinkURI,
 		DeprecatedIntegrationContext: deprecatedIntegrationContext,
 		DeprecatedServiceAccountName: source.Spec.DeprecatedServiceAccountName,
 	}

--- a/camel/source/pkg/reconciler/resources/context.go
+++ b/camel/source/pkg/reconciler/resources/context.go
@@ -31,7 +31,7 @@ func MakeContext(namespace string, image string) *camelv1alpha1.IntegrationConte
 			GenerateName: "ctx-",
 			Namespace:    namespace,
 			Labels: map[string]string{
-				"app": "camel-k",
+				"app":                           "camel-k",
 				"camel.apache.org/context.type": camelv1alpha1.IntegrationContextTypeExternal,
 			},
 		},


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
