### PR TITLE
Add release labels to all objects

### DIFF
--- a/config/tools/event-display/event-display.yaml
+++ b/config/tools/event-display/event-display.yaml
@@ -17,6 +17,8 @@ apiVersion: serving.knative.dev/v1alpha1
 kind: Service
 metadata:
   name: event-display
+  labels:
+    contrib.eventing.knative.dev/release: devel
 spec:
   runLatest:
     configuration:

--- a/contrib/awssqs/config/100-namespace.yaml
+++ b/contrib/awssqs/config/100-namespace.yaml
@@ -16,3 +16,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/contrib/awssqs/config/200-serviceaccount.yaml
+++ b/contrib/awssqs/config/200-serviceaccount.yaml
@@ -17,3 +17,5 @@ kind: ServiceAccount
 metadata:
   name: awssqs-controller-manager
   namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/contrib/awssqs/config/201-clusterrole.yaml
+++ b/contrib/awssqs/config/201-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: awssqs-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 rules:
 - apiGroups:
   - apps

--- a/contrib/awssqs/config/202-clusterrolebinding.yaml
+++ b/contrib/awssqs/config/202-clusterrolebinding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: awssqs-controller-rolebinding
+  labels:
+    contrib.eventing.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/contrib/awssqs/config/300-awssqssource.yaml
+++ b/contrib/awssqs/config/300-awssqssource.yaml
@@ -16,6 +16,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
+    contrib.eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     knative.dev/crd-install: "true"
   name: awssqssources.sources.eventing.knative.dev

--- a/contrib/awssqs/config/400-controller-service.yaml
+++ b/contrib/awssqs/config/400-controller-service.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    contrib.eventing.knative.dev/release: devel
     control-plane: awssqs-controller-manager
   name: awssqs-controller-manager
   namespace: knative-sources

--- a/contrib/awssqs/config/500-controller.yaml
+++ b/contrib/awssqs/config/500-controller.yaml
@@ -16,6 +16,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
+    contrib.eventing.knative.dev/release: devel
     control-plane: awssqs-controller-manager
   name: awssqs-controller-manager
   namespace: knative-sources

--- a/contrib/awssqs/config/600-istioegress.yaml
+++ b/contrib/awssqs/config/600-istioegress.yaml
@@ -17,6 +17,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: awssqs-bus-ext
+  labels:
+    contrib.eventing.knative.dev/release: devel
 spec:
   hosts:
   - "*.amazonaws.com"

--- a/contrib/gcppubsub/config/100-namespace.yaml
+++ b/contrib/gcppubsub/config/100-namespace.yaml
@@ -16,3 +16,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/contrib/gcppubsub/config/200-serviceaccount.yaml
+++ b/contrib/gcppubsub/config/200-serviceaccount.yaml
@@ -17,6 +17,8 @@ kind: ServiceAccount
 metadata:
   name: gcppubsub-controller-manager
   namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel
 secrets:
 - name: gcppubsub-source-key
 ---
@@ -24,6 +26,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: gcppubsub-source-key
+  labels:
+    contrib.eventing.knative.dev/release: devel
 type: Opaque
 data:
   'key.json': ""

--- a/contrib/gcppubsub/config/201-clusterrole.yaml
+++ b/contrib/gcppubsub/config/201-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventing-sources-gcppubsub-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 rules:
 
 - apiGroups:

--- a/contrib/gcppubsub/config/202-clusterrolebinding.yaml
+++ b/contrib/gcppubsub/config/202-clusterrolebinding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-sources-gcppubsub-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
 - kind: ServiceAccount
   name: gcppubsub-controller-manager
@@ -31,6 +33,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-sources-gcppubsub-resolver
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
 - kind: ServiceAccount
   name: gcppubsub-controller-manager

--- a/contrib/gcppubsub/config/300-gcppubsubsource.yaml
+++ b/contrib/gcppubsub/config/300-gcppubsubsource.yaml
@@ -16,6 +16,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
+    contrib.eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     knative.dev/crd-install: "true"
   name: gcppubsubsources.sources.eventing.knative.dev

--- a/contrib/gcppubsub/config/400-controller-service.yaml
+++ b/contrib/gcppubsub/config/400-controller-service.yaml
@@ -18,6 +18,7 @@ metadata:
   name: gcppubsub-controller
   namespace: knative-sources
   labels:
+    contrib.eventing.knative.dev/release: devel
     control-plane: gcppubsub-controller-manager
 spec:
   selector:

--- a/contrib/gcppubsub/config/500-controller.yaml
+++ b/contrib/gcppubsub/config/500-controller.yaml
@@ -18,6 +18,7 @@ metadata:
   name: gcppubsub-controller-manager
   namespace: knative-sources
   labels:
+    contrib.eventing.knative.dev/release: devel
     control-plane: gcppubsub-controller-manager
 spec:
   selector:

--- a/contrib/gcppubsub/config/600-istioegress.yaml
+++ b/contrib/gcppubsub/config/600-istioegress.yaml
@@ -17,6 +17,8 @@ apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
   name: gcppubsub-bus-ext
+  labels:
+    contrib.eventing.knative.dev/release: devel
 spec:
   hosts:
   - "*.googleapis.com"

--- a/contrib/github/config/100-namespace.yaml
+++ b/contrib/github/config/100-namespace.yaml
@@ -16,3 +16,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/contrib/github/config/200-serviceaccount.yaml
+++ b/contrib/github/config/200-serviceaccount.yaml
@@ -17,3 +17,5 @@ kind: ServiceAccount
 metadata:
   name: github-controller-manager
   namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/contrib/github/config/201-clusterrole.yaml
+++ b/contrib/github/config/201-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventing-sources-github-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 rules:
 # Sources admin
 - apiGroups:

--- a/contrib/github/config/202-clusterrolebinding.yaml
+++ b/contrib/github/config/202-clusterrolebinding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-sources-github-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
 - kind: ServiceAccount
   name: github-controller-manager
@@ -31,6 +33,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-sources-github-addressable-resolver
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
 - kind: ServiceAccount
   name: github-controller-manager

--- a/contrib/github/config/300-githubsource.yaml
+++ b/contrib/github/config/300-githubsource.yaml
@@ -15,10 +15,11 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  name: githubsources.sources.eventing.knative.dev
   labels:
+    contrib.eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-  name: githubsources.sources.eventing.knative.dev
 spec:
   group: sources.eventing.knative.dev
   names:

--- a/contrib/github/config/400-controller-service.yaml
+++ b/contrib/github/config/400-controller-service.yaml
@@ -18,6 +18,7 @@ metadata:
   name: github-controller
   namespace: knative-sources
   labels:
+    contrib.eventing.knative.dev/release: devel
     control-plane: github-controller-manager
 spec:
   selector:

--- a/contrib/github/config/500-controller.yaml
+++ b/contrib/github/config/500-controller.yaml
@@ -18,6 +18,7 @@ metadata:
   name: github-controller-manager
   namespace: knative-sources
   labels:
+    contrib.eventing.knative.dev/release: devel
     control-plane: github-controller-manager
 spec:
   selector:


### PR DESCRIPTION
Using `contrib.eventing.knative.dev/release` as the label name rather than `sources.eventing.knative.dev/release` since this repo was renamed to eventing-contrib and it might contain things that are not sources.