### PR TITLE
Stop using PrependGenerateNameReactor.

### DIFF
--- a/kafka/channel/pkg/reconciler/testing/factory.go
+++ b/kafka/channel/pkg/reconciler/testing/factory.go
@@ -61,9 +61,6 @@ func MakeFactory(ctor Ctor) Factory {
 		eventRecorder := record.NewFakeRecorder(maxEventBufferSize)
 		statsReporter := &FakeStatsReporter{}
 
-		PrependGenerateNameReactor(&client.Fake)
-		PrependGenerateNameReactor(&dynamicClient.Fake)
-
 		// Set up our Controller from the fakes.
 		c := ctor(&ls, reconciler.Options{
 			KubeClientSet:    kubeClient,

--- a/natss/pkg/reconciler/testing/factory.go
+++ b/natss/pkg/reconciler/testing/factory.go
@@ -61,9 +61,6 @@ func MakeFactory(ctor Ctor) Factory {
 		eventRecorder := record.NewFakeRecorder(maxEventBufferSize)
 		statsReporter := &FakeStatsReporter{}
 
-		PrependGenerateNameReactor(&client.Fake)
-		PrependGenerateNameReactor(&dynamicClient.Fake)
-
 		// Set up our Controller from the fakes.
 		c := ctor(&ls, reconciler.Options{
 			KubeClientSet:    kubeClient,


### PR DESCRIPTION
This is broken by the K8s test libs starting in 1.14, and to work properly we would need to patch vendor to partially revert the library change.

The intent of this is to remove the logic to avoid having someone unknowingly start to depend on this functionality, which keeps eventing-contrib from having to carry this patch.
