### PR TITLE
Trivial: drop errant test logging/debug line

### DIFF
--- a/kafka/channel/pkg/dispatcher/dispatcher_test.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher_test.go
@@ -488,7 +488,6 @@ func TestToKafkaMessage(t *testing.T) {
 	if diff := cmp.Diff(want, got, cmpopts.IgnoreUnexported(sarama.ProducerMessage{})); diff != "" {
 		t.Errorf("unexpected message (-want, +got) = %s", diff)
 	}
-	t.Logf("specversion %s", event.SpecVersion())
 }
 
 type dispatchTestHandler struct {


### PR DESCRIPTION
https://github.com/knative/eventing-contrib/pull/788 forgot to remove the logging line from dispatcher_test.go:TestToKafkaMessage