### PR TITLE
Adding standard duck label on CRD to signal this resource adheres to Addressable

### DIFF
--- a/kafka/channel/config/300-kafka-channel.yaml
+++ b/kafka/channel/config/300-kafka-channel.yaml
@@ -20,6 +20,7 @@ metadata:
     contrib.eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
 spec:
   group: messaging.knative.dev
   version: v1alpha1

--- a/natss/config/300-natss-channel.yaml
+++ b/natss/config/300-natss-channel.yaml
@@ -20,6 +20,7 @@ metadata:
     contrib.eventing.knative.dev/release: devel
     knative.dev/crd-install: "true"
     messaging.knative.dev/subscribable: "true"
+    duck.knative.dev/addressable: "true"
 spec:
   group: messaging.knative.dev
   version: v1alpha1


### PR DESCRIPTION
## Proposed Changes

  * Label Kakfa and NATS channel CRDs with `duck.knative.dev/addressable: "true"`.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Kakfa and NATS channel CRDs are now labeled with duck.knative.dev/addressable: "true".
```