### PR TITLE
Trigger NatssChannel reconciliation in case of errors

### DIFF
--- a/natss/pkg/reconciler/dispatcher/natsschannel.go
+++ b/natss/pkg/reconciler/dispatcher/natsschannel.go
@@ -130,7 +130,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, key string) error {
 		logging.FromContext(ctx).Error("Failed to update NatssChannel status", zap.Error(updateStatusErr))
 		return updateStatusErr
 	}
-	return nil
+
+	// Trigger reconciliation in case of errors
+	return reconcileErr
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, natssChannel *v1alpha1.NatssChannel) error {


### PR DESCRIPTION
## Description ##

Fix the NatssChannel not ready state caused by restarting the natss-dispatcher and not being able to connect to the nats server before reconciliation. 

## Proposed Changes

Reque NatssChannel reconciliation in case of errors.