### PR TITLE
Add ClusterRole to get, list and watch couchdb sources

### DIFF
--- a/couchdb/source/config/201-clusterrole.yaml
+++ b/couchdb/source/config/201-clusterrole.yaml
@@ -84,3 +84,23 @@ rules:
   resources:
     - eventtypes
   verbs: *everything
+
+---
+# The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
+# See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: eventing-contrib-couchdb-source-observer
+  labels:
+    eventing.knative.dev/release: devel
+    duck.knative.dev/source: "true"
+rules:
+  - apiGroups:
+      - "sources.eventing.knative.dev"
+    resources:
+      - "couchdbsources"
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
Fixes #645 

## Proposed Changes

  * Add ClusterRole to get, list and watch couchdb sources
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```