### PR TITLE
Fix #805: add duck.InformerFactory to camel source context (0.11)

### DIFF
--- a/camel/source/pkg/reconciler/camelsource.go
+++ b/camel/source/pkg/reconciler/camelsource.go
@@ -37,6 +37,7 @@ import (
 	"knative.dev/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1"
 	"knative.dev/eventing-contrib/camel/source/pkg/reconciler/resources"
 	"knative.dev/eventing-contrib/pkg/controller/sdk"
+	"knative.dev/pkg/client/injection/ducks/duck/v1/addressable"
 	"knative.dev/pkg/injection/clients/dynamicclient"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/resolver"
@@ -69,6 +70,7 @@ func Add(mgr manager.Manager, logger *zap.SugaredLogger) error {
 		return err
 	}
 	ctx = context.WithValue(ctx, dynamicclient.Key{}, dynamicClient)
+	ctx = addressable.WithDuck(ctx)
 
 	p := &sdk.Provider{
 		AgentName: controllerAgentName,


### PR DESCRIPTION
Fixes #805 on 0.11 branch

## Proposed Changes

  * Fix error that causes crash on 0.11 branch

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```