### PR TITLE
Add ClusterRole to get, list and watch sources in eventing-contrib

### DIFF
--- a/awssqs/config/201-clusterrole.yaml
+++ b/awssqs/config/201-clusterrole.yaml
@@ -92,3 +92,22 @@ rules:
   verbs:
   - get
   - list
+
+# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-contrib-awssqs-source-resolver
+  labels:
+    eventing.knative.dev/release: devel
+    duck.knative.dev/sourceObserver: "true"
+rules:
+  - apiGroups:
+      - "sources.eventing.knative.dev"
+    resources:
+      - "awssqssources"
+    verbs:
+      - get
+      - list
+      - watch

--- a/awssqs/config/201-clusterrole.yaml
+++ b/awssqs/config/201-clusterrole.yaml
@@ -93,15 +93,15 @@ rules:
   - get
   - list
 
-# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: eventing-contrib-awssqs-source-resolver
+  name: eventing-contrib-awssqs-source-observer
   labels:
     eventing.knative.dev/release: devel
-    duck.knative.dev/sourceObserver: "true"
+    duck.knative.dev/source: "true"
 rules:
   - apiGroups:
       - "sources.eventing.knative.dev"

--- a/awssqs/config/201-clusterrole.yaml
+++ b/awssqs/config/201-clusterrole.yaml
@@ -93,8 +93,10 @@ rules:
   - get
   - list
 
-# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
+
 ---
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
+# See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/camel/source/config/201-clusterrole.yaml
+++ b/camel/source/config/201-clusterrole.yaml
@@ -83,15 +83,15 @@ rules:
   - patch
   - delete
 
-# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: eventing-contrib-camel-source-resolver
+  name: eventing-contrib-camel-source-observer
   labels:
     eventing.knative.dev/release: devel
-    duck.knative.dev/sourceObserver: "true"
+    duck.knative.dev/source: "true"
 rules:
   - apiGroups:
       - "sources.eventing.knative.dev"

--- a/camel/source/config/201-clusterrole.yaml
+++ b/camel/source/config/201-clusterrole.yaml
@@ -82,3 +82,22 @@ rules:
   - update
   - patch
   - delete
+
+# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-contrib-camel-source-resolver
+  labels:
+    eventing.knative.dev/release: devel
+    duck.knative.dev/sourceObserver: "true"
+rules:
+  - apiGroups:
+      - "sources.eventing.knative.dev"
+    resources:
+      - "camelsources"
+    verbs:
+      - get
+      - list
+      - watch

--- a/camel/source/config/201-clusterrole.yaml
+++ b/camel/source/config/201-clusterrole.yaml
@@ -83,8 +83,9 @@ rules:
   - patch
   - delete
 
-# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
 ---
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
+# See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/github/config/201-clusterrole.yaml
+++ b/github/config/201-clusterrole.yaml
@@ -89,15 +89,15 @@ rules:
   - eventtypes
   verbs: *everything
 
-# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: eventing-contrib-github-source-resolver
+  name: eventing-contrib-github-source-observer
   labels:
     eventing.knative.dev/release: devel
-    duck.knative.dev/sourceObserver: "true"
+    duck.knative.dev/source: "true"
 rules:
   - apiGroups:
       - "sources.eventing.knative.dev"

--- a/github/config/201-clusterrole.yaml
+++ b/github/config/201-clusterrole.yaml
@@ -88,3 +88,22 @@ rules:
   resources:
   - eventtypes
   verbs: *everything
+
+# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-contrib-github-source-resolver
+  labels:
+    eventing.knative.dev/release: devel
+    duck.knative.dev/sourceObserver: "true"
+rules:
+  - apiGroups:
+      - "sources.eventing.knative.dev"
+    resources:
+      - "githubsources"
+    verbs:
+      - get
+      - list
+      - watch

--- a/github/config/201-clusterrole.yaml
+++ b/github/config/201-clusterrole.yaml
@@ -89,8 +89,9 @@ rules:
   - eventtypes
   verbs: *everything
 
-# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
 ---
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
+# See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/kafka/source/config/201-clusterrole.yaml
+++ b/kafka/source/config/201-clusterrole.yaml
@@ -67,8 +67,9 @@ rules:
   - eventtypes
   verbs: *everything
 
-# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
 ---
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
+# See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/kafka/source/config/201-clusterrole.yaml
+++ b/kafka/source/config/201-clusterrole.yaml
@@ -67,15 +67,15 @@ rules:
   - eventtypes
   verbs: *everything
 
-# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: eventing-contrib-kafka-source-resolver
+  name: eventing-contrib-kafka-source-observer
   labels:
     eventing.knative.dev/release: devel
-    duck.knative.dev/sourceObserver: "true"
+    duck.knative.dev/source: "true"
 rules:
   - apiGroups:
       - "sources.eventing.knative.dev"

--- a/kafka/source/config/201-clusterrole.yaml
+++ b/kafka/source/config/201-clusterrole.yaml
@@ -67,3 +67,21 @@ rules:
   - eventtypes
   verbs: *everything
 
+# The role is needed for the aggregated role source-resolver in knative-eventing to provide readonly access to "Sources"
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-contrib-kafka-source-resolver
+  labels:
+    eventing.knative.dev/release: devel
+    duck.knative.dev/sourceObserver: "true"
+rules:
+  - apiGroups:
+      - "sources.eventing.knative.dev"
+    resources:
+      - "kafkasources"
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Fixes #583 

## Proposed Changes

  * Add ClusterRole to get, list and watch "awssqssources", "camelsources", "kafkasources" and "githubsources" 
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```