### PR TITLE
Revert upgrade to Beta serving. Use Alpha api but Beta shape. Lemonaid.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1811,6 +1811,7 @@
     "knative.dev/pkg/test",
     "knative.dev/pkg/test/logging",
     "knative.dev/pkg/webhook",
+    "knative.dev/serving/pkg/apis/serving/v1alpha1",
     "knative.dev/serving/pkg/apis/serving/v1beta1",
     "knative.dev/serving/pkg/client/clientset/versioned",
     "knative.dev/serving/pkg/client/clientset/versioned/typed/serving/v1beta1",

--- a/github/pkg/apis/addtoscheme_serving_v1alpha1.go
+++ b/github/pkg/apis/addtoscheme_serving_v1alpha1.go
@@ -16,8 +16,9 @@ limitations under the License.
 
 package apis
 
+import servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
+
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
-	// TODO: add this back when we move to v1beta1 serving.
-	// AddToSchemes = append(AddToSchemes, servingv1beta1.SchemeBuilder.AddToScheme)
+	AddToSchemes = append(AddToSchemes, servingv1alpha1.SchemeBuilder.AddToScheme)
 }

--- a/github/pkg/reconciler/githubsource_test.go
+++ b/github/pkg/reconciler/githubsource_test.go
@@ -30,16 +30,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
-	sourcesv1alpha1 "knative.dev/eventing-contrib/github/pkg/apis/sources/v1alpha1"
-	"knative.dev/eventing-contrib/github/pkg/reconciler/resources"
-	controllertesting "knative.dev/eventing-contrib/pkg/controller/testing"
-	"knative.dev/eventing-contrib/pkg/reconciler/eventtype"
 	eventingv1alpha1 "knative.dev/eventing/pkg/apis/eventing/v1alpha1"
 	"knative.dev/pkg/apis"
 	duckv1alpha1 "knative.dev/pkg/apis/duck/v1alpha1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
-	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
+	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sourcesv1alpha1 "knative.dev/eventing-contrib/github/pkg/apis/sources/v1alpha1"
+	"knative.dev/eventing-contrib/github/pkg/reconciler/resources"
+	controllertesting "knative.dev/eventing-contrib/pkg/controller/testing"
+	"knative.dev/eventing-contrib/pkg/reconciler/eventtype"
 )
 
 var (
@@ -48,7 +49,6 @@ var (
 )
 
 const (
-	image            = "knative.dev/test/image"
 	gitHubSourceName = "testgithubsource"
 	testNS           = "testnamespace"
 	gitHubSourceUID  = "2b2219e2-ce67-11e8-b3a3-42010a8a00af"
@@ -86,7 +86,7 @@ func init() {
 	// Add types to scheme
 	sourcesv1alpha1.SchemeBuilder.AddToScheme(scheme.Scheme)
 	duckv1alpha1.AddToScheme(scheme.Scheme)
-	servingv1beta1.AddToScheme(scheme.Scheme)
+	servingv1alpha1.AddToScheme(scheme.Scheme)
 	eventingv1alpha1.AddToScheme(scheme.Scheme)
 }
 
@@ -194,19 +194,19 @@ var testCases = []controllertesting.TestCase{
 			}(),
 			// service resource
 			func() runtime.Object {
-				svc := &servingv1beta1.Service{
+				svc := &servingv1alpha1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNS,
 						Name:      serviceName,
 					},
-					Status: servingv1beta1.ServiceStatus{
+					Status: servingv1alpha1.ServiceStatus{
 						Status: duckv1beta1.Status{
 							Conditions: duckv1beta1.Conditions{{
-								Type:   servingv1beta1.ServiceConditionReady,
+								Type:   servingv1alpha1.ServiceConditionReady,
 								Status: corev1.ConditionTrue,
 							}},
 						},
-						RouteStatusFields: servingv1beta1.RouteStatusFields{
+						RouteStatusFields: servingv1alpha1.RouteStatusFields{
 							URL: &serviceURL,
 						},
 					},
@@ -251,19 +251,19 @@ var testCases = []controllertesting.TestCase{
 			}(),
 			// service resource
 			func() runtime.Object {
-				svc := &servingv1beta1.Service{
+				svc := &servingv1alpha1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNS,
 						Name:      serviceName,
 					},
-					Status: servingv1beta1.ServiceStatus{
+					Status: servingv1alpha1.ServiceStatus{
 						Status: duckv1beta1.Status{
 							Conditions: duckv1beta1.Conditions{{
-								Type:   servingv1beta1.ServiceConditionReady,
+								Type:   servingv1alpha1.ServiceConditionReady,
 								Status: corev1.ConditionTrue,
 							}},
 						},
-						RouteStatusFields: servingv1beta1.RouteStatusFields{
+						RouteStatusFields: servingv1alpha1.RouteStatusFields{
 							URL: &serviceURL,
 						},
 					},
@@ -310,19 +310,19 @@ var testCases = []controllertesting.TestCase{
 			}(),
 			// service resource
 			func() runtime.Object {
-				svc := &servingv1beta1.Service{
+				svc := &servingv1alpha1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNS,
 						Name:      serviceName,
 					},
-					Status: servingv1beta1.ServiceStatus{
+					Status: servingv1alpha1.ServiceStatus{
 						Status: duckv1beta1.Status{
 							Conditions: duckv1beta1.Conditions{{
-								Type:   servingv1beta1.ServiceConditionReady,
+								Type:   servingv1alpha1.ServiceConditionReady,
 								Status: corev1.ConditionTrue,
 							}},
 						},
-						RouteStatusFields: servingv1beta1.RouteStatusFields{
+						RouteStatusFields: servingv1alpha1.RouteStatusFields{
 							URL: &serviceURL,
 						},
 					},
@@ -417,19 +417,19 @@ var testCases = []controllertesting.TestCase{
 			}(),
 			// service resource
 			func() runtime.Object {
-				svc := &servingv1beta1.Service{
+				svc := &servingv1alpha1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNS,
 						Name:      serviceName,
 					},
-					Status: servingv1beta1.ServiceStatus{
+					Status: servingv1alpha1.ServiceStatus{
 						Status: duckv1beta1.Status{
 							Conditions: duckv1beta1.Conditions{{
-								Type:   servingv1beta1.ServiceConditionReady,
+								Type:   servingv1alpha1.ServiceConditionReady,
 								Status: corev1.ConditionTrue,
 							}},
 						},
-						RouteStatusFields: servingv1beta1.RouteStatusFields{
+						RouteStatusFields: servingv1alpha1.RouteStatusFields{
 							URL: &serviceURL,
 						},
 					},
@@ -542,19 +542,19 @@ var testCases = []controllertesting.TestCase{
 			}(),
 			// service resource
 			func() runtime.Object {
-				svc := &servingv1beta1.Service{
+				svc := &servingv1alpha1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNS,
 						Name:      serviceName,
 					},
-					Status: servingv1beta1.ServiceStatus{
+					Status: servingv1alpha1.ServiceStatus{
 						Status: duckv1beta1.Status{
 							Conditions: duckv1beta1.Conditions{{
-								Type:   servingv1beta1.ServiceConditionReady,
+								Type:   servingv1alpha1.ServiceConditionReady,
 								Status: corev1.ConditionTrue,
 							}},
 						},
-						RouteStatusFields: servingv1beta1.RouteStatusFields{
+						RouteStatusFields: servingv1alpha1.RouteStatusFields{
 							URL: &serviceURL,
 						},
 					},
@@ -600,19 +600,19 @@ var testCases = []controllertesting.TestCase{
 			}(),
 			// service resource
 			func() runtime.Object {
-				svc := &servingv1beta1.Service{
+				svc := &servingv1alpha1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNS,
 						Name:      serviceName,
 					},
-					Status: servingv1beta1.ServiceStatus{
+					Status: servingv1alpha1.ServiceStatus{
 						Status: duckv1beta1.Status{
 							Conditions: duckv1beta1.Conditions{{
-								Type:   servingv1beta1.ServiceConditionReady,
+								Type:   servingv1alpha1.ServiceConditionReady,
 								Status: corev1.ConditionTrue,
 							}},
 						},
-						RouteStatusFields: servingv1beta1.RouteStatusFields{
+						RouteStatusFields: servingv1alpha1.RouteStatusFields{
 							URL: &serviceURL,
 						},
 					},
@@ -655,19 +655,19 @@ var testCases = []controllertesting.TestCase{
 			}(),
 			// service resource
 			func() runtime.Object {
-				svc := &servingv1beta1.Service{
+				svc := &servingv1alpha1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNS,
 						Name:      serviceName,
 					},
-					Status: servingv1beta1.ServiceStatus{
+					Status: servingv1alpha1.ServiceStatus{
 						Status: duckv1beta1.Status{
 							Conditions: duckv1beta1.Conditions{{
-								Type:   servingv1beta1.ServiceConditionReady,
+								Type:   servingv1alpha1.ServiceConditionReady,
 								Status: corev1.ConditionTrue,
 							}},
 						},
-						RouteStatusFields: servingv1beta1.RouteStatusFields{
+						RouteStatusFields: servingv1alpha1.RouteStatusFields{
 							URL: &serviceURL,
 						},
 					},
@@ -713,19 +713,19 @@ var testCases = []controllertesting.TestCase{
 			}(),
 			// service resource
 			func() runtime.Object {
-				svc := &servingv1beta1.Service{
+				svc := &servingv1alpha1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNS,
 						Name:      serviceName,
 					},
-					Status: servingv1beta1.ServiceStatus{
+					Status: servingv1alpha1.ServiceStatus{
 						Status: duckv1beta1.Status{
 							Conditions: duckv1beta1.Conditions{{
-								Type:   servingv1beta1.ServiceConditionReady,
+								Type:   servingv1alpha1.ServiceConditionReady,
 								Status: corev1.ConditionTrue,
 							}},
 						},
-						RouteStatusFields: servingv1beta1.RouteStatusFields{
+						RouteStatusFields: servingv1alpha1.RouteStatusFields{
 							URL: &serviceURL,
 						},
 					},
@@ -774,19 +774,19 @@ var testCases = []controllertesting.TestCase{
 			}(),
 			// service resource
 			func() runtime.Object {
-				svc := &servingv1beta1.Service{
+				svc := &servingv1alpha1.Service{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: testNS,
 						Name:      serviceName,
 					},
-					Status: servingv1beta1.ServiceStatus{
+					Status: servingv1alpha1.ServiceStatus{
 						Status: duckv1beta1.Status{
 							Conditions: duckv1beta1.Conditions{{
-								Type:   servingv1beta1.ServiceConditionReady,
+								Type:   servingv1alpha1.ServiceConditionReady,
 								Status: corev1.ConditionTrue,
 							}},
 						},
-						RouteStatusFields: servingv1beta1.RouteStatusFields{
+						RouteStatusFields: servingv1alpha1.RouteStatusFields{
 							URL: &serviceURL,
 						},
 					},

--- a/github/pkg/reconciler/resources/service.go
+++ b/github/pkg/reconciler/resources/service.go
@@ -22,13 +22,15 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	sourcesv1alpha1 "knative.dev/eventing-contrib/github/pkg/apis/sources/v1alpha1"
+	servingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
 	servingv1beta1 "knative.dev/serving/pkg/apis/serving/v1beta1"
+
+	sourcesv1alpha1 "knative.dev/eventing-contrib/github/pkg/apis/sources/v1alpha1"
 )
 
 // MakeService generates, but does not create, a Service for the given
 // GitHubSource.
-func MakeService(source *sourcesv1alpha1.GitHubSource, receiveAdapterImage string) *servingv1beta1.Service {
+func MakeService(source *sourcesv1alpha1.GitHubSource, receiveAdapterImage string) *servingv1alpha1.Service {
 	labels := map[string]string{
 		"receive-adapter": "github",
 	}
@@ -50,22 +52,24 @@ func MakeService(source *sourcesv1alpha1.GitHubSource, receiveAdapterImage strin
 		},
 	}
 	containerArgs := []string{fmt.Sprintf("--sink=%s", sinkURI)}
-	return &servingv1beta1.Service{
+	return &servingv1alpha1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", source.Name),
 			Namespace:    source.Namespace,
 			Labels:       labels,
 		},
-		Spec: servingv1beta1.ServiceSpec{
-			ConfigurationSpec: servingv1beta1.ConfigurationSpec{
-				Template: servingv1beta1.RevisionTemplateSpec{
-					Spec: servingv1beta1.RevisionSpec{
-						PodSpec: corev1.PodSpec{
-							Containers: []corev1.Container{{
-								Image: receiveAdapterImage,
-								Env:   env,
-								Args:  containerArgs,
-							}},
+		Spec: servingv1alpha1.ServiceSpec{
+			ConfigurationSpec: servingv1alpha1.ConfigurationSpec{
+				Template: &servingv1alpha1.RevisionTemplateSpec{
+					Spec: servingv1alpha1.RevisionSpec{
+						RevisionSpec: servingv1beta1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{{
+									Image: receiveAdapterImage,
+									Env:   env,
+									Args:  containerArgs,
+								}},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Fixes https://github.com/knative/eventing-contrib/issues/562

## Proposed Changes

  * Use Alpha api but Beta shape. Lemonaid.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Github will launch as 1valpha1 serving resource.
```