### PR TITLE
Update Status.ObservedGeneration when reconcile sources resources

### DIFF
--- a/awssqs/pkg/reconciler/awssqssource.go
+++ b/awssqs/pkg/reconciler/awssqssource.go
@@ -132,6 +132,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) error
 
 	r.addFinalizer(src)
 
+	src.Status.ObservedGeneration = src.Generation
 	src.Status.InitializeConditions()
 
 	sinkURI, err := sinks.GetSinkURI(ctx, r.client, src.Spec.Sink, src.Namespace)

--- a/camel/source/pkg/reconciler/camelsource.go
+++ b/camel/source/pkg/reconciler/camelsource.go
@@ -109,6 +109,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) error
 		return nil
 	}
 
+	source.Status.ObservedGeneration = source.Generation
 	source.Status.InitializeConditions()
 
 	sinkURI, err := sinks.GetSinkURI(ctx, r.client, source.Spec.Sink, source.Namespace)

--- a/github/pkg/reconciler/githubsource.go
+++ b/github/pkg/reconciler/githubsource.go
@@ -131,6 +131,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) error
 }
 
 func (r *reconciler) reconcile(ctx context.Context, source *sourcesv1alpha1.GitHubSource) error {
+	source.Status.ObservedGeneration = source.Generation
 	source.Status.InitializeConditions()
 
 	accessToken, err := r.secretFrom(ctx, source.Namespace, source.Spec.AccessToken.SecretKeyRef)

--- a/kafka/source/pkg/reconciler/kafkasource.go
+++ b/kafka/source/pkg/reconciler/kafkasource.go
@@ -97,6 +97,7 @@ func (r *reconciler) Reconcile(ctx context.Context, object runtime.Object) error
 
 	logger.Info("Reconciling new source: ", zap.Any("source", src))
 
+	src.Status.ObservedGeneration = src.Generation
 	src.Status.InitializeConditions()
 
 	sinkURI, err := sinks.GetSinkURI(ctx, r.client, src.Spec.Sink, src.Namespace)


### PR DESCRIPTION
Fixes #599 

## Proposed Changes

  *Update Status.ObservedGeneration when reconcile sources resources
  *Add unit test
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
None
```