### PR TITLE
support other cred providers in sqs adapter

### DIFF
--- a/awssqs/cmd/receive_adapter/main.go
+++ b/awssqs/cmd/receive_adapter/main.go
@@ -21,6 +21,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
+
 	awssqs "knative.dev/eventing-contrib/awssqs/pkg/adapter"
 	"knative.dev/pkg/signals"
 
@@ -60,10 +62,13 @@ func main() {
 		log.Fatalf("Unable to create logger: %v", err)
 	}
 
+	profileName := ""
+	creds := credentials.NewSharedCredentials(getRequiredEnv(envCredsFile), profileName)
+
 	adapter := &awssqs.Adapter{
 		QueueURL:             getRequiredEnv(envQueueURL),
 		SinkURI:              getRequiredEnv(envSinkURI),
-		CredsFile:            getRequiredEnv(envCredsFile),
+		Credentials:          creds,
 		OnFailedPollWaitSecs: 2,
 	}
 


### PR DESCRIPTION
## Background

I'd like to use the SQS adapter from [awssqs/pkg/adapter](https://github.com/knative/eventing-contrib/tree/master/awssqs/pkg/adapter) with a custom credentials provider, but at the moment the adapter strictly uses a credentials file.

This PR proposes allowing the adapter to accept any [AWS credentials provider](https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/), which will enable others to initialize and inject their own. It also updates the adapter container's main.go to create and use a file-based provider so that this change is transparent to current container users.

## Proposed Changes

  * enable SQS receive adapter to use [AWS credentials providers](https://docs.aws.amazon.com/sdk-for-go/api/aws/credentials/) other than a file

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
The SQS receive_adapter now accepts a credentials provider rather than a path to a credentials file, enabling use of alternate providers. If you use the adapter via the default cmd and container this change is transparent. If you use the adapter directly then action required: you will need to specify your file in a SharedCredentials provider and use that to initialize the adapter.
```