### PR TITLE
Reflecting the channel subfolder...

### DIFF
--- a/kafka/channel/config/500-controller.yaml
+++ b/kafka/channel/config/500-controller.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kafka-ch-controller
       containers:
         - name: controller
-          image: knative.dev/eventing-contrib/kafka/cmd/channel_controller
+          image: knative.dev/eventing-contrib/kafka/channel/cmd/channel_controller
           env:
           - name: CONFIG_LOGGING_NAME
             value: config-logging

--- a/kafka/channel/config/500-dispatcher.yaml
+++ b/kafka/channel/config/500-dispatcher.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kafka-ch-dispatcher
       containers:
         - name: dispatcher
-          image: knative.dev/eventing-contrib/kafka/cmd/channel_dispatcher
+          image: knative.dev/eventing-contrib/kafka/channel/cmd/channel_dispatcher
           env:
             - name: CONFIG_LOGGING_NAME
               value: config-logging

--- a/kafka/channel/config/500-webhook.yaml
+++ b/kafka/channel/config/500-webhook.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: kafka-webhook
         terminationMessagePolicy: FallbackToLogsOnError
-        image: knative.dev/eventing-contrib/kafka/cmd/webhook
+        image: knative.dev/eventing-contrib/kafka/channel/cmd/webhook
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging


### PR DESCRIPTION
Applying #530 to master branch


test with:
* https://github.com/matzew/knative-eventing-samples/tree/master/04_kafka_source_channel
* exposed strimzi

log messages were consumed via:
* kafkacat (connected to the actual topic)
* the `ksvc`'s log (`user-container`)

