### PR TITLE
Make our deepcopy-gen approach consistent with other repos.

### DIFF
--- a/awssqs/pkg/apis/apis.go
+++ b/awssqs/pkg/apis/apis.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Generate deepcopy for apis
-//go:generate go run ../../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../../hack/boilerplate.go.txt
-
 // Package apis contains Kubernetes API groups.
 package apis
 

--- a/camel/source/pkg/apis/apis.go
+++ b/camel/source/pkg/apis/apis.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Generate deepcopy for apis
-//go:generate go run ../../../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../../../hack/boilerplate.go.txt
-
 // Package apis contains Kubernetes API groups.
 package apis
 

--- a/couchdb/source/pkg/apis/apis.go
+++ b/couchdb/source/pkg/apis/apis.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Generate deepcopy for apis
-//go:generate go run ../../../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../../../hack/boilerplate.go.txt
-
 // Package apis contains Kubernetes API groups.
 package apis
 

--- a/github/pkg/apis/apis.go
+++ b/github/pkg/apis/apis.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Generate deepcopy for apis
-//go:generate go run ../../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../../hack/boilerplate.go.txt
-
 // Package apis contains Kubernetes API groups.
 package apis
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -24,10 +24,6 @@ CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/k8s.io/code-
 
 KNATIVE_CODEGEN_PKG=${KNATIVE_CODEGEN_PKG:-$(cd ${REPO_ROOT_DIR}; ls -d -1 ./vendor/knative.dev/pkg 2>/dev/null || echo ../pkg)}
 
-# Generate based on annotations
-go generate ./pkg/... ./cmd/... ./github/pkg/... ./camel/source/pkg/... ./kafka/source/pkg/... ./kafka/channel/pkg/... ./awssqs/pkg/... \
-  ./couchdb/source/pkg/... ./natss/pkg/... ./prometheus/pkg/...
-
 # Sources
 API_DIRS_SOURCES=(github/pkg camel/source/pkg kafka/source/pkg awssqs/pkg couchdb/source/pkg prometheus/pkg)
 
@@ -67,6 +63,16 @@ for DIR in "${API_DIRS_CHANNELS[@]}"; do
     "messaging:v1alpha1" \
     --go-header-file ${REPO_ROOT_DIR}/hack/boilerplate.go.txt
 done
+
+# Depends on generate-groups.sh to install bin/deepcopy-gen
+${GOPATH}/bin/deepcopy-gen \
+  -O zz_generated.deepcopy \
+  --go-header-file ${REPO_ROOT_DIR}/hack/boilerplate.go.txt \
+  -i knative.dev/eventing-contrib/prometheus/pkg/apis \
+  -i knative.dev/eventing-contrib/awssqs/pkg/apis \
+  -i knative.dev/eventing-contrib/couchdb/source/pkg/apis \
+  -i knative.dev/eventing-contrib/camel/source/pkg/apis \
+  -i knative.dev/eventing-contrib/github/pkg/apis
 
 # Make sure our dependencies are up-to-date
 ${REPO_ROOT_DIR}/hack/update-deps.sh

--- a/prometheus/pkg/apis/apis.go
+++ b/prometheus/pkg/apis/apis.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Generate deepcopy for apis
-//go:generate go run ../../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../../hack/boilerplate.go.txt
-
 // Package apis contains Kubernetes API groups.
 package apis
 


### PR DESCRIPTION
This angers the knobots that try to auto-import across repos.