### PR TITLE
Adding webhook support for github source.

### DIFF
--- a/github/cmd/webhook/main.go
+++ b/github/cmd/webhook/main.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	githubv1alpha1 "knative.dev/eventing-contrib/github/pkg/apis/sources/v1alpha1"
+	"knative.dev/eventing/pkg/logconfig"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
+	"knative.dev/pkg/webhook"
+	"knative.dev/pkg/webhook/certificates"
+	"knative.dev/pkg/webhook/resourcesemantics"
+	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
+	"knative.dev/pkg/webhook/resourcesemantics/validation"
+)
+
+var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
+	githubv1alpha1.SchemeGroupVersion.WithKind("GitHubSource"): &githubv1alpha1.GitHubSource{},
+}
+
+func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return defaulting.NewAdmissionController(ctx,
+		// Name of the resource webhook.
+		"defaulting.webhook.github.sources.knative.dev",
+
+		// The path on which to serve the webhook.
+		"/defaulting",
+
+		// The resources to validate and default.
+		types,
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		func(ctx context.Context) context.Context {
+			return ctx
+		},
+
+		// Whether to disallow unknown fields.
+		true,
+	)
+}
+
+func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return validation.NewAdmissionController(ctx,
+		// Name of the resource webhook.
+		"validation.webhook.github.sources.knative.dev",
+
+		// The path on which to serve the webhook.
+		"/validation",
+
+		// The resources to validate and default.
+		types,
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		func(ctx context.Context) context.Context {
+			return ctx
+		},
+
+		// Whether to disallow unknown fields.
+		true,
+	)
+}
+
+func main() {
+	// Set up a signal context with our webhook options
+	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
+		ServiceName: logconfig.WebhookName(),
+		Port:        8443,
+		SecretName:  "sources-webhook-certs",
+	})
+
+	sharedmain.MainWithContext(ctx, logconfig.WebhookName(),
+		certificates.NewController,
+		NewDefaultingAdmissionController,
+		NewValidationAdmissionController,
+		// TODO(mattmoor): Support config validation in eventing-contrib.
+	)
+}

--- a/github/config/200-serviceaccount.yaml
+++ b/github/config/200-serviceaccount.yaml
@@ -19,3 +19,11 @@ metadata:
   namespace: knative-sources
   labels:
     contrib.eventing.knative.dev/release: devel
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: github-webhook
+  namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel

--- a/github/config/300-githubsource.yaml
+++ b/github/config/300-githubsource.yaml
@@ -73,12 +73,18 @@ spec:
   subresources:
     status: {}
   additionalPrinterColumns:
-  - name: Ready
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
-  - name: Reason
-    type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    - name: Ready
+      type: string
+      JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+    - name: Reason
+      type: string
+      JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    - name: Sink
+      type: string
+      JSONPath: ".status.sinkUri"
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
       properties:

--- a/github/config/500-webhook-configuration.yaml
+++ b/github/config/500-webhook-configuration.yaml
@@ -1,0 +1,54 @@
+# Copyright 2019 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: defaulting.webhook.github.sources.knative.dev
+  labels:
+    contrib.eventing.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: github-webhook
+      namespace: knative-eventing
+  failurePolicy: Fail
+  name: defaulting.webhook.github.sources.knative.dev
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.github.sources.knative.dev
+  labels:
+    contrib.eventing.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: github-webhook
+      namespace: knative-sources
+  failurePolicy: Fail
+  name: validation.webhook.github.sources.knative.dev
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sources-webhook-certs
+  namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel
+# The data is populated at install time.

--- a/github/config/500-webhook.yaml
+++ b/github/config/500-webhook.yaml
@@ -1,0 +1,53 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: github-webhook
+  namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel
+spec:
+  replicas: 1
+  selector:
+    matchLabels: &labels
+      app: github-webhook
+      role: github-webhook
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels: *labels
+    spec:
+      serviceAccountName: github-webhook
+      containers:
+      - name: github-webhook
+        terminationMessagePolicy: FallbackToLogsOnError
+        image: knative.dev/eventing-contrib/github/cmd/webhook
+        env:
+          - name: SYSTEM_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: CONFIG_LOGGING_NAME
+            value: config-logging
+          - name: METRICS_DOMAIN
+            value: knative.dev/eventing
+          - name: WEBHOOK_NAME
+            value: github-webhook
+        ports:
+          - containerPort: 9090
+            name: metrics
+        # TODO set proper resource limits.

--- a/github/pkg/apis/sources/v1alpha1/githubsource_defaults.go
+++ b/github/pkg/apis/sources/v1alpha1/githubsource_defaults.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+)
+
+func (g *GitHubSource) SetDefaults(ctx context.Context) {
+	g.Spec.SetDefaults(ctx)
+}
+
+func (gs *GitHubSourceSpec) SetDefaults(ctx context.Context) {
+	// Nothing yet.
+}

--- a/github/pkg/apis/sources/v1alpha1/githubsource_defaults_test.go
+++ b/github/pkg/apis/sources/v1alpha1/githubsource_defaults_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCouchDbDefaults(t *testing.T) {
+	testCases := map[string]struct {
+		initial  GitHubSource
+		expected GitHubSource
+	}{
+		"nil spec": {
+			initial: GitHubSource{},
+			expected: GitHubSource{
+				Spec: GitHubSourceSpec{
+				},
+			},
+		},
+	}
+	for n, tc := range testCases {
+		t.Run(n, func(t *testing.T) {
+			tc.initial.SetDefaults(context.TODO())
+			if diff := cmp.Diff(tc.expected, tc.initial); diff != "" {
+				t.Fatalf("Unexpected defaults (-want, +got): %s", diff)
+			}
+		})
+	}
+}

--- a/github/pkg/apis/sources/v1alpha1/githubsource_types.go
+++ b/github/pkg/apis/sources/v1alpha1/githubsource_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"knative.dev/pkg/webhook/resourcesemantics"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,8 @@ import (
 
 // Check that GitHubSource can be validated and can be defaulted.
 var _ runtime.Object = (*GitHubSource)(nil)
+
+var _ resourcesemantics.GenericCRD = (*GitHubSource)(nil)
 
 // GitHubSourceSpec defines the desired state of GitHubSource
 // +kubebuilder:categories=all,knative,eventing,sources

--- a/github/pkg/apis/sources/v1alpha1/githubsource_validation.go
+++ b/github/pkg/apis/sources/v1alpha1/githubsource_validation.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+
+	"knative.dev/pkg/apis"
+)
+
+func (g *GitHubSource) Validate(ctx context.Context) *apis.FieldError {
+	return g.Spec.Validate(ctx).ViaField("spec")
+}
+
+func (gs *GitHubSourceSpec) Validate(ctx context.Context) *apis.FieldError {
+	var errs *apis.FieldError
+
+	// TODO: there are more requirements for GitHubSource. Add them here.
+
+	// Validate sink
+	if gs.Sink == nil {
+		fe := apis.ErrMissingField("sink")
+		errs = errs.Also(fe)
+	} else if fe := gs.Sink.Validate(ctx); fe != nil {
+		errs = errs.Also(fe.ViaField("sink"))
+	}
+	return errs
+}

--- a/github/pkg/apis/sources/v1alpha1/githubsource_validation_test.go
+++ b/github/pkg/apis/sources/v1alpha1/githubsource_validation_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"knative.dev/pkg/webhook/resourcesemantics"
+
+	"knative.dev/pkg/apis"
+)
+
+func TestGitHubSourceValidation(t *testing.T) {
+	testCases := map[string]struct {
+		cr   resourcesemantics.GenericCRD
+		want *apis.FieldError
+	}{
+		"missing sink": {
+			cr: &GitHubSource{
+				Spec: GitHubSourceSpec{},
+			},
+			want: func() *apis.FieldError {
+				var errs *apis.FieldError
+				fe := apis.ErrMissingField("spec.sink")
+				errs = errs.Also(fe)
+				return errs
+			}(),
+		},
+	}
+
+	for n, test := range testCases {
+		t.Run(n, func(t *testing.T) {
+			got := test.cr.Validate(context.Background())
+			if diff := cmp.Diff(test.want.Error(), got.Error()); diff != "" {
+				t.Errorf("%s: validate (-want, +got) = %v", n, diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Proposed Changes

  * Use the defaulting and validating webhooks for GitHubSource

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
NONE
```