### PR TITLE
golang format tools

### DIFF
--- a/github/pkg/apis/sources/v1alpha1/githubsource_defaults_test.go
+++ b/github/pkg/apis/sources/v1alpha1/githubsource_defaults_test.go
@@ -31,8 +31,7 @@ func TestCouchDbDefaults(t *testing.T) {
 		"nil spec": {
 			initial: GitHubSource{},
 			expected: GitHubSource{
-				Spec: GitHubSourceSpec{
-				},
+				Spec: GitHubSourceSpec{},
 			},
 		},
 	}

--- a/github/pkg/apis/sources/v1alpha1/githubsource_types.go
+++ b/github/pkg/apis/sources/v1alpha1/githubsource_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+
 	"knative.dev/pkg/webhook/resourcesemantics"
 
 	corev1 "k8s.io/api/core/v1"


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party)`
/assign n3wscott
/cc n3wscott
