### PR TITLE
Update source to produce 1.0 data

### DIFF
--- a/awssqs/pkg/adapter/adapter.go
+++ b/awssqs/pkg/adapter/adapter.go
@@ -25,8 +25,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents"
-	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
+	cloudevents "github.com/cloudevents/sdk-go"
+	ce_client "github.com/cloudevents/sdk-go/pkg/cloudevents/client"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 
 	"go.uber.org/zap"
@@ -54,7 +54,7 @@ type Adapter struct {
 	OnFailedPollWaitSecs time.Duration
 
 	// Client sends cloudevents to the target.
-	client client.Client
+	client ce_client.Client
 }
 
 // getRegion takes an AWS SQS URL and extracts the region from it
@@ -168,28 +168,40 @@ func (a *Adapter) receiveMessage(ctx context.Context, m *sqs.Message, ack func()
 	}
 }
 
-// postMessage sends an SQS event to the SinkURI
-func (a *Adapter) postMessage(ctx context.Context, logger *zap.SugaredLogger, m *sqs.Message) error {
+func (a *Adapter) makeEvent(m *sqs.Message) (*cloudevents.Event, error) {
 
 	// TODO verify the timestamp conversion
 	timestamp, err := strconv.ParseInt(*m.Attributes["SentTimestamp"], 10, 64)
 	if err != nil {
-		logger.Errorw("Failed to unmarshal the message.", zap.Error(err), zap.Any("message", m.Body))
 		timestamp = time.Now().UnixNano()
 	}
 
-	event := cloudevents.Event{
-		Context: cloudevents.EventContextV1{
-			ID:     *m.MessageId,
-			Type:   sourcesv1alpha1.AwsSqsSourceEventType,
-			Source: *types.ParseURIRef(a.QueueURL),
-			Time:   &types.Timestamp{Time: time.Unix(timestamp, 0)},
-		}.AsV1(),
-		Data: m,
-	}
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
+	event.SetID(*m.MessageId)
+	event.SetType(sourcesv1alpha1.AwsSqsSourceEventType)
+	event.SetSource(types.ParseURIRef(a.QueueURL).String())
+	event.SetTime(time.Unix(timestamp, 0))
 
-	_, _, err = a.client.Send(context.TODO(), event)
-	return err
+	if err := event.SetData(m); err != nil {
+		return nil, err
+	}
+	return &event, nil
+}
+
+// postMessage sends an SQS event to the SinkURI
+func (a *Adapter) postMessage(ctx context.Context, logger *zap.SugaredLogger, m *sqs.Message) error {
+
+	event, err := a.makeEvent(m)
+
+	if err != nil {
+		logger.Error("Cloud Event creation error", zap.Error(err))
+		return err
+	}
+	if _, _, err = a.client.Send(context.TODO(), *event); err != nil {
+		logger.Error("Cloud Event delivery error", zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 // poll reads messages from the queue in batches of a given maximum size.

--- a/awssqs/pkg/adapter/adapter.go
+++ b/awssqs/pkg/adapter/adapter.go
@@ -179,12 +179,12 @@ func (a *Adapter) postMessage(ctx context.Context, logger *zap.SugaredLogger, m 
 	}
 
 	event := cloudevents.Event{
-		Context: cloudevents.EventContextV03{
+		Context: cloudevents.EventContextV1{
 			ID:     *m.MessageId,
 			Type:   sourcesv1alpha1.AwsSqsSourceEventType,
-			Source: *types.ParseURLRef(a.QueueURL),
+			Source: *types.ParseURIRef(a.QueueURL),
 			Time:   &types.Timestamp{Time: time.Unix(timestamp, 0)},
-		}.AsV02(),
+		}.AsV1(),
 		Data: m,
 	}
 

--- a/cmd/heartbeats/main.go
+++ b/cmd/heartbeats/main.go
@@ -109,15 +109,15 @@ func main() {
 		hb.Sequence++
 
 		event := cloudevents.Event{
-			Context: cloudevents.EventContextV03{
+			Context: cloudevents.EventContextV1{
 				Type:   eventType,
-				Source: *types.ParseURLRef(eventSource),
+				Source: *types.ParseURIRef(eventSource),
 				Extensions: map[string]interface{}{
 					"the":   42,
 					"heart": "yes",
 					"beats": true,
 				},
-			}.AsV02(),
+			}.AsV1(),
 			Data: hb,
 		}
 

--- a/cmd/websocketsource/main.go
+++ b/cmd/websocketsource/main.go
@@ -77,10 +77,10 @@ func main() {
 		}
 
 		event := cloudevents.Event{
-			Context: cloudevents.EventContextV03{
+			Context: cloudevents.EventContextV1{
 				Type:   eventType,
-				Source: *types.ParseURLRef(eventSource),
-			}.AsV02(),
+				Source: *types.ParseURIRef(eventSource),
+			}.AsV1(),
 			Data: message,
 		}
 		if _, _, err := ce.Send(context.TODO(), event); err != nil {

--- a/couchdb/source/pkg/adapter/adapter.go
+++ b/couchdb/source/pkg/adapter/adapter.go
@@ -166,7 +166,7 @@ func (a *couchDbAdapter) processChanges() {
 }
 
 func (a *couchDbAdapter) makeEvent(changes *kivik.Changes) (*cloudevents.Event, error) {
-	event := cloudevents.NewEvent(cloudevents.VersionV03)
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetID(changes.Seq())
 	event.SetSource(a.source)
 	event.SetSubject(changes.ID())

--- a/github/pkg/adapter/adapter.go
+++ b/github/pkg/adapter/adapter.go
@@ -34,8 +34,6 @@ import (
 const (
 	GHHeaderEvent    = "GitHub-Event"
 	GHHeaderDelivery = "GitHub-Delivery"
-	GHCEHeaderEvent    = "event"
-	GHCEHeaderDelivery = "delivery"
 )
 
 // Adapter converts incoming GitHub webhook events to CloudEvents
@@ -85,8 +83,6 @@ func (a *Adapter) handleEvent(payload interface{}, hdr http.Header) error {
 	event.SetID(eventID)
 	event.SetType(cloudEventType)
 	event.SetSource(a.source)
-	event.SetExtension(GHCEHeaderEvent, gitHubEventType)
-	event.SetExtension(GHCEHeaderDelivery, eventID)
 	event.SetSubject(subject)
 	event.SetDataContentType(cloudevents.ApplicationJSON)
 	event.SetData(payload)

--- a/github/pkg/adapter/adapter.go
+++ b/github/pkg/adapter/adapter.go
@@ -34,6 +34,8 @@ import (
 const (
 	GHHeaderEvent    = "GitHub-Event"
 	GHHeaderDelivery = "GitHub-Delivery"
+	GHCEHeaderEvent    = "event"
+	GHCEHeaderDelivery = "delivery"
 )
 
 // Adapter converts incoming GitHub webhook events to CloudEvents
@@ -79,12 +81,12 @@ func (a *Adapter) handleEvent(payload interface{}, hdr http.Header) error {
 	cloudEventType := sourcesv1alpha1.GitHubEventType(gitHubEventType)
 	subject := subjectFromGitHubEvent(gh.Event(gitHubEventType), payload)
 
-	event := cloudevents.NewEvent(cloudevents.VersionV03)
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetID(eventID)
 	event.SetType(cloudEventType)
 	event.SetSource(a.source)
-	event.SetExtension(GHHeaderEvent, gitHubEventType)
-	event.SetExtension(GHHeaderDelivery, eventID)
+	event.SetExtension(GHCEHeaderEvent, gitHubEventType)
+	event.SetExtension(GHCEHeaderDelivery, eventID)
 	event.SetSubject(subject)
 	event.SetDataContentType(cloudevents.ApplicationJSON)
 	event.SetData(payload)

--- a/github/pkg/adapter/adapter_test.go
+++ b/github/pkg/adapter/adapter_test.go
@@ -539,13 +539,13 @@ func TestHandleEvent(t *testing.T) {
 
 	expectedRequest := requestValidation{
 		Headers: map[string][]string{
-			"ce-specversion":     {"0.3"},
+			"ce-specversion":     {"1.0"},
 			"ce-id":              {"12345"},
 			"ce-time":            {"2019-01-29T09:35:10.69383396-08:00"},
 			"ce-type":            {"dev.knative.source.github.pull_request"},
 			"ce-source":          {testSource},
-			"ce-github-delivery": {"12345"},
-			"ce-github-event":    {"pull_request"},
+			"ce-delivery": {"12345"},
+			"ce-event":    {"pull_request"},
 			"ce-subject":         {testSubject},
 			"content-type":       {"application/json"},
 		},

--- a/github/pkg/adapter/adapter_test.go
+++ b/github/pkg/adapter/adapter_test.go
@@ -544,8 +544,6 @@ func TestHandleEvent(t *testing.T) {
 			"ce-time":            {"2019-01-29T09:35:10.69383396-08:00"},
 			"ce-type":            {"dev.knative.source.github.pull_request"},
 			"ce-source":          {testSource},
-			"ce-delivery": {"12345"},
-			"ce-event":    {"pull_request"},
 			"ce-subject":         {testSubject},
 			"content-type":       {"application/json"},
 		},

--- a/kafka/source/pkg/adapter/adapter.go
+++ b/kafka/source/pkg/adapter/adapter.go
@@ -181,6 +181,7 @@ func (a *Adapter) Handle(ctx context.Context, msg *sarama.ConsumerMessage) (bool
 	event.SetTime(msg.Timestamp)
 	event.SetType(sourcesv1alpha1.KafkaEventType)
 	event.SetSource(sourcesv1alpha1.KafkaEventSource(a.config.Namespace, a.config.Name, msg.Topic))
+	event.SetSubject(sourcesv1alpha1.KafkaEventSubject(msg.Partition, msg.Offset))
 	event.SetDataContentType(cloudevents.ApplicationJSON)
 	event.SetExtension("key", string(msg.Key))
 	err := event.SetData(msg.Value)

--- a/kafka/source/pkg/adapter/adapter.go
+++ b/kafka/source/pkg/adapter/adapter.go
@@ -181,7 +181,7 @@ func (a *Adapter) Handle(ctx context.Context, msg *sarama.ConsumerMessage) (bool
 	event.SetTime(msg.Timestamp)
 	event.SetType(sourcesv1alpha1.KafkaEventType)
 	event.SetSource(sourcesv1alpha1.KafkaEventSource(a.config.Namespace, a.config.Name, msg.Topic))
-	event.SetSubject(sourcesv1alpha1.KafkaEventSubject(msg.Partition, msg.Offset))
+	event.SetSubject(makeEventSubject(msg.Partition, msg.Offset))
 	event.SetDataContentType(cloudevents.ApplicationJSON)
 	event.SetExtension("key", string(msg.Key))
 	err := event.SetData(msg.Value)
@@ -250,6 +250,12 @@ func newTLSConfig(clientCert, clientKey, caCert string) (*tls.Config, error) {
 
 	return config, nil
 }
+
+// KafkaEventSubject returns the Kafka CloudEvent subject of the message.
+func makeEventSubject(partion int32, offset int64) string {
+	return fmt.Sprintf("partion:%d#%d", partion, offset)
+}
+
 
 // verifyCertSkipHostname verifies certificates in the same way that the
 // default TLS handshake does, except it skips hostname verification. It must

--- a/kafka/source/pkg/apis/sources/v1alpha1/kafka_types.go
+++ b/kafka/source/pkg/apis/sources/v1alpha1/kafka_types.go
@@ -135,11 +135,6 @@ func KafkaEventSource(namespace, kafkaSourceName, topic string) string {
 	return fmt.Sprintf("/apis/v1/namespaces/%s/kafkasources/%s#%s", namespace, kafkaSourceName, topic)
 }
 
-// KafkaEventSource returns the Kafka CloudEvent subject of the message.
-func KafkaEventSubject(partion int32, offset int64) string {
-	return fmt.Sprintf("partion:%d#%d", partion, offset)
-}
-
 // KafkaSourceStatus defines the observed state of KafkaSource.
 type KafkaSourceStatus struct {
 	// inherits duck/v1alpha1 Status, which currently provides:

--- a/kafka/source/pkg/apis/sources/v1alpha1/kafka_types.go
+++ b/kafka/source/pkg/apis/sources/v1alpha1/kafka_types.go
@@ -135,6 +135,11 @@ func KafkaEventSource(namespace, kafkaSourceName, topic string) string {
 	return fmt.Sprintf("/apis/v1/namespaces/%s/kafkasources/%s#%s", namespace, kafkaSourceName, topic)
 }
 
+// KafkaEventSource returns the Kafka CloudEvent subject of the message.
+func KafkaEventSubject(partion int32, offset int64) string {
+	return fmt.Sprintf("partion:%d#%d", partion, offset)
+}
+
 // KafkaSourceStatus defines the observed state of KafkaSource.
 type KafkaSourceStatus struct {
 	// inherits duck/v1alpha1 Status, which currently provides:

--- a/prometheus/pkg/adapter/adapter.go
+++ b/prometheus/pkg/adapter/adapter.go
@@ -155,7 +155,7 @@ func (a *prometheusAdapter) send() {
 }
 
 func (a *prometheusAdapter) makeEvent(payload interface{}) (*cloudevents.Event, error) {
-	event := cloudevents.NewEvent(cloudevents.VersionV03)
+	event := cloudevents.NewEvent(cloudevents.VersionV1)
 	event.SetSource(a.source)
 	event.SetID(string(uuid.NewUUID()))
 	event.SetType(v1alpha1.PromQLPrometheusSourceEventType)


### PR DESCRIPTION

## Proposed Changes

  * have our source now produce 1.0 compliant data

## Github source

@bbrowning @lberk @lionelvillard  For GH Source I had some funky change to do.... 

see https://github.com/knative/eventing-contrib/issues/780  


**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Due to cloudEvent spec changes, the github delivery and github event EXTENSION was renamed to just event and delivery
```