### PR TITLE
remove odd cmd/ double path ... but why does ko not complain...

### DIFF
--- a/kafka/channel/config/500-controller.yaml
+++ b/kafka/channel/config/500-controller.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kafka-ch-controller
       containers:
         - name: controller
-          image: github.com/knative/eventing-contrib/kafka/channel/cmd/cmd/channel_controller
+          image: github.com/knative/eventing-contrib/kafka/channel/cmd/channel_controller
           env:
           - name: CONFIG_LOGGING_NAME
             value: config-logging

--- a/kafka/channel/config/500-dispatcher.yaml
+++ b/kafka/channel/config/500-dispatcher.yaml
@@ -30,7 +30,7 @@ spec:
       serviceAccountName: kafka-ch-dispatcher
       containers:
         - name: dispatcher
-          image: github.com/knative/eventing-contrib/kafka/channel/cmd/cmd/channel_dispatcher
+          image: github.com/knative/eventing-contrib/kafka/channel/cmd/channel_dispatcher
           env:
             - name: CONFIG_LOGGING_NAME
               value: config-logging

--- a/kafka/channel/config/500-webhook.yaml
+++ b/kafka/channel/config/500-webhook.yaml
@@ -33,7 +33,7 @@ spec:
       containers:
       - name: kafka-webhook
         terminationMessagePolicy: FallbackToLogsOnError
-        image: github.com/knative/eventing-contrib/kafka/channel/cmd/cmd/webhook
+        image: github.com/knative/eventing-contrib/kafka/channel/cmd/webhook
         volumeMounts:
         - name: config-logging
           mountPath: /etc/config-logging

--- a/kafka/channel/config/provisioner/kafka.yaml
+++ b/kafka/channel/config/provisioner/kafka.yaml
@@ -131,7 +131,7 @@ spec:
       serviceAccountName: kafka-channel-controller
       containers:
       - name: kafka-channel-controller-controller
-        image: github.com/knative/eventing-contrib/kafka/channel/cmd/cmd/controller
+        image: github.com/knative/eventing-contrib/kafka/channel/cmd/controller
         volumeMounts:
           - name: kafka-channel-controller-config
             mountPath: /etc/config-provisioner
@@ -210,7 +210,7 @@ spec:
       serviceAccountName: kafka-channel-dispatcher
       containers:
         - name: dispatcher
-          image: github.com/knative/eventing-contrib/kafka/channel/cmd/cmd/dispatcher
+          image: github.com/knative/eventing-contrib/kafka/channel/cmd/dispatcher
           env:
             - name: SYSTEM_NAMESPACE
               valueFrom:


### PR DESCRIPTION
## Proposed Changes

  * fix wrong double `cmd` path ...
  * 
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note

make channel usable ...

```