### PR TITLE
Format markdown

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -18,8 +18,8 @@ Before submitting a PR, see also [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ### Requirements
 
-You must have the core of [Knative Serving](http://github.com/knative/serving) running
-on your cluster.
+You must have the core of [Knative Serving](http://github.com/knative/serving)
+running on your cluster.
 
 You must have [Knative Eventing](http://github.com/knative/eventing) running on
 your cluster.


### PR DESCRIPTION
Produced via:
  `prettier --write --prose-wrap=always $(find -name '*.md' | grep -v vendor | grep -v .github)`
/assign @n3wscott
