### PR TITLE
Porting sink change over from 'eventing core'

### DIFF
--- a/camel/source/pkg/reconciler/camelsource_test.go
+++ b/camel/source/pkg/reconciler/camelsource_test.go
@@ -55,7 +55,7 @@ const (
 	addressableKind       = "Sink"
 	addressableAPIVersion = "duck.knative.dev/v1alpha1"
 	addressableDNS        = "addressable.sink.svc.cluster.local"
-	addressableURI        = "http://addressable.sink.svc.cluster.local/"
+	addressableURI        = "http://addressable.sink.svc.cluster.local"
 )
 
 func init() {

--- a/contrib/gcppubsub/pkg/reconciler/gcppubsubsource_test.go
+++ b/contrib/gcppubsub/pkg/reconciler/gcppubsubsource_test.go
@@ -61,7 +61,7 @@ const (
 	brokerKind                 = "Broker"
 	addressableAPIVersion      = "duck.knative.dev/v1alpha1"
 	addressableDNS             = "addressable.sink.svc.cluster.local"
-	addressableURI             = "http://addressable.sink.svc.cluster.local/"
+	addressableURI             = "http://addressable.sink.svc.cluster.local"
 	transformerAddressableName = "testtransformer"
 )
 

--- a/contrib/github/pkg/reconciler/githubsource_test.go
+++ b/contrib/github/pkg/reconciler/githubsource_test.go
@@ -23,14 +23,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/knative/eventing-contrib/contrib/github/pkg/reconciler/resources"
-	"github.com/knative/eventing-contrib/pkg/reconciler/eventtype"
-	"knative.dev/pkg/apis"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/google/go-cmp/cmp"
 	sourcesv1alpha1 "github.com/knative/eventing-contrib/contrib/github/pkg/apis/sources/v1alpha1"
+	"github.com/knative/eventing-contrib/contrib/github/pkg/reconciler/resources"
 	controllertesting "github.com/knative/eventing-contrib/pkg/controller/testing"
+	"github.com/knative/eventing-contrib/pkg/reconciler/eventtype"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	servingv1beta1 "github.com/knative/serving/pkg/apis/serving/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -39,8 +36,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
+	"knative.dev/pkg/apis"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -55,7 +54,7 @@ const (
 	gitHubSourceUID  = "2b2219e2-ce67-11e8-b3a3-42010a8a00af"
 
 	addressableDNS = "addressable.sink.svc.cluster.local"
-	addressableURI = "http://addressable.sink.svc.cluster.local/"
+	addressableURI = "http://addressable.sink.svc.cluster.local"
 
 	addressableName       = "testsink"
 	addressableKind       = "Sink"

--- a/kafka/source/pkg/reconciler/kafkasource_test.go
+++ b/kafka/source/pkg/reconciler/kafkasource_test.go
@@ -23,10 +23,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/knative/eventing-contrib/pkg/reconciler/eventtype"
-
 	sourcesv1alpha1 "github.com/knative/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1"
 	controllertesting "github.com/knative/eventing-contrib/pkg/controller/testing"
+	"github.com/knative/eventing-contrib/pkg/reconciler/eventtype"
 	eventingv1alpha1 "github.com/knative/eventing/pkg/apis/eventing/v1alpha1"
 	eventingsourcesv1alpha1 "github.com/knative/eventing/pkg/apis/sources/v1alpha1"
 	v1 "k8s.io/api/apps/v1"
@@ -62,7 +61,7 @@ const (
 	brokerKind            = "Broker"
 	addressableAPIVersion = "duck.knative.dev/v1alpha1"
 	addressableDNS        = "addressable.sink.svc.cluster.local"
-	addressableURI        = "http://addressable.sink.svc.cluster.local/"
+	addressableURI        = "http://addressable.sink.svc.cluster.local"
 )
 
 func init() {

--- a/pkg/controller/sinks/sinks.go
+++ b/pkg/controller/sinks/sinks.go
@@ -57,9 +57,10 @@ func GetSinkURI(ctx context.Context, c client.Client, sink *corev1.ObjectReferen
 		return "", fmt.Errorf("sink %s does not contain address", objIdentifier)
 	}
 
-	if t.Status.Address.Hostname == "" {
+	url := t.Status.Address.GetURL()
+	if url.Host == "" {
 		return "", fmt.Errorf("sink %s contains an empty hostname", objIdentifier)
 	}
 
-	return fmt.Sprintf("http://%s/", t.Status.Address.Hostname), nil
+	return url.String(), nil
 }

--- a/pkg/controller/sinks/sinks_test.go
+++ b/pkg/controller/sinks/sinks_test.go
@@ -69,7 +69,7 @@ func TestGetSinkURI(t *testing.T) {
 			},
 			namespace: testNS,
 			ref:       getAddressableRef(),
-			want:      fmt.Sprintf("http://%s/", addressableDNS),
+			want:      fmt.Sprintf("http://%s", addressableDNS),
 		},
 		"nil hostname": {
 			objects: []runtime.Object{


### PR DESCRIPTION
Fixes #475

## Proposed Changes

  * porting `sink` part of fbee61d9eb61a760a49783196e63a4a0c4c789f0 over to contrib, in addtion to @n3wscott's update to the `knative.dev/pkg` usage

Tested w/ the Kafka Source.

KSVC:
```
apiVersion: serving.knative.dev/v1beta1
kind: Service
metadata:
  name: k8s-event-display
spec:
  template:
    spec:
      containers:
      - image: docker.io/cds19/event-display
```

Kafka:
```
apiVersion: sources.eventing.knative.dev/v1alpha1
kind: KafkaSource
metadata:
  name: kafka-source2
spec:
  consumerGroup: ledemo
  bootstrapServers: my-cluster-kafka-bootstrap.kafka:9092
  topics: my-topic
  sink:
    apiVersion: serving.knative.dev/v1beta1
    kind: Service
    name: k8s-event-display

```