### PR TITLE
Documentation Improvements

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -89,7 +89,7 @@ kubectl -n knative-sources logs \
 ```
 
 _See [camel/source/samples/README.md](./camel/source/samples/README.md),
-[kafka/source/samples/README.md](./kafka/source/samples/README.md) for
+[kafka/source/README.md](./kafka/source/README.md) for
 instructions on installing the Camel Source and Kafka Source._
 
 ## Iterating

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,7 +79,13 @@ github-controller-manager-0   1/1       Running   0          2h
 You can access the Github eventing manager's logs with:
 
 ```shell
-kubectl -n knative-sources logs $(kubectl -n knative-sources get pods -l control-plane=github-controller-manager -o name)
+kubectl -n knative-sources logs \
+    $(kubectl \
+        -n knative-sources \
+        get pods \
+        -l control-plane=github-controller-manager \
+        -o name \
+    )
 ```
 
 _See [camel/source/samples/README.md](./camel/source/samples/README.md),
@@ -92,7 +98,7 @@ As you make changes to the code-base:
 
 - **If you change a package's deps** (including adding external dep), then you
   must run [`./hack/update-deps.sh`](./hack/update-deps.sh).
-- **If you change a type definition (<source_name>/pkg/apis/),** then
+- **If you change a type definition (\<source_name\>/pkg/apis/),** then
   you must run [`./hack/update-codegen.sh`](./hack/update-codegen.sh). _This
   also runs [`./hack/update-deps.sh`](./hack/update-deps.sh)._
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -25,7 +25,7 @@ You must have [Knative Eventing](http://github.com/knative/eventing) running on
 your cluster.
 
 You must have
-[ko](https://github.com/google/go-containerregistry/blob/master/cmd/ko/README.md)
+[ko](https://github.com/google/ko)
 installed.
 
 ### Checkout your fork

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -62,7 +62,7 @@ of the sources _Github Source_, _AWS SQS Source_, _Camel Source_, _Kafka Source_
 with:
 
 ```
-ko apply -f contrib/<source_name>/
+ko apply -f <source_name>/config  # e.g. github/config
 ```
 
 These commands are idempotent, so you can run them at any time to update your
@@ -92,7 +92,7 @@ As you make changes to the code-base:
 
 - **If you change a package's deps** (including adding external dep), then you
   must run [`./hack/update-deps.sh`](./hack/update-deps.sh).
-- **If you change a type definition (contrib/<source_name>/pkg/apis/),** then
+- **If you change a type definition (<source_name>/pkg/apis/),** then
   you must run [`./hack/update-codegen.sh`](./hack/update-codegen.sh). _This
   also runs [`./hack/update-deps.sh`](./hack/update-deps.sh)._
 
@@ -123,7 +123,7 @@ Running tests as you make changes to the code-base is pretty simple. See
 You can delete `Knative Sources` with:
 
 ```shell
-ko delete -f contrib/<source_name>/config/
+ko delete -f <source_name>/config/
 ```
 
 <!--

--- a/awssqs/samples/README.md
+++ b/awssqs/samples/README.md
@@ -17,10 +17,10 @@ commands from the root.
    [Knative Eventing](https://github.com/knative/docs/tree/master/eventing).
 
 1. The
-   [in-memory `ClusterChannelProvisioner`](https://knative.dev/eventing/tree/master/config/provisioners/in-memory-channel)
-   should be installed in your cluster. At the time of writing (release v0.5.0)
+   [in-memory channel CRD](https://github.com/knative/eventing/blob/master/config/channels/in-memory-channel/README.md)
+   should be installed in your cluster. At the time of writing (release v0.8.0)
    it is part of the default instructions so you will probably have it there
-   already.
+   already. For a development cluster see [this](https://github.com/knative/eventing/blob/master/DEVELOPMENT.md#install-channels).
 
 ### Create a channel and subscriber
 
@@ -59,7 +59,7 @@ kubectl -n knative-sources create secret generic awssqs-source-credentials --fro
 Deploy the `AwsSqsSource` controller as part of eventing-source's controller.
 
 ```shell
-ko -n default apply -f awssqs/config/
+ko apply -f awssqs/config/
 ```
 
 Note that if the `Source` Service Account secret is in a non-default location,

--- a/awssqs/samples/README.md
+++ b/awssqs/samples/README.md
@@ -25,7 +25,7 @@ commands from the root.
 ### Create a channel and subscriber
 
 ```shell
-ko apply -f contrib/awssqs/samples/display-resources.yaml
+ko apply -f awssqs/samples/display-resources.yaml
 ```
 
 The sample provided will configure an in-memory channel (named `awssqs-test` and
@@ -57,7 +57,7 @@ kubectl -n knative-sources create secret generic awssqs-source-credentials --fro
 Deploy the `AwsSqsSource` controller as part of eventing-source's controller.
 
 ```shell
-ko -n default apply -f contrib/awssqs/config/
+ko -n default apply -f awssqs/config/
 ```
 
 Note that if the `Source` Service Account secret is in a non-default location,
@@ -75,7 +75,7 @@ Replace the place holders in `samples/awssqs-source.yaml`.
 Now deploy `awssqs-source.yaml`.
 
 ```shell
-ko apply -f contrib/awssqs/samples/awssqs-source.yaml
+ko apply -f awssqs/samples/awssqs-source.yaml
 ```
 
 You can use [kail](https://github.com/boz/kail/) to tail the logs of the

--- a/awssqs/samples/README.md
+++ b/awssqs/samples/README.md
@@ -11,16 +11,16 @@ commands from the root.
 
 ### Prerequisites
 
-1.  Create an [AWS SQS queue](https://aws.amazon.com/sqs/).
+1. Create an [AWS SQS queue](https://aws.amazon.com/sqs/).
 
-1.  Setup
-    [Knative Eventing](https://github.com/knative/docs/tree/master/eventing).
+1. Setup
+   [Knative Eventing](https://github.com/knative/docs/tree/master/eventing).
 
-1.  The
-    [in-memory `ClusterChannelProvisioner`](https://knative.dev/eventing/tree/master/config/provisioners/in-memory-channel)
-    should be installed in your cluster. At the time of writing (release v0.5.0)
-    it is part of the default instructions so you will probably have it there
-    already.
+1. The
+   [in-memory `ClusterChannelProvisioner`](https://knative.dev/eventing/tree/master/config/provisioners/in-memory-channel)
+   should be installed in your cluster. At the time of writing (release v0.5.0)
+   it is part of the default instructions so you will probably have it there
+   already.
 
 ### Create a channel and subscriber
 
@@ -42,9 +42,11 @@ Acquire
 [AWS Credentials](https://docs.aws.amazon.com/general/latest/gr/aws-security-credentials.html)
 for the same account. Your credentials file should look like this:
 
-     [default]
-     aws_access_key_id = ...
-     aws_secret_access_key = ...
+```
+[default]
+aws_access_key_id = ...
+aws_secret_access_key = ...
+```
 
 Then create a secret for the downloaded key:
 

--- a/awssqs/samples/awssqs-source.yaml
+++ b/awssqs/samples/awssqs-source.yaml
@@ -11,6 +11,6 @@ spec:
     key: credentials
   queueUrl: QUEUE_URL
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1alpha1
     kind: Channel
     name: awssqs-test

--- a/awssqs/samples/display-resources.yaml
+++ b/awssqs/samples/display-resources.yaml
@@ -1,26 +1,25 @@
 # Channel for testing events.
 
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1alpha1
 kind: Channel
 metadata:
   name: awssqs-test
 spec:
-  provisioner:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: ClusterChannelProvisioner
-    name: in-memory-channel
+  channelTemplate:
+    apiVersion: messaging.knative.dev/v1alpha1
+    kind: InMemoryChannel
 
 ---
 
 # Subscription from the AWS SQS Source's output Channel to the Knative Service below.
 
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1alpha1
 kind: Subscription
 metadata:
   name: awssqs-source-display
 spec:
   channel:
-    apiVersion: eventing.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1alpha1
     kind: Channel
     name: awssqs-test
   subscriber:

--- a/camel/source/samples/display_resources.yaml
+++ b/camel/source/samples/display_resources.yaml
@@ -1,26 +1,25 @@
 # Channel for testing events.
 
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1alpha1
 kind: Channel
 metadata:
   name: camel-test
 spec:
-  provisioner:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: ClusterChannelProvisioner
-    name: in-memory
+  channelTemplate:
+    apiVersion: messaging.knative.dev/v1alpha1
+    kind: InMemoryChannel
 
 ---
 
 # Subscription from the CamelSource's output Channel to the Knative Service below.
 
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1alpha1
 kind: Subscription
 metadata:
   name: camel-source-display
 spec:
   channel:
-    apiVersion: eventing.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1alpha1
     kind: Channel
     name: camel-test
   subscriber:

--- a/camel/source/samples/source_camel_k.yaml
+++ b/camel/source/samples/source_camel_k.yaml
@@ -19,6 +19,6 @@ spec:
             .setHeader("Content-Type").constant("application/json")
             .to("knative:endpoint/sink?cloudEventsType=org.apache.camel.quote")
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1alpha1
     kind: Channel
     name: camel-test

--- a/camel/source/samples/source_telegram.yaml
+++ b/camel/source/samples/source_telegram.yaml
@@ -19,6 +19,6 @@ spec:
         # Camel K option to enable serialization of the component output
         camel.component.knative.jsonSerializationEnabled: "true"
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1alpha1
     kind: Channel
     name: camel-test

--- a/camel/source/samples/source_timer_flow.yaml
+++ b/camel/source/samples/source_timer_flow.yaml
@@ -17,6 +17,6 @@ spec:
           - set-body:
               constant: Hello world!
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1alpha1
     kind: Channel
     name: camel-test

--- a/github/samples/githubsource.yaml
+++ b/github/samples/githubsource.yaml
@@ -28,7 +28,7 @@ spec:
       name: githubsecret
       key: secretToken
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1alpha1
     kind: Channel
     name: githubchannel
 
@@ -45,12 +45,11 @@ stringData:
 
 ---
 
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1alpha1
 kind: Channel
 metadata:
   name: githubchannel
 spec:
-  provisioner:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: ClusterChannelProvisioner
-    name: in-memory-channel
+  channelTemplate:
+    apiVersion: messaging.knative.dev/v1alpha1
+    kind: InMemoryChannel

--- a/samples/cronjob-source/README.md
+++ b/samples/cronjob-source/README.md
@@ -25,7 +25,6 @@
 
 ### Deployment
 
-<!-- TODO: is part of knative 0.8 ? only required for dev -->
 1. Deploy the `CronJobSource` controller as part of eventing-source's
    controller.
 

--- a/samples/cronjob-source/README.md
+++ b/samples/cronjob-source/README.md
@@ -6,10 +6,10 @@
 
 1. Setup [Knative Eventing](https://www.knative.dev/docs/eventing/).
 1. If your installed version of Eventing did not include the in-memory channel
-   provisioner, install the
-   [in-memory `ClusterChannelProvisioner`](https://knative.dev/eventing/tree/master/config/provisioners/in-memory-channel)
-   now. If you installed Eventing using the `eventing.yaml` file, the channel
-   provisioner was included. (See the
+   CRD, install the
+   [in-memory channel CRD](https://github.com/knative/eventing/blob/master/config/channels/in-memory-channel/README.md)
+   now. If you installed Eventing using the `release.yaml` file, the channel
+   CRD was included. (See the
    [Custom install guide](https://www.knative.dev/docs/install/knative-custom-install/)
    for information about what is include in each install file.)
    - Note that you can skip this if you choose to use a different type of
@@ -25,6 +25,7 @@
 
 ### Deployment
 
+<!-- TODO: is part of knative 0.8 ? only required for dev -->
 1. Deploy the `CronJobSource` controller as part of eventing-source's
    controller.
 

--- a/samples/cronjob-source/channel.yaml
+++ b/samples/cronjob-source/channel.yaml
@@ -1,10 +1,9 @@
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1alpha1
 kind: Channel
 metadata:
   name: cj-1
   namespace: default
 spec:
-  provisioner:
-    apiVersion: eventing.knative.dev/v1alpha1
-    kind: ClusterChannelProvisioner
-    name: in-memory-channel
+  channelTemplate:
+    apiVersion: messaging.knative.dev/v1alpha1
+    kind: InMemoryChannel

--- a/samples/cronjob-source/source.yaml
+++ b/samples/cronjob-source/source.yaml
@@ -6,6 +6,6 @@ spec:
   schedule: '* * * * *'
   data: '{"message": "Hello world!"}'
   sink:
-    apiVersion: eventing.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1alpha1
     kind: Channel
     name: cj-1

--- a/samples/cronjob-source/subscriber.yaml
+++ b/samples/cronjob-source/subscriber.yaml
@@ -1,13 +1,13 @@
 # Subscription from the CronJobSource's output Channel to the Knative Service below.
 
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1alpha1
 kind: Subscription
 metadata:
   name: cronjob-source-sample
   namespace: default
 spec:
   channel:
-    apiVersion: eventing.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1alpha1
     kind: Channel
     name: cj-1
   subscriber:

--- a/samples/heartbeats/README.md
+++ b/samples/heartbeats/README.md
@@ -8,8 +8,7 @@ sources to see a working example.
 ### Prerequisites
 
 - [ ] Install [Knative](https://www.knative.dev/docs/install/)
-- [ ] Install
-      [ko](https://github.com/google/go-containerregistry/tree/master/cmd/ko)
+- [ ] Install [ko](https://github.com/google/ko)
 
 ### Deploy Heartbeats Sender and Receiver
 
@@ -24,7 +23,7 @@ ko apply -f ./samples/heartbeats/
 View sender logs:
 
 ```shell
-kubectl logs --tail=50 -l source=heartbeats-sender -c source
+kubectl logs --tail=50 containersource-heartbeats-<TAB> -c source
 ```
 
 View receiver logs:


### PR DESCRIPTION
## Proposed Changes

  * Adjust all commands to use flat-hierarchy (introduced [here](https://github.com/knative/eventing-contrib/blob/master/DEVELOPMENT.md#installing-sources)) instead of `contrib/<source_name>` since `contrib` folder does not exist anymore
  * Fix kubectl command using source=heartbeats-sender label
  * Migrate channels and subscriptions to messaging.knative.dev
  * Fix markdown linter and dead links complaints

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Improve documentation of eventing-contrib
```