### PR TITLE
Skip the flaky e2e test

### DIFF
--- a/test/e2e/channel_defaulter_test.go
+++ b/test/e2e/channel_defaulter_test.go
@@ -26,12 +26,14 @@ import (
 
 // TestChannelClusterDefaulter tests a cluster defaulted channel can be created with the template specified through configmap.
 func TestChannelClusterDefaulter(t *testing.T) {
+	// TODO(chizhg): reenable the test after solving https://github.com/knative/eventing-contrib/issues/627
 	t.Skip()
 	helpers.ChannelClusterDefaulterTestHelper(t, channelTestRunner)
 }
 
 // TestChannelNamespaceDefaulter tests a namespace defaulted channel can be created with the template specified through configmap.
 func TestChannelNamespaceDefaulter(t *testing.T) {
+	// TODO(chizhg): reenable the test after solving https://github.com/knative/eventing-contrib/issues/627
 	t.Skip()
 	helpers.ChannelNamespaceDefaulterTestHelper(t, channelTestRunner)
 }

--- a/test/e2e/channel_defaulter_test.go
+++ b/test/e2e/channel_defaulter_test.go
@@ -26,10 +26,12 @@ import (
 
 // TestChannelClusterDefaulter tests a cluster defaulted channel can be created with the template specified through configmap.
 func TestChannelClusterDefaulter(t *testing.T) {
+	t.Skip()
 	helpers.ChannelClusterDefaulterTestHelper(t, channelTestRunner)
 }
 
 // TestChannelNamespaceDefaulter tests a namespace defaulted channel can be created with the template specified through configmap.
 func TestChannelNamespaceDefaulter(t *testing.T) {
+	t.Skip()
 	helpers.ChannelNamespaceDefaulterTestHelper(t, channelTestRunner)
 }


### PR DESCRIPTION

## Proposed Changes
* For now, skip the flaky test mentioned in https://github.com/knative/eventing-contrib/issues/627

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```

/cc @nachocano 
/cc @matzew 