### PR TITLE
golang format tools

### DIFF
--- a/camel/source/pkg/reconciler/camelsource_test.go
+++ b/camel/source/pkg/reconciler/camelsource_test.go
@@ -539,11 +539,11 @@ func getDeletedSource() *sourcesv1alpha1.CamelSource {
 
 func om(namespace, name string, generation int64) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Namespace: namespace,
-		Name:      name,
-		Generation:generation,
-		SelfLink:  fmt.Sprintf("/apis/eventing/sources/v1alpha1/namespaces/%s/object/%s", namespace, name),
-		UID:       sourceUID,
+		Namespace:  namespace,
+		Name:       name,
+		Generation: generation,
+		SelfLink:   fmt.Sprintf("/apis/eventing/sources/v1alpha1/namespaces/%s/object/%s", namespace, name),
+		UID:        sourceUID,
 	}
 }
 

--- a/github/pkg/reconciler/githubsource_test.go
+++ b/github/pkg/reconciler/githubsource_test.go
@@ -52,7 +52,7 @@ const (
 	gitHubSourceName = "testgithubsource"
 	testNS           = "testnamespace"
 	gitHubSourceUID  = "2b2219e2-ce67-11e8-b3a3-42010a8a00af"
-	generation = 1
+	generation       = 1
 
 	addressableDNS = "addressable.sink.svc.cluster.local"
 	addressableURI = "http://addressable.sink.svc.cluster.local"
@@ -125,7 +125,7 @@ var testCases = []controllertesting.TestCase{
 				return s
 			}(),
 		},
-		WantErrMsg:   `sink "testnamespace/testunaddressable" (duck.knative.dev/v1alpha1, Kind=KResource) does not contain address`,
+		WantErrMsg:  `sink "testnamespace/testunaddressable" (duck.knative.dev/v1alpha1, Kind=KResource) does not contain address`,
 		IgnoreTimes: true,
 	}, {
 		Name:       "valid githubsource, sink is addressable",
@@ -1033,10 +1033,10 @@ func gitHubSourceType() metav1.TypeMeta {
 
 func om(namespace, name string, generation int64) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Namespace: namespace,
-		Name:      name,
-		Generation:generation,
-		SelfLink:  fmt.Sprintf("/apis/eventing/sources/v1alpha1/namespaces/%s/object/%s", namespace, name),
+		Namespace:  namespace,
+		Name:       name,
+		Generation: generation,
+		SelfLink:   fmt.Sprintf("/apis/eventing/sources/v1alpha1/namespaces/%s/object/%s", namespace, name),
 	}
 }
 

--- a/kafka/source/pkg/reconciler/kafkasource_test.go
+++ b/kafka/source/pkg/reconciler/kafkasource_test.go
@@ -211,7 +211,6 @@ func TestReconcile(t *testing.T) {
 				}(),
 				getEventType("name1", "topic1"),
 				getEventType("name2", "topic2"),
-
 			},
 		}, {
 			Name: "successful create missing event types",
@@ -299,7 +298,6 @@ func TestReconcile(t *testing.T) {
 					s.Status.ObservedGeneration = generation
 					return s
 				}(),
-
 			},
 			WantErrMsg: "test-induced-error",
 		},
@@ -468,11 +466,11 @@ func getReadyAndMarkEventTypesSourceWithKind(kind string) *sourcesv1alpha1.Kafka
 
 func om(namespace, name string, generation int64) metav1.ObjectMeta {
 	return metav1.ObjectMeta{
-		Namespace: namespace,
-		Name:      name,
-		Generation:generation,
-		SelfLink:  fmt.Sprintf("/apis/eventing/sources/v1alpha1/namespaces/%s/object/%s", namespace, name),
-		UID:       sourceUID,
+		Namespace:  namespace,
+		Name:       name,
+		Generation: generation,
+		SelfLink:   fmt.Sprintf("/apis/eventing/sources/v1alpha1/namespaces/%s/object/%s", namespace, name),
+		UID:        sourceUID,
 	}
 }
 


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign n3wscott
