### PR TITLE
move nats-approvers over from eventing

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,6 +20,11 @@ aliases:
     - bbrowning
     - matzew
 
+  natss-approvers:
+    - Abd4llA
+  natss-reviewers:
+    - Abd4llA
+
   productivity-approvers:
   - adrcunha
   - chaodaiG


### PR DESCRIPTION
Addresses knative/eventing#1567

## Proposed Changes

  * copy over the natss-approvers and nats-reviewers from eventing due to moving here.
https://github.com/knative/eventing/blob/master/OWNERS_ALIASES#L17

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```