### PR TITLE
Follow-up: service ports name following istio-naming convention

### DIFF
--- a/awssqs/config/400-controller-service.yaml
+++ b/awssqs/config/400-controller-service.yaml
@@ -24,4 +24,5 @@ spec:
   selector:
     control-plane: awssqs-controller-manager
   ports:
-  - port: 443
+  - name: https-awssqs
+    port: 443

--- a/camel/source/config/400-controller-service.yaml
+++ b/camel/source/config/400-controller-service.yaml
@@ -24,4 +24,5 @@ spec:
   selector:
     control-plane: camel-controller-manager
   ports:
-  - port: 443
+  - name: https-camel
+    port: 443

--- a/couchdb/source/config/400-controller-service.yaml
+++ b/couchdb/source/config/400-controller-service.yaml
@@ -23,4 +23,5 @@ spec:
   selector:
     control-plane: couchdb-controller-manager
   ports:
-  - port: 443
+  - name: https-couchdb
+    port: 443

--- a/couchdb/source/config/400-webhook-service.yaml
+++ b/couchdb/source/config/400-webhook-service.yaml
@@ -22,7 +22,8 @@ metadata:
   namespace: knative-sources
 spec:
   ports:
-    - port: 443
+    - name: https-webhook
+      port: 443
       targetPort: 8443
   selector:
     role: couchdb-webhook

--- a/github/config/400-controller-service.yaml
+++ b/github/config/400-controller-service.yaml
@@ -24,4 +24,5 @@ spec:
   selector:
     control-plane: github-controller-manager
   ports:
-  - port: 443
+  - name: https-github
+    port: 443

--- a/kafka/channel/config/200-dispatcher-service.yaml
+++ b/kafka/channel/config/200-dispatcher-service.yaml
@@ -26,6 +26,7 @@ spec:
       messaging.knative.dev/channel: kafka-channel
       messaging.knative.dev/role: dispatcher
   ports:
-    - port: 80
+    - name: http-dispatcher
+      port: 80
       protocol: TCP
       targetPort: 8080

--- a/kafka/channel/config/400-webhook-service.yaml
+++ b/kafka/channel/config/400-webhook-service.yaml
@@ -22,7 +22,8 @@ metadata:
     role: kafka-webhook
 spec:
   ports:
-    - port: 443
+    - name: https-webhook
+      port: 443
       targetPort: 8443
   selector:
     role: kafka-webhook

--- a/kafka/source/config/400-controller-service.yaml
+++ b/kafka/source/config/400-controller-service.yaml
@@ -24,4 +24,5 @@ spec:
   selector:
     control-plane: kafka-controller-manager
   ports:
-  - port: 443
+  - name: https-kafka
+    port: 443

--- a/natss/config/200-dispatcher-service.yaml
+++ b/natss/config/200-dispatcher-service.yaml
@@ -26,6 +26,7 @@ spec:
     messaging.knative.dev/channel: natss-channel
     messaging.knative.dev/role: dispatcher
   ports:
-  - port: 80
+  - name: http-dispatcher
+    port: 80
     protocol: TCP
     targetPort: 8080

--- a/natss/config/broker/natss.yaml
+++ b/natss/config/broker/natss.yaml
@@ -37,7 +37,7 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-  - name: client
+  - name: tcp-client
     port: 4222
     protocol: TCP
     targetPort: client

--- a/prometheus/config/400-controller-service.yaml
+++ b/prometheus/config/400-controller-service.yaml
@@ -23,4 +23,5 @@ spec:
   selector:
     control-plane: prometheus-controller-manager
   ports:
-  - port: 443
+  - name: https-prom
+    port: 443


### PR DESCRIPTION
To be on safer side when using hand in hand with Istio, we follow service port naming convention as stated here ->https://istio.io/docs/setup/kubernetes/additional-setup/requirements/
Serving/Eventing already updated.

We have seen issue with istio as been discussed over here -> istio/istio#14520

Fixes #

## Proposed Changes

- Service port name should follow the istio naming convention based on this link:

https://istio.io/docs/setup/kubernetes/additional-setup/requirements/

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```
* Service port name should follow the istio naming convention based on this link:
https://istio.io/docs/setup/kubernetes/additional-setup/requirements/
```