### PR TITLE
Fix link in Natss readme pointing to a Knative Setup link which no longer worked

### DIFF
--- a/natss/config/README.md
+++ b/natss/config/README.md
@@ -22,7 +22,7 @@ They do not offer:
 ## Deployment steps
 
 1. Setup
-   [Knative Eventing](https://knative.dev/eventing/blob/master/DEVELOPMENT.md).
+   [Knative Eventing](https://knative.dev/docs/eventing/getting-started/).
 1. If not done already, install a [NATS Streaming](./broker/README.md)
 1. Apply the NATSS configuration:
 


### PR DESCRIPTION
…

Fixes broken link to Knative Eventing Setup in Natss config readme file.

## Proposed Changes

  * Update Natss config readme link to Knative Eventing Setup

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```