### PR TITLE
Add kafka-source to addressable resolver imc

### DIFF
--- a/kafka/source/config/200-addressable-resolver-clusterrole.yaml
+++ b/kafka/source/config/200-addressable-resolver-clusterrole.yaml
@@ -1,0 +1,32 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: imc-addressable-resolver
+  labels:
+    contrib.eventing.knative.dev/release: devel
+    duck.knative.dev/addressable: "true"
+# Do not use this role directly. These rules will be added to the "addressable-resolver" role.
+rules:
+  - apiGroups:
+      - messaging.knative.dev
+    resources:
+      - inmemorychannels
+      - inmemorychannels/status
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
While trying to wire up a `KafkaSource` to a `InMemoryChannel` was getting errors from the kafka-controller-manager.

`kubectl auth can-i get inmemorychannel.messaging.knative.dev --as=system:serviceaccount:knative-sources:kafka-controller-manager`
would return `no`

Adding this clusterrole fixed things.