### PR TITLE
Kafka: can we just use the uid and not name

### DIFF
--- a/kafka/channel/pkg/dispatcher/dispatcher.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher.go
@@ -117,7 +117,7 @@ func (d *KafkaDispatcher) UpdateKafkaConsumers(config *multichannelfanout.Config
 		for _, subSpec := range cc.FanoutConfig.Subscriptions {
 			// TODO: use better way to get the provided Name/Namespce for the Subscription
 			// we NEED this for better consumer groups
-			sub := newSubscription(subSpec, subSpec.DeprecatedRef.Name, subSpec.DeprecatedRef.Namespace)
+			sub := newSubscription(subSpec, string(subSpec.UID), cc.Namespace)
 			if _, ok := d.kafkaConsumerGroups[channelRef][sub]; !ok {
 				// only subscribe when not exists in channel-subscriptions map
 				// do not need to resubscribe every time channel fanout config is updated


### PR DESCRIPTION
## Proposed Changes

  * do not use name from `DeprecatedRef` of subscription, use uid for kafka subs.

`spec.DeprecatedRef` will be removed.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
name changes to uid for subscriptions in kafka.
```