### PR TITLE
remove vaikas-google in favor of vaikas

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,7 +4,6 @@ approvers:
 - evankanderson
 - grantr
 - Harwayne
-- vaikas-google
 - vaikas
 - n3wscott
 - matzew
@@ -17,7 +16,6 @@ reviewers:
 - evankanderson
 - grantr
 - Harwayne
-- vaikas-google
 - vaikas
 - n3wscott
 - matzew


### PR DESCRIPTION
Fixes #

## Proposed Changes

  * remove vaikas-google from OWNERS file, it was moved to vaikas

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```