### PR TITLE
Always upload test images from vendor

### DIFF
--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -44,3 +44,7 @@ git apply ${REPO_ROOT_DIR}/hack/set-span-id.patch
 # Patch Kivik
 # see https://github.com/go-kivik/kivik/issues/420
 git apply ${REPO_ROOT_DIR}/hack/kivik-set-zero.patch
+
+# We vendor test image code from eventing, in order to use ko to resolve them into Docker images, the
+# path has to be a GOPATH.
+git apply ${REPO_ROOT_DIR}/hack/update-image-paths.patch

--- a/hack/update-image-paths.patch
+++ b/hack/update-image-paths.patch
@@ -1,0 +1,33 @@
+diff --git a/vendor/knative.dev/eventing/test/test_images/logevents/pod.yaml b/vendor/knative.dev/eventing/test/test_images/logevents/pod.yaml
+index 8e71971b..17c2060f 100644
+--- a/vendor/knative.dev/eventing/test/test_images/logevents/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/logevents/pod.yaml
+@@ -5,5 +5,5 @@ metadata:
+ spec:
+   containers:
+     - name: logevents
+-      image: knative.dev/eventing/test/test_images/logevents
++      image: knative.dev/eventing-contrib/vendor/knative.dev/eventing/test/test_images/logevents
+ 
+diff --git a/vendor/knative.dev/eventing/test/test_images/sendevents/pod.yaml b/vendor/knative.dev/eventing/test/test_images/sendevents/pod.yaml
+index 6cd6f6ee..15b24dcb 100644
+--- a/vendor/knative.dev/eventing/test/test_images/sendevents/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/sendevents/pod.yaml
+@@ -5,5 +5,5 @@ metadata:
+ spec:
+   containers:
+     - name: sendevents
+-      image: knative.dev/eventing/test/test_images/sendevents
++      image: knative.dev/eventing-contrib/vendor/knative.dev/eventing/test/test_images/sendevents
+ 
+diff --git a/vendor/knative.dev/eventing/test/test_images/transformevents/pod.yaml b/vendor/knative.dev/eventing/test/test_images/transformevents/pod.yaml
+index bcdc5e24..b69c997c 100644
+--- a/vendor/knative.dev/eventing/test/test_images/transformevents/pod.yaml
++++ b/vendor/knative.dev/eventing/test/test_images/transformevents/pod.yaml
+@@ -5,5 +5,5 @@ metadata:
+ spec:
+   containers:
+     - name: transformevents
+-      image: knative.dev/eventing/test/test_images/transformevents
++      image: knative.dev/eventing-contrib/vendor/knative.dev/eventing/test/test_images/transformevents
+ 

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -104,16 +104,9 @@ function test_setup() {
   install_channel_crds || return 1
 
   # Publish test images.
-  echo ">> Publishing test images"
-  if is_release_branch; then
-    echo ">> Publishing test images from vendor"
-    $(dirname $0)/upload-test-images.sh ${VENDOR_EVENTING_TEST_IMAGES} e2e || fail_test "Error uploading test images"
-  else
-    echo ">> Publishing test images from Eventing HEAD"
-    $(dirname $0)/upload-test-images.sh ${HEAD_EVENTING_TEST_IMAGES} e2e || fail_test "Error uploading test images"
-  fi
-  # TODO: also publish test images in eventing-contrib when there are actual images
-  # for testing
+  echo ">> Publishing test images from vendor"
+  $(dirname $0)/upload-test-images.sh ${VENDOR_EVENTING_TEST_IMAGES} e2e || fail_test "Error uploading test images"
+  # TODO: also publish test images in eventing-contrib when there are actual images for testing
   # $(dirname $0)/upload-test-images.sh "test/test_images" e2e || fail_test "Error uploading test images"
 }
 

--- a/vendor/knative.dev/eventing/test/test_images/logevents/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/logevents/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: logevents
-      image: knative.dev/eventing/test/test_images/logevents
+      image: knative.dev/eventing-contrib/vendor/knative.dev/eventing/test/test_images/logevents
 

--- a/vendor/knative.dev/eventing/test/test_images/sendevents/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/sendevents/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: sendevents
-      image: knative.dev/eventing/test/test_images/sendevents
+      image: knative.dev/eventing-contrib/vendor/knative.dev/eventing/test/test_images/sendevents
 

--- a/vendor/knative.dev/eventing/test/test_images/transformevents/pod.yaml
+++ b/vendor/knative.dev/eventing/test/test_images/transformevents/pod.yaml
@@ -5,5 +5,5 @@ metadata:
 spec:
   containers:
     - name: transformevents
-      image: knative.dev/eventing/test/test_images/transformevents
+      image: knative.dev/eventing-contrib/vendor/knative.dev/eventing/test/test_images/transformevents
 


### PR DESCRIPTION
## Proposed Changes
Always upload test images from vendored eventing. To do this, we need to change the image path to the correct GOPATH

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```

/cc @Harwayne 