### PR TITLE
add missing type

### DIFF
--- a/couchdb/source/config/300-couchdbsource.yaml
+++ b/couchdb/source/config/300-couchdbsource.yaml
@@ -77,6 +77,25 @@ spec:
                   uri:
                     type: string
                     description: "the target URI. If ref is provided, this must be relative URI reference."
+              - type: object
+                description: "DEPRECATED: a reference to a Kubernetes object from which to retrieve the target URI."
+                required:
+                - apiVersion
+                - kind
+                - name
+                properties:
+                  apiVersion:
+                    type: string
+                    minLength: 1
+                  kind:
+                    type: string
+                    minLength: 1
+                  name:
+                    type: string
+                    minLength: 1
+                  uri:
+                    type: string
+                    description: "the target URI. If ref is provided, this must be relative URI reference."
             feed:
               type: string
               enum: ["continuous", "normal"]

--- a/kafka/source/config/300-kafkasource.yaml
+++ b/kafka/source/config/300-kafkasource.yaml
@@ -127,29 +127,48 @@ spec:
               type: string
             sink:
               anyOf:
-                - type: object
-                  description: "the destination that should receive events."
-                  properties:
-                    ref:
-                      type: object
-                      description: "a reference to a Kubernetes object from which to retrieve the target URI."
-                      required:
-                        - apiVersion
-                        - kind
-                        - name
-                      properties:
-                        apiVersion:
-                          type: string
-                          minLength: 1
-                        kind:
-                          type: string
-                          minLength: 1
-                        name:
-                          type: string
-                          minLength: 1
-                    uri:
-                      type: string
-                      description: "the target URI. If ref is provided, this must be relative URI reference."
+              - type: object
+                description: "the destination that should receive events."
+                properties:
+                  ref:
+                    type: object
+                    description: "a reference to a Kubernetes object from which to retrieve the target URI."
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    properties:
+                      apiVersion:
+                        type: string
+                        minLength: 1
+                      kind:
+                        type: string
+                        minLength: 1
+                      name:
+                        type: string
+                        minLength: 1
+                  uri:
+                    type: string
+                    description: "the target URI. If ref is provided, this must be relative URI reference."
+              - type: object
+                description: "DEPRECATED: a reference to a Kubernetes object from which to retrieve the target URI."
+                required:
+                - apiVersion
+                - kind
+                - name
+                properties:
+                  apiVersion:
+                    type: string
+                    minLength: 1
+                  kind:
+                    type: string
+                    minLength: 1
+                  name:
+                    type: string
+                    minLength: 1
+                  uri:
+                    type: string
+                    description: "the target URI. If ref is provided, this must be relative URI reference."
           type: object
           required:
               - bootstrapServers


### PR DESCRIPTION
## Proposed Changes

  * Add missing type

Still using `anyOf` because `oneOf` must validate one and only one schema. And also this will go away next release.