### PR TITLE
Fix scheme import paths.

### DIFF
--- a/awssqs/pkg/apis/addtoscheme_sources_v1alpha1.go
+++ b/awssqs/pkg/apis/addtoscheme_sources_v1alpha1.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package apis
 
-import "knative.dev/eventing-contrib/github/pkg/apis/sources/v1alpha1"
+import "knative.dev/eventing-contrib/awssqs/pkg/apis/sources/v1alpha1"
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back

--- a/github/pkg/apis/addtoscheme_sources_v1alpha1.go
+++ b/github/pkg/apis/addtoscheme_sources_v1alpha1.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package apis
 
-import "knative.dev/eventing-contrib/awssqs/pkg/apis/sources/v1alpha1"
+import "knative.dev/eventing-contrib/github/pkg/apis/sources/v1alpha1"
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back


### PR DESCRIPTION
A prior change to "flatten" things mixed up these two files resulting in them having the wrong schemes imported.  This flips them back.
