### PR TITLE
Make eventSource and eventType to be flags

### DIFF
--- a/cmd/heartbeats/main.go
+++ b/cmd/heartbeats/main.go
@@ -38,12 +38,16 @@ type Heartbeat struct {
 }
 
 var (
-	sink      string
-	label     string
-	periodStr string
+	eventSource string
+	eventType   string
+	sink        string
+	label       string
+	periodStr   string
 )
 
 func init() {
+	flag.StringVar(&eventSource, "eventSource", "", "the event-source (CloudEvents)")
+	flag.StringVar(&eventType, "eventType", "dev.knative.eventing.samples.heartbeat", "the event-type (CloudEvents)")
 	flag.StringVar(&sink, "sink", "", "the host url to heartbeat to")
 	flag.StringVar(&label, "label", "", "a special label")
 	flag.StringVar(&periodStr, "period", "5", "the number of seconds between heartbeats")
@@ -85,9 +89,10 @@ func main() {
 		period = time.Duration(p) * time.Second
 	}
 
-	source := types.ParseURLRef(
-		fmt.Sprintf("https://github.com/knative/eventing-contrib/cmd/heartbeats/#%s/%s", env.Namespace, env.Name))
-	log.Printf("Heartbeats Source: %s", source)
+	if eventSource == "" {
+		eventSource := fmt.Sprintf("https://github.com/knative/eventing-contrib/cmd/heartbeats/#%s/%s", env.Namespace, env.Name)
+		log.Printf("Heartbeats Source: %s", eventSource)
+	}
 
 	if len(label) > 0 && label[0] == '"' {
 		label, _ = strconv.Unquote(label)
@@ -102,8 +107,8 @@ func main() {
 
 		event := cloudevents.Event{
 			Context: cloudevents.EventContextV02{
-				Type:   "dev.knative.eventing.samples.heartbeat",
-				Source: *source,
+				Type:   eventType,
+				Source: *types.ParseURLRef(eventSource),
 				Extensions: map[string]interface{}{
 					"the":   42,
 					"heart": "yes",


### PR DESCRIPTION
As part of fixes https://github.com/knative/eventing/issues/1395

## Proposed Changes
* Make eventSource and eventType to be flags so that we can use heartbeats container image to send CloudEvents with different sources and types.


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```