### PR TITLE
Make gcloud a no-op if not available for test scripts

### DIFF
--- a/test/upload-test-images.sh
+++ b/test/upload-test-images.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# If gcloud is not available make it a no-op, not an error.
+which gcloud &> /dev/null || gcloud() { echo "[ignore-gcloud $*]" 1>&2; }
+
 set -o errexit
 
 function upload_test_images() {


### PR DESCRIPTION
Fixes the same issue as knative/eventing#1507
## Proposed Changes

If gcloud is unavailable, replace it with a no-op shell function