### PR TITLE
Fix for issue 1059: implemented Kafka channel controller and dispatcher restart on config-kafka ConfigMap update

### DIFF
--- a/kafka/channel/cmd/channel_controller/main.go
+++ b/kafka/channel/cmd/channel_controller/main.go
@@ -67,9 +67,10 @@ func main() {
 	if err != nil {
 		logger.Fatalw("Error loading kafka config", zap.Error(err))
 	}
+	logger.Info("Starting the Kafka controller")
+	logger.Info("Kafka broker configuration - ", utils.BrokerConfigMapKey + ": ", kafkaConfig.Brokers)
 
 	logger = logger.With(zap.String("controller/impl", "pkg"))
-	logger.Info("Starting the Kafka controller")
 
 	systemNS := system.Namespace()
 
@@ -116,6 +117,8 @@ func main() {
 	opt.ConfigMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, logconfig.Controller))
 	// TODO: Watch the observability config map and dynamically update metrics exporter.
 	//opt.ConfigMapWatcher.Watch(metrics.ObservabilityConfigName, metrics.UpdateExporterFromConfigMap(component, logger))
+	// Watch the config-kafka config map and restart if it changes
+	opt.ConfigMapWatcher.Watch("config-kafka", utils.KafkaConfigMapObserver(logger))
 	if err := opt.ConfigMapWatcher.Start(stopCh); err != nil {
 		logger.Fatalw("failed to start configuration manager", zap.Error(err))
 	}

--- a/kafka/channel/cmd/channel_dispatcher/main.go
+++ b/kafka/channel/cmd/channel_dispatcher/main.go
@@ -63,6 +63,8 @@ func main() {
 	if err != nil {
 		logger.Fatalw("Error loading kafka config", zap.Error(err))
 	}
+	logger.Info("Starting the Kafka dispatcher")
+	logger.Info("Kafka broker configuration - ", utils.BrokerConfigMapKey + ": ", kafkaConfig.Brokers)
 
 	args := &dispatcher.KafkaDispatcherArgs{
 		ClientID:     "kafka-ch-dispatcher",
@@ -76,7 +78,6 @@ func main() {
 	}
 
 	logger = logger.With(zap.String("controller/impl", "pkg"))
-	logger.Info("Starting the Kafka dispatcher")
 
 	const numControllers = 1
 	cfg.QPS = numControllers * rest.DefaultQPS
@@ -108,7 +109,8 @@ func main() {
 	opt.ConfigMapWatcher.Watch(logging.ConfigMapName(), logging.UpdateLevelFromConfigMap(logger, atomicLevel, logconfig.Controller))
 	// TODO: Watch the observability config map and dynamically update metrics exporter.
 	//opt.ConfigMapWatcher.Watch(metrics.ObservabilityConfigName, metrics.UpdateExporterFromConfigMap(component, logger))
-
+	// Watch the config-kafka config map and restart if it changes
+	opt.ConfigMapWatcher.Watch("config-kafka", utils.KafkaConfigMapObserver(logger))
 	// Setup zipkin tracing.
 	if err = tracing.SetupDynamicPublishing(logger, opt.ConfigMapWatcher, "kafka-ch-dispatcher"); err != nil {
 		logger.Fatalw("Error setting up Zipkin publishing", zap.Error(err))


### PR DESCRIPTION
Fixes #1059

## Proposed Changes
  * Kafka channel controller and dispatcher restart when the config-kafka ConfigMap is updated in order to pick up the new Kafka configuration
 * Kafka configuration is logged

**Release Note**
NONE