### PR TITLE
Automatic release tag labels

### DIFF
--- a/camel/source/config/100-namespace.yaml
+++ b/camel/source/config/100-namespace.yaml
@@ -16,3 +16,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/camel/source/config/200-serviceaccount.yaml
+++ b/camel/source/config/200-serviceaccount.yaml
@@ -17,3 +17,5 @@ kind: ServiceAccount
 metadata:
   name: camel-controller-manager
   namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/camel/source/config/201-clusterrole.yaml
+++ b/camel/source/config/201-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: camel-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 rules:
 - apiGroups:
   - apps

--- a/camel/source/config/202-clusterrolebinding.yaml
+++ b/camel/source/config/202-clusterrolebinding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: camel-controller-rolebinding
+  labels:
+    contrib.eventing.knative.dev/release: devel
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -31,6 +33,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-sources-camel-controller-addressable-resolver
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
 - kind: ServiceAccount
   name: camel-controller-manager

--- a/camel/source/config/300-camelsource.yaml
+++ b/camel/source/config/300-camelsource.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   labels:
+    contrib.eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     knative.dev/crd-install: "true"
   name: camelsources.sources.eventing.knative.dev

--- a/camel/source/config/400-controller-service.yaml
+++ b/camel/source/config/400-controller-service.yaml
@@ -16,6 +16,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    contrib.eventing.knative.dev/release: devel
     control-plane: camel-controller-manager
   name: camel-controller-manager
   namespace: knative-sources

--- a/camel/source/config/500-controller.yaml
+++ b/camel/source/config/500-controller.yaml
@@ -16,6 +16,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   labels:
+    contrib.eventing.knative.dev/release: devel
     control-plane: camel-controller-manager
   name: camel-controller-manager
   namespace: knative-sources

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -32,11 +32,20 @@ COMPONENTS=(
 readonly COMPONENTS
 
 function build_release() {
+   # Update release labels if this is a tagged release
+  if [[ -n "${TAG}" ]]; then
+    echo "Tagged release, updating release labels to contrib.eventing.knative.dev/release: \"${TAG}\""
+    LABEL_YAML_CMD=(sed -e "s|contrib.eventing.knative.dev/release: devel|contrib.eventing.knative.dev/release: \"${TAG}\"|")
+  else
+    echo "Untagged release, will NOT update release labels"
+    LABEL_YAML_CMD=(cat)
+  fi
+
   local all_yamls=()
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
     echo "Building Knative Eventing Sources - ${config}"
-    ko resolve ${KO_FLAGS} -f ${config}/ > ${yaml}
+    ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   done
   ARTIFACTS_TO_PUBLISH="${all_yamls[@]}"

--- a/kafka/source/config/100-namespace.yaml
+++ b/kafka/source/config/100-namespace.yaml
@@ -16,3 +16,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/kafka/source/config/200-serviceaccount.yaml
+++ b/kafka/source/config/200-serviceaccount.yaml
@@ -17,3 +17,5 @@ kind: ServiceAccount
 metadata:
   name: kafka-controller-manager
   namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/kafka/source/config/201-clusterrole.yaml
+++ b/kafka/source/config/201-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventing-sources-kafka-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 rules:
 
 - apiGroups:

--- a/kafka/source/config/202-clusterrolebinding.yaml
+++ b/kafka/source/config/202-clusterrolebinding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventing-sources-kafka-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
 - kind: ServiceAccount
   name: kafka-controller-manager
@@ -30,7 +32,9 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: eventing-sources-kafka-controller-addressable-resolver 
+  name: eventing-sources-kafka-controller-addressable-resolver
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
 - kind: ServiceAccount
   name: kafka-controller-manager

--- a/kafka/source/config/300-kafkasource.yaml
+++ b/kafka/source/config/300-kafkasource.yaml
@@ -16,6 +16,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   labels:
+    contrib.eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     knative.dev/crd-install: "true"
   name: kafkasources.sources.eventing.knative.dev

--- a/kafka/source/config/400-controller-service.yaml
+++ b/kafka/source/config/400-controller-service.yaml
@@ -18,6 +18,7 @@ metadata:
   name: kafka-controller
   namespace: knative-sources
   labels:
+    contrib.eventing.knative.dev/release: devel
     control-plane: kafka-controller-manager
 spec:
   selector:

--- a/kafka/source/config/500-controller.yaml
+++ b/kafka/source/config/500-controller.yaml
@@ -18,6 +18,7 @@ metadata:
   name: kafka-controller-manager
   namespace: knative-sources
   labels:
+    contrib.eventing.knative.dev/release: devel
     control-plane: kafka-controller-manager
 spec:
   selector:


### PR DESCRIPTION
Companion to https://github.com/knative/eventing/pull/1644.

## Proposed Changes

- Automatically update version labels in release artifacts when a tagged release is generated
- Add release labels to non-ConfigMap objects that don't have them, mainly Kafka and Camel sources.