### PR TITLE
Add release tag labels to Kafka Channel objects [0.8]

### DIFF
--- a/kafka/channel/config/200-addressable-resolver-clusterrole.yaml
+++ b/kafka/channel/config/200-addressable-resolver-clusterrole.yaml
@@ -17,7 +17,7 @@ kind: ClusterRole
 metadata:
   name: kafka-addressable-resolver
   labels:
-    eventing.knative.dev/release: devel
+    contrib.eventing.knative.dev/release: devel
     duck.knative.dev/addressable: "true"
 # Do not use this role directly. These rules will be added to the "addressable-resolver" role.
 rules:

--- a/kafka/channel/config/200-channelable-manipulator-clusterrole.yaml
+++ b/kafka/channel/config/200-channelable-manipulator-clusterrole.yaml
@@ -17,6 +17,7 @@ kind: ClusterRole
 metadata:
   name: kafka-channelable-manipulator
   labels:
+    contrib.eventing.knative.dev/release: devel
     duck.knative.dev/channelable: "true"
 # Do not use this role directly. These rules will be added to the "channelable-manipulator" role.
 rules:

--- a/kafka/channel/config/200-controller-clusterrole.yaml
+++ b/kafka/channel/config/200-controller-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kafka-ch-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - messaging.knative.dev

--- a/kafka/channel/config/200-dispatcher-clusterrole.yaml
+++ b/kafka/channel/config/200-dispatcher-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kafka-ch-dispatcher
+  labels:
+    contrib.eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - messaging.knative.dev

--- a/kafka/channel/config/200-dispatcher-service.yaml
+++ b/kafka/channel/config/200-dispatcher-service.yaml
@@ -18,6 +18,7 @@ metadata:
   name: kafka-ch-dispatcher
   namespace: knative-eventing
   labels:
+      contrib.eventing.knative.dev/release: devel
       messaging.knative.dev/channel: kafka-channel
       messaging.knative.dev/role: dispatcher
 spec:

--- a/kafka/channel/config/200-serviceaccount.yaml
+++ b/kafka/channel/config/200-serviceaccount.yaml
@@ -17,6 +17,8 @@ kind: ServiceAccount
 metadata:
   name: kafka-ch-controller
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
 
 ---
 apiVersion: v1
@@ -24,6 +26,8 @@ kind: ServiceAccount
 metadata:
   name: kafka-ch-dispatcher
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
 
 ---
 apiVersion: v1
@@ -31,3 +35,5 @@ kind: ServiceAccount
 metadata:
   name: kafka-webhook
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/kafka/channel/config/200-webhook-clusterrole.yaml
+++ b/kafka/channel/config/200-webhook-clusterrole.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kafka-webhook
+  labels:
+    contrib.eventing.knative.dev/release: devel
 rules:
   # For watching logging configuration and getting certs.
   - apiGroups:

--- a/kafka/channel/config/201-clusterrolebinding.yaml
+++ b/kafka/channel/config/201-clusterrolebinding.yaml
@@ -16,6 +16,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-ch-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-ch-controller
@@ -31,6 +33,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-ch-dispatcher
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-ch-dispatcher
@@ -46,6 +50,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-webhook
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-webhook

--- a/kafka/channel/config/300-kafka-channel.yaml
+++ b/kafka/channel/config/300-kafka-channel.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
  name: kafkachannels.messaging.knative.dev
  labels:
+    contrib.eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
 spec:

--- a/kafka/channel/config/400-webhook-service.yaml
+++ b/kafka/channel/config/400-webhook-service.yaml
@@ -15,10 +15,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    role: kafka-webhook
   name: kafka-webhook
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
+    role: kafka-webhook
 spec:
   ports:
     - port: 443

--- a/kafka/channel/config/500-controller.yaml
+++ b/kafka/channel/config/500-controller.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: kafka-ch-controller
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/kafka/channel/config/500-dispatcher.yaml
+++ b/kafka/channel/config/500-dispatcher.yaml
@@ -17,6 +17,9 @@ kind: Deployment
 metadata:
   name: kafka-ch-dispatcher
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
+    role: kafka-webhook
 spec:
   replicas: 1
   selector:

--- a/kafka/channel/config/500-webhook.yaml
+++ b/kafka/channel/config/500-webhook.yaml
@@ -17,6 +17,8 @@ kind: Deployment
 metadata:
   name: kafka-webhook
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:

--- a/kafka/channel/config/provisioner/kafka.yaml
+++ b/kafka/channel/config/provisioner/kafka.yaml
@@ -16,6 +16,8 @@ apiVersion: eventing.knative.dev/v1alpha1
 kind: ClusterChannelProvisioner
 metadata:
   name: kafka
+  labels:
+    contrib.eventing.knative.dev/release: devel
 spec: {}
 ---
 
@@ -24,12 +26,16 @@ kind: ServiceAccount
 metadata:
   name: kafka-channel-controller
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
 ---
 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kafka-channel-controller
+  labels:
+    contrib.eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - eventing.knative.dev
@@ -88,6 +94,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-channel-controller-manage
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-channel-controller
@@ -103,6 +111,8 @@ kind: ConfigMap
 metadata:
   name: kafka-channel-controller-config
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
 data:
   # Broker URL's for the provisioner. Replace this with the URL's for your kafka cluster,
   # which is in the format of my-cluster-kafka-bootstrap.my-kafka-namespace:9092.
@@ -119,6 +129,8 @@ kind: Deployment
 metadata:
   name: kafka-channel-controller
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:
@@ -151,6 +163,8 @@ kind: ServiceAccount
 metadata:
   name: kafka-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
 
 ---
 
@@ -158,6 +172,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kafka-channel-dispatcher
+  labels:
+    contrib.eventing.knative.dev/release: devel
 rules:
   - apiGroups:
       - "" # Core API group.
@@ -181,6 +197,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kafka-channel-dispatcher
+  labels:
+    contrib.eventing.knative.dev/release: devel
 subjects:
   - kind: ServiceAccount
     name: kafka-channel-dispatcher
@@ -197,6 +215,8 @@ kind: Deployment
 metadata:
   name: kafka-channel-dispatcher
   namespace: knative-eventing
+  labels:
+    contrib.eventing.knative.dev/release: devel
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
These were missed in the shuffle from the eventing repo.