### PR TITLE
golang format tools

### DIFF
--- a/natss/pkg/dispatcher/testing/testing.go
+++ b/natss/pkg/dispatcher/testing/testing.go
@@ -27,7 +27,7 @@ import (
 )
 
 // DispatcherDoNothing is a dummy mock which doesn't do anything
-type DispatcherDoNothing struct {}
+type DispatcherDoNothing struct{}
 
 var _ dispatcher.NatssDispatcher = (*DispatcherDoNothing)(nil)
 

--- a/natss/pkg/reconciler/dispatcher/natsschannel_test.go
+++ b/natss/pkg/reconciler/dispatcher/natsschannel_test.go
@@ -46,11 +46,11 @@ func TestAllCases(t *testing.T) {
 	table := TableTest{
 		{
 			Name: "make sure reconcile handles bad keys",
-			Key: "too/many/parts",
+			Key:  "too/many/parts",
 		},
 		{
 			Name: "make sure reconcile handles good keys that don't exist",
-			Key: "foo/not-found",
+			Key:  "foo/not-found",
 		},
 		{
 			Name: "reconcile ok: channel ready",
@@ -104,10 +104,10 @@ func TestAllCases(t *testing.T) {
 		natssDispatcher := dispatchertesting.NewDispatcherDoNothing()
 
 		r := Reconciler{
-			Base:                 reconciler.NewBase(opt, controllerAgentName),
-			natssDispatcher:      natssDispatcher,
-			natsschannelLister:   listers.GetNatssChannelLister(),
-			impl:                 nil,
+			Base:               reconciler.NewBase(opt, controllerAgentName),
+			natssDispatcher:    natssDispatcher,
+			natsschannelLister: listers.GetNatssChannelLister(),
+			impl:               nil,
 		}
 
 		return &r
@@ -151,10 +151,10 @@ func TestFailedNatssSubscription(t *testing.T) {
 		natssDispatcher := dispatchertesting.NewDispatcherFailNatssSubscription()
 
 		r := Reconciler{
-			Base:                 reconciler.NewBase(opt, controllerAgentName),
-			natssDispatcher:      natssDispatcher,
-			natsschannelLister:   listers.GetNatssChannelLister(),
-			impl:                 nil,
+			Base:               reconciler.NewBase(opt, controllerAgentName),
+			natssDispatcher:    natssDispatcher,
+			natsschannelLister: listers.GetNatssChannelLister(),
+			impl:               nil,
 		}
 
 		return &r


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party)`
/assign n3wscott
/cc n3wscott
