### PR TITLE
release patch: renaming kafka to kafka importer, and adding CRD and CCP based channels

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -26,7 +26,9 @@ COMPONENTS=(
   ["gcppubsub.yaml"]="gcppubsub/config"
   ["event-display.yaml"]="config/tools/event-display"
   ["camel.yaml"]="camel/source/config"
-  ["kafka.yaml"]="kafka/source/config"
+  ["kafka-importer.yaml"]="kafka/source/config"
+  ["kafka-channel-crd.yaml"]="kafka/channel/config"
+  ["kafka-channel-ccp.yaml"]="kafka/channel/config/provisioner"
   ["awssqs.yaml"]="contrib/awssqs/config"
 )
 readonly COMPONENTS


### PR DESCRIPTION
Fixes #512

## Proposed Changes

  * adding kafka channels (CRD / CCP) to release script (#512)
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
 include the missing kafka channels
```