### PR TITLE
Don't ignore parsing errors

### DIFF
--- a/github/cmd/receive_adapter/main.go
+++ b/github/cmd/receive_adapter/main.go
@@ -118,6 +118,9 @@ func main() {
 				log.Print("Event not found")
 				return
 			}
+			w.WriteHeader(http.StatusBadRequest)
+			log.Printf("Error processing request: %s", err)
+			return
 		}
 
 		ra.HandleEvent(event, r.Header)


### PR DESCRIPTION
If the request generates an error (e.g. HMAC verification failed) we shouldn't
just silently ignore it, the event will be nil so there's no point in going on.
We should return/log the error so someone can figure out what's going on.

Signed-off-by: Doug Davis <dug@us.ibm.com>

/cc @n3wscott 