### PR TITLE
Added v1beta1 serving API for github source.

### DIFF
--- a/contrib/github/pkg/apis/addtoscheme_serving_v1beta1.go
+++ b/contrib/github/pkg/apis/addtoscheme_serving_v1beta1.go
@@ -17,10 +17,10 @@ limitations under the License.
 package apis
 
 import (
-	servingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	servingv1beta1 "github.com/knative/serving/pkg/apis/serving/v1beta1"
 )
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	AddToSchemes = append(AddToSchemes, servingv1alpha1.SchemeBuilder.AddToScheme)
+	AddToSchemes = append(AddToSchemes, servingv1beta1.SchemeBuilder.AddToScheme)
 }


### PR DESCRIPTION
Fixes #481 

## Proposed Changes

  * Added the v1beta1 serving API to the scheme instead of v1alpha1.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```NONE
```