### PR TITLE
golang format tools

### DIFF
--- a/camel/source/pkg/reconciler/camelsource_test.go
+++ b/camel/source/pkg/reconciler/camelsource_test.go
@@ -404,7 +404,7 @@ func makeContext(namespace string, image string) *camelv1alpha1.IntegrationKit {
 			GenerateName: "ctx-",
 			Namespace:    namespace,
 			Labels: map[string]string{
-				"app": "camel-k",
+				"app":                       "camel-k",
 				"camel.apache.org/kit.type": camelv1alpha1.IntegrationKitTypeExternal,
 			},
 		},

--- a/camel/source/pkg/reconciler/resources/flow.go
+++ b/camel/source/pkg/reconciler/resources/flow.go
@@ -17,7 +17,7 @@ limitations under the License.
 package resources
 
 import (
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // MarshalCamelFlows marshals a list of flows into their standard yaml representation


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -type f -name '*.go' -print))`
  `goimports -w $(find -name '*.go' | grep -v vendor)`
/assign n3wscott
