### PR TITLE
Prometheus Source: added support for basic TLS configuration and authentication

### DIFF
--- a/prometheus/README.md
+++ b/prometheus/README.md
@@ -9,8 +9,10 @@ sent to the configured sink as CloudEvents.
 
 ## Deployment steps
 
+### Kubernetes
+
 1. Setup [Knative Eventing](../DEVELOPMENT.md)
-1. Create a PrometheusSource CRD, specifying the URL for the Prometheus server,
+1. Create a PrometheusSource CR, specifying the URL for the Prometheus server,
    the PromQL query to run and the sink to send CloudEvents to:
 
    ```yaml
@@ -26,3 +28,38 @@ sent to the configured sink as CloudEvents.
        kind: Service
        name: event-display
    ```
+
+### OpenShift Monitoring Stack
+
+The following assumes deployment of the Prometheus Source into the default project to run
+under the default service account.
+
+1. Setup [Knative Eventing](../DEVELOPMENT.md)
+1. Create a ConfigMap for the Service signer CA bundle and annotate it
+   accordingly:
+
+``` bash
+oc apply -f demo/openshift-service-serving-signer-cabundle.yaml
+oc annotate configmap openshift-service-serving-signer-cabundle service.beta.openshift.io/inject-cabundle=true
+```
+
+1. Bind the cluster-monitoring-view ClusterRole to the default service account:
+
+``` bash
+oc adm policy add-cluster-role-to-user cluster-monitoring-view system:serviceaccount:default:default
+```
+
+1. Deploy an event-display sink for the events produced by the Prometheus source:
+
+``` bash
+oc apply -f demo/sink.yaml
+```
+
+1. Create a CR for the Source, configured to communicate to the in-cluster
+   Prometheus server. The authTokenFile field is the conventional location
+   for the service account authentication token. The caCertConfigMap is the
+   name of the Service signer CA ConfigMap.
+
+``` bash
+oc apply -f demo/source_openshift.yaml
+```

--- a/prometheus/config/300-prometheussource.yaml
+++ b/prometheus/config/300-prometheussource.yaml
@@ -64,6 +64,15 @@ spec:
               type: string
               description:
                 The PromQL query to run against the Prometheus server
+            authTokenFile:
+              type: string
+              description:
+                The name of the file containing the authenication token
+            caCertConfigMap:
+              type: string
+              description:
+                The name of the config map containing the CA certificate of the
+                Prometheus service's signer.
             sink:
               type: object
               description: >

--- a/prometheus/demo/openshift-service-serving-signer-cabundle.yaml
+++ b/prometheus/demo/openshift-service-serving-signer-cabundle.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openshift-service-serving-signer-cabundle

--- a/prometheus/demo/source_openshift.yaml
+++ b/prometheus/demo/source_openshift.yaml
@@ -1,0 +1,13 @@
+apiVersion: sources.eventing.knative.dev/v1alpha1
+kind: PrometheusSource
+metadata:
+  name: prometheus-source
+spec:
+  serverURL: https://prometheus-k8s.openshift-monitoring.svc:9091
+  promQL: ALERTS
+  authTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+  caCertConfigMap: openshift-service-serving-signer-cabundle
+  sink:
+    apiVersion: serving.knative.dev/v1
+    kind: Service
+    name: event-display

--- a/prometheus/pkg/apis/sources/v1alpha1/prometheussource_types.go
+++ b/prometheus/pkg/apis/sources/v1alpha1/prometheussource_types.go
@@ -68,7 +68,16 @@ type PrometheusSourceSpec struct {
 	// PromQL is the Prometheus query for this source
 	PromQL string `json:"promQL"`
 
-	// Sink is a reference to an object that will resolve to a domain
+	// The name of the file containing the authenication token
+	// +optional
+	AuthTokenFile string `json:"authTokenFile,omitempty"`
+
+	// The name of the config map containing the CA certificate of the
+	// Prometheus service's signer.
+	// +optional
+	CACertConfigMap string `json:"caCertConfigMap,omitempty"`
+
+	// Sink is a reference to an object that will resolve to a host
 	// name to use as the sink.
 	// +optional
 	Sink *corev1.ObjectReference `json:"sink,omitempty"`


### PR DESCRIPTION
## Proposed Changes

Added authTokenFile and caCertConfigMap fields to the source CRD, as conduits for
specifying the Authorization Bearer authentication token and a Config Map with a
CA certificate the Prometheus server's certificate is signed with.
