### PR TITLE
Use Namespace and name on kafka consumer group

### DIFF
--- a/kafka/channel/pkg/dispatcher/dispatcher_test.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
+	v1 "k8s.io/api/core/v1"
 	"net/http"
 	"testing"
 
@@ -146,10 +147,16 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-1",
+									},
 									UID:           "subscription-1",
 									SubscriberURI: "http://test/subscriber",
 								},
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-2",
+									},
 									UID:           "subscription-2",
 									SubscriberURI: "http://test/subscriber",
 								},
@@ -175,10 +182,16 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-1",
+									},
 									UID:           "subscription-1",
 									SubscriberURI: "http://test/subscriber",
 								},
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-2",
+									},
 									UID:           "subscription-2",
 									SubscriberURI: "http://test/subscriber",
 								}}}}},
@@ -192,10 +205,16 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-2",
+									},
 									UID:           "subscription-2",
 									SubscriberURI: "http://test/subscriber",
 								},
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-3",
+									},
 									UID:           "subscription-3",
 									SubscriberURI: "http://test/subscriber",
 								},
@@ -224,10 +243,16 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-1",
+									},
 									UID:           "subscription-1",
 									SubscriberURI: "http://test/subscriber",
 								},
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-2",
+									},
 									UID:           "subscription-2",
 									SubscriberURI: "http://test/subscriber",
 								},
@@ -242,6 +267,9 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-1",
+									},
 									UID:           "subscription-1",
 									SubscriberURI: "http://test/subscriber",
 								},
@@ -255,10 +283,16 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 						FanoutConfig: fanout.Config{
 							Subscriptions: []eventingduck.SubscriberSpec{
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-3",
+									},
 									UID:           "subscription-3",
 									SubscriberURI: "http://test/subscriber",
 								},
 								{
+									DeprecatedRef: &v1.ObjectReference{
+										Name: "subscription-4",
+									},
 									UID:           "subscription-4",
 									SubscriberURI: "http://test/subscriber",
 								},


### PR DESCRIPTION
In the past we used to use namespace/name on the consumergroup:
* https://github.com/knative/eventing/blob/release-0.5/contrib/kafka/pkg/dispatcher/dispatcher.go#L171

But https://github.com/knative/eventing/pull/1057 changed that to only use a `UID` on it.

**Problem:**

(re)creating subscriptions is ending up in different consumer groups.

The issue was raised by @yuzisun chatting, while looking at #758


## Proposed Changes

  * use a more reliable consumer group setup

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Consumer groups will no longer have random UID (subscription UID) names, they will go back to the old behavior of using a stable combination of namespace and name
```