### PR TITLE
Minior fix to have controller name to be valid for later metrics usage

### DIFF
--- a/couchdb/source/cmd/controller/main.go
+++ b/couchdb/source/cmd/controller/main.go
@@ -22,5 +22,5 @@ import (
 )
 
 func main() {
-	sharedmain.Main("couchdb-controller", reconciler.NewController)
+	sharedmain.Main("couchdb_controller", reconciler.NewController)
 }


### PR DESCRIPTION
controller name should be valid for later metrics usage, see: https://github.com/knative/eventing/pull/1747/files

