### PR TITLE
golang format tools

### DIFF
--- a/kafka/channel/pkg/controller/channel/reconcile.go
+++ b/kafka/channel/pkg/controller/channel/reconcile.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"knative.dev/eventing-contrib/kafka/channel/pkg/controller"
+	topicUtils "knative.dev/eventing-contrib/kafka/channel/pkg/utils"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	util "knative.dev/eventing/pkg/provisioners"
-	topicUtils "knative.dev/eventing-contrib/kafka/channel/pkg/utils"
 
 	eventingNames "knative.dev/eventing/pkg/reconciler/names"
 	"knative.dev/pkg/apis"

--- a/kafka/channel/pkg/utils/util_test.go
+++ b/kafka/channel/pkg/utils/util_test.go
@@ -43,7 +43,6 @@ func TestGenerateTopicNameWithHyphen(t *testing.T) {
 	}
 }
 
-
 func TestGetKafkaConfig(t *testing.T) {
 
 	testCases := []struct {


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign n3wscott
