### PR TITLE
golang format tools

### DIFF
--- a/kafka/source/cmd/controller/main.go
+++ b/kafka/source/cmd/controller/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"knative.dev/eventing-contrib/kafka/source/pkg/reconciler"
+	kafka "knative.dev/eventing-contrib/kafka/source/pkg/reconciler"
 	"knative.dev/pkg/injection/sharedmain"
 )
 

--- a/kafka/source/pkg/reconciler/resources/labels_test.go
+++ b/kafka/source/pkg/reconciler/resources/labels_test.go
@@ -17,8 +17,9 @@ limitations under the License.
 package resources
 
 import (
-	"github.com/google/go-cmp/cmp"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestGetLabels(t *testing.T) {


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign n3wscott
