### PR TITLE
eventing-contrib test work with go1.13

### DIFF
--- a/test/e2e_flags.go
+++ b/test/e2e_flags.go
@@ -19,8 +19,6 @@ limitations under the License.
 package test
 
 import (
-	"flag"
-
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/logging"
 )
@@ -32,10 +30,11 @@ var EventingSourcesFlags = initializeEventingSourcesFlags()
 type EventingSourcesEnvironmentFlags struct {
 }
 
+// initializeEventingSourcesFlags registers flags used by e2e tests, calling flag.Parse() here would fail in
+// go1.13+, see https://github.com/knative/test-infra/issues/1329 for details
 func initializeEventingSourcesFlags() *EventingSourcesEnvironmentFlags {
 	var f EventingSourcesEnvironmentFlags
 
-	flag.Parse()
 	logging.InitializeLogger(pkgTest.Flags.LogVerbose)
 
 	if pkgTest.Flags.EmitMetrics {


### PR DESCRIPTION
Test would fail with go1.13 as it changed where testing flags are registered, fixing it by deleting explicit flag parsing like in https://github.com/knative/serving/pull/5398

/cc @mattmoor 
/cc @n3wscott 
/cc @adrcunha 