### PR TITLE
fix 404 in API comment for HTML ref doc build

### DIFF
--- a/contrib/gcppubsub/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go
+++ b/contrib/gcppubsub/pkg/apis/sources/v1alpha1/gcp_pubsub_types.go
@@ -55,8 +55,8 @@ var _ = duck.VerifyType(&GcpPubSubSource{}, &duckv1alpha1.Conditions{})
 type GcpPubSubSourceSpec struct {
 	// GcpCredsSecret is the credential to use to poll the GCP PubSub Subscription. It is not used
 	// to create or delete the Subscription, only to poll it. The value of the secret entry must be
-	// a service account key in the JSON format (see
-	// https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
+	// a service account key in the JSON format
+	// ( see https://cloud.google.com/iam/docs/creating-managing-service-account-keys ).
 	GcpCredsSecret corev1.SecretKeySelector `json:"gcpCredsSecret,omitempty"`
 
 	// GoogleCloudProject is the ID of the Google Cloud Project that the PubSub Topic exists in.


### PR DESCRIPTION
Fixes https://github.com/knative/docs/issues/1559

## Proposed Changes

  * add whitespace between URL and parenthesis to workaround known blackfriday markdown processor limitation. otherwise, this file gets generated with a 404 broken link in the HTML (for the API ref docs in knative.dev)

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```