### PR TITLE
Nicer rendering of kafkasource

### DIFF
--- a/kafka/source/config/300-kafkasource.yaml
+++ b/kafka/source/config/300-kafkasource.yaml
@@ -38,6 +38,22 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  additionalPrinterColumns:
+    - name: Topics
+      type: string
+      JSONPath: ".spec.topics"
+    - name: BootstrapServers
+      type: string
+      JSONPath: ".spec.bootstrapServers"
+    - name: Ready
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Ready\")].status"
+    - name: Reason
+      type: string
+      JSONPath: ".status.conditions[?(@.type==\"Ready\")].reason"
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
Improve info for kafaksource, by showing infos like the broker and the topic 

```
kubectl get kafkasource 
NAME          TOPICS                                      BOOTSTRAPSERVERS                       READY   REASON     AGE
kafka-source  knative-messaging-kafka.default.mychannel   my-cluster-kafka-bootstrap.kafka:9092  True               24s
```

VERSUS old:

```
kubectl get kafkasource 
NAME           AGE
kafka-source   7s
```


## Proposed Changes

  * better rendering for kafka SRC

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```