### PR TITLE
refactor natss test logger

### DIFF
--- a/natss/pkg/stanutil/stanutil_test.go
+++ b/natss/pkg/stanutil/stanutil_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package stanutil
 
 import (
+	"go.uber.org/zap/zapcore"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/nats-io/nats-streaming-server/server"
 	"go.uber.org/zap"
-	channels "knative.dev/eventing/pkg/channel"
+	"knative.dev/pkg/logging"
 	_ "knative.dev/pkg/system/testing"
 )
 
@@ -38,7 +39,7 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	logger = channels.NewProvisionerLoggerFromConfig(channels.NewLoggingConfig())
+	logger = setupLogger()
 	defer logger.Sync()
 
 	stanServer, err := startNatss()
@@ -88,4 +89,35 @@ func startNatss() (*server.StanServer, error) {
 
 func stopNatss(server *server.StanServer) {
 	server.Shutdown()
+}
+
+func newLoggingConfig() *logging.Config {
+	lc := &logging.Config{}
+	lc.LoggingConfig = `{
+		"level": "info",
+		"development": false,
+		"outputPaths": ["stdout"],
+		"errorOutputPaths": ["stderr"],
+		"encoding": "json",
+		"encoderConfig": {
+			"timeKey": "ts",
+			"levelKey": "level",
+			"nameKey": "logger",
+			"callerKey": "caller",
+			"messageKey": "msg",
+			"stacktraceKey": "stacktrace",
+			"lineEnding": "",
+			"levelEncoder": "",
+			"timeEncoder": "iso8601",
+			"durationEncoder": "",
+			"callerEncoder": ""
+		}
+	}`
+	lc.LoggingLevel = make(map[string]zapcore.Level)
+	return lc
+}
+
+func setupLogger() *zap.SugaredLogger {
+	logger, _ := logging.NewLoggerFromConfig(newLoggingConfig(), "stanutil_test")
+	return logger
 }

--- a/natss/pkg/stanutil/stanutil_test.go
+++ b/natss/pkg/stanutil/stanutil_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package stanutil
 
 import (
-	"go.uber.org/zap/zapcore"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/nats-io/nats-streaming-server/server"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"knative.dev/pkg/logging"
 	_ "knative.dev/pkg/system/testing"
 )


### PR DESCRIPTION

deleting old code, that will get deleted

## Proposed Changes

  * in https://github.com/knative/eventing/pull/2064/files we remove old provisioner code
  * this PR removes the last caller, and inlines the setup of the logger on this one test file

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```