### PR TITLE
Add missing flow field to Camel source CRD validation

### DIFF
--- a/camel/source/config/300-camelsource.yaml
+++ b/camel/source/config/300-camelsource.yaml
@@ -65,6 +65,8 @@ spec:
                     context:
                       type: string
                   type: object
+                flow:
+                  type: string
                 integration:
                   type: object
               type: object


### PR DESCRIPTION
Fixes #566

## Proposed Changes

Add the `flow` field to the Camel source CRD validation section.

/cc @nicolaferraro 