### PR TITLE
add appender to release, alphatebize files

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -22,14 +22,15 @@ source $(dirname $0)/../vendor/knative.dev/test-infra/scripts/release.sh
 # Yaml files to generate, and the source config dir for them.
 declare -A COMPONENTS
 COMPONENTS=(
-  ["github.yaml"]="github/config"
-  ["event-display.yaml"]="config/tools/event-display"
+  ["appender.yaml"]="config/tools/appender"
+  ["awssqs.yaml"]="awssqs/config"
   ["camel.yaml"]="camel/source/config"
+  ["couchdb.yaml"]="couchdb/source/config"
+  ["event-display.yaml"]="config/tools/event-display"
+  ["github.yaml"]="github/config"
   ["kafka-source.yaml"]="kafka/source/config"
   ["kafka-channel.yaml"]="kafka/channel/config"
   ["natss-channel.yaml"]="natss/config"
-  ["awssqs.yaml"]="awssqs/config"
-  ["couchdb.yaml"]="couchdb/source/config"
   ["prometheus-source.yaml"]="prometheus/config"
 )
 readonly COMPONENTS
@@ -47,7 +48,7 @@ function build_release() {
   local all_yamls=()
   for yaml in "${!COMPONENTS[@]}"; do
     local config="${COMPONENTS[${yaml}]}"
-    echo "Building Knative Eventing Sources - ${config}"
+    echo "Building Knative Eventing Contrib - ${config}"
     ko resolve ${KO_FLAGS} -f ${config}/ | "${LABEL_YAML_CMD[@]}" > ${yaml}
     all_yamls+=(${yaml})
   done


### PR DESCRIPTION

## Proposed Changes

  * release appender as part of the release
  * alphatebize the release files
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
Release appender that's used in some of the knative.dev/eventing sample examples.
```