### PR TITLE
Adding NatssChannel CRD for release script

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -28,6 +28,7 @@ COMPONENTS=(
   ["camel.yaml"]="camel/source/config"
   ["kafka-importer.yaml"]="kafka/source/config"
   ["kafka-channel.yaml"]="kafka/channel/config"
+  ["natss-channel.yaml"]="natss/config"
   ["awssqs.yaml"]="awssqs/config"
 )
 readonly COMPONENTS


### PR DESCRIPTION

## Proposed Changes

  * adding natss channel (CRD) to release script (was not added with #491)

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```