### PR TITLE
golang format tools

### DIFF
--- a/camel/source/pkg/reconciler/camelsource_test.go
+++ b/camel/source/pkg/reconciler/camelsource_test.go
@@ -370,7 +370,7 @@ func makeContext(namespace string, image string) *camelv1alpha1.IntegrationKit {
 			GenerateName: "ctx-",
 			Namespace:    namespace,
 			Labels: map[string]string{
-				"app": "camel-k",
+				"app":                       "camel-k",
 				"camel.apache.org/kit.type": camelv1alpha1.IntegrationKitTypeExternal,
 			},
 		},

--- a/camel/source/pkg/reconciler/resources/flow.go
+++ b/camel/source/pkg/reconciler/resources/flow.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // AddSinkToCamelFlow adds the knative endpoint sink to a user-provided yaml flow

--- a/camel/source/pkg/reconciler/resources/flow_test.go
+++ b/camel/source/pkg/reconciler/resources/flow_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package resources
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestCamelFlow(t *testing.T) {


### PR DESCRIPTION
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign @n3wscott
