### PR TITLE
Stop skipping Broker Tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1544,7 +1544,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ea0d4e1b231c23123d771043229e5dc6237a6d32b977fa336b5239c8d800945b"
+  digest = "1:d380cfa7fc55e76f51e74d5f063890a319733929014e14e9374a2d67dd0057d4"
   name = "knative.dev/eventing"
   packages = [
     "pkg/apis/duck",
@@ -1600,7 +1600,7 @@
     "test/e2e/helpers",
   ]
   pruneopts = "NUT"
-  revision = "f20c3b23dc7e85c7ef8289e36f41690a379f5334"
+  revision = "96384412d4698fd27470b48a03e6ec64808576f6"
 
 [[projects]]
   branch = "master"

--- a/hack/set-span-id.patch
+++ b/hack/set-span-id.patch
@@ -1,13 +1,15 @@
 diff --git a/vendor/go.opencensus.io/trace/trace.go b/vendor/go.opencensus.io/trace/trace.go
-index 38ead7bf..9e6fe483 100644
+index 38ead7bf..8793af0a 100644
 --- a/vendor/go.opencensus.io/trace/trace.go
 +++ b/vendor/go.opencensus.io/trace/trace.go
-@@ -261,6 +261,11 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
+@@ -261,6 +261,13 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
  	return span
  }
  
 +func (s *Span) SetSpanID(spanID SpanID) {
-+	s.data.SpanID = spanID
++	if s.data != nil {
++		s.data.SpanID = spanID
++	}
 +	s.spanContext.SpanID = spanID
 +}
 +

--- a/test/e2e/broker_channel_flow_test.go
+++ b/test/e2e/broker_channel_flow_test.go
@@ -24,6 +24,5 @@ import (
 )
 
 func TestBrokerChannelFlow(t *testing.T) {
-	t.Skip("See issue: https://github.com/knative/eventing-contrib/issues/639")
 	helpers.BrokerChannelFlowTestHelper(t, channelTestRunner)
 }

--- a/test/e2e/broker_event_transformation_test.go
+++ b/test/e2e/broker_event_transformation_test.go
@@ -24,6 +24,5 @@ import (
 )
 
 func TestEventTransformationForTrigger(t *testing.T) {
-	t.Skip("See issue: https://github.com/knative/eventing-contrib/issues/639")
 	helpers.EventTransformationForTriggerTestHelper(t, channelTestRunner)
 }

--- a/vendor/go.opencensus.io/trace/trace.go
+++ b/vendor/go.opencensus.io/trace/trace.go
@@ -262,7 +262,9 @@ func startSpanInternal(name string, hasParent bool, parent SpanContext, remotePa
 }
 
 func (s *Span) SetSpanID(spanID SpanID) {
-	s.data.SpanID = spanID
+	if s.data != nil {
+		s.data.SpanID = spanID
+	}
 	s.spanContext.SpanID = spanID
 }
 

--- a/vendor/knative.dev/eventing/pkg/tracing/traceparent.go
+++ b/vendor/knative.dev/eventing/pkg/tracing/traceparent.go
@@ -69,7 +69,7 @@ func AddSpanFromTraceparentAttribute(ctx context.Context, name string, event clo
 	}
 	tps, ok := tp.(string)
 	if !ok {
-		return ctx, fmt.Errorf("extention attribute %q's value was not a string: %T", traceparentAttribute, tps)
+		return ctx, fmt.Errorf("extension attribute %q's value was not a string: %T", traceparentAttribute, tps)
 	}
 	sc, err := parseTraceparent(tps)
 	if err != nil {


### PR DESCRIPTION
Fixes #639

## Proposed Changes

  * Update knative/eventing.
  * No longer skip the Broker tests.
      * Needed knative/eventing#1986.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```