### PR TITLE
Added Kafka headers to event generated from KafkaSource

### DIFF
--- a/kafka/source/pkg/adapter/adapter_test.go
+++ b/kafka/source/pkg/adapter/adapter_test.go
@@ -32,6 +32,8 @@ import (
 	"testing"
 	"time"
 
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/cloudevents/types"
 	"knative.dev/eventing/pkg/adapter"
 	"knative.dev/pkg/source"
 
@@ -44,21 +46,90 @@ import (
 )
 
 func TestPostMessage_ServeHTTP(t *testing.T) {
+	aTimestamp := time.Now()
+
 	testCases := map[string]struct {
-		sink              func(http.ResponseWriter, *http.Request)
-		reqBody           string
-		attributes        map[string]string
-		expectedEventType string
-		error             bool
+		sink            func(http.ResponseWriter, *http.Request)
+		message         *sarama.ConsumerMessage
+		expectedHeaders map[string]string
+		expectedBody    string
+		error           bool
 	}{
-		"accepted": {
-			sink:    sinkAccepted,
-			reqBody: `{"key":"value"}`,
+		"accepted_simple": {
+			sink: sinkAccepted,
+			message: &sarama.ConsumerMessage{
+				Key:       []byte("key"),
+				Topic:     "topic1",
+				Value:     mustJsonMarshal(t, map[string]string{"key": "value"}),
+				Partition: 1,
+				Offset:    2,
+				Timestamp: aTimestamp,
+			},
+			expectedHeaders: map[string]string{
+				"ce-id":        makeEventId(1, 2),
+				"ce-time":      types.FormatTime(aTimestamp),
+				"ce-type":      sourcesv1alpha1.KafkaEventType,
+				"ce-source":    sourcesv1alpha1.KafkaEventSource("test", "test", "topic1"),
+				"ce-subject":   makeEventSubject(1, 2),
+				"ce-key":       "key",
+				"content-type": cloudevents.ApplicationJSON,
+			},
+			expectedBody: `{"key":"value"}`,
+			error:        false,
+		},
+		"accepted_complex": {
+			sink: sinkAccepted,
+			message: &sarama.ConsumerMessage{
+				Key:   []byte("key"),
+				Topic: "topic1",
+				Headers: []*sarama.RecordHeader{
+					{
+						Key: []byte("hello"), Value: []byte("world"),
+					},
+					{
+						Key: []byte("name"), Value: []byte("Francesco"),
+					},
+				},
+				Value:     mustJsonMarshal(t, map[string]string{"key": "value"}),
+				Partition: 1,
+				Offset:    2,
+				Timestamp: aTimestamp,
+			},
+			expectedHeaders: map[string]string{
+				"ce-id":               makeEventId(1, 2),
+				"ce-time":             types.FormatTime(aTimestamp),
+				"ce-type":             sourcesv1alpha1.KafkaEventType,
+				"ce-source":           sourcesv1alpha1.KafkaEventSource("test", "test", "topic1"),
+				"ce-subject":          makeEventSubject(1, 2),
+				"ce-key":              "key",
+				"content-type":        cloudevents.ApplicationJSON,
+				"ce-kafkaheaderhello": "world",
+				"ce-kafkaheadername":  "Francesco",
+			},
+			expectedBody: `{"key":"value"}`,
+			error:        false,
 		},
 		"rejected": {
-			sink:    sinkRejected,
-			reqBody: `{"key":"value"}`,
-			error:   true,
+			sink: sinkRejected,
+			message: &sarama.ConsumerMessage{
+				Key:       []byte("key"),
+				Topic:     "topic1",
+				Value:     mustJsonMarshal(t, map[string]string{"key": "value"}),
+				Partition: 1,
+				Offset:    2,
+				Timestamp: aTimestamp,
+			},
+			expectedHeaders: map[string]string{
+				"ce-id":        makeEventId(1, 2),
+				"ce-time":      types.FormatTime(aTimestamp),
+				"ce-type":      sourcesv1alpha1.KafkaEventType,
+				"ce-source":    sourcesv1alpha1.KafkaEventSource("test", "test", "topic1"),
+				"ce-subject":   makeEventSubject(1, 2),
+				"ce-key":       "key",
+				"content-type": cloudevents.ApplicationJSON,
+			},
+			expectedBody: `{"key":"value"}`,
+			error:        true,
 		},
 	}
 
@@ -92,41 +163,34 @@ func TestPostMessage_ServeHTTP(t *testing.T) {
 				reporter: statsReporter,
 			}
 
-			data, err := json.Marshal(map[string]string{"key": "value"})
-			if err != nil {
-				t.Errorf("unexpected error, %v", err)
-			}
-
-			m := &sarama.ConsumerMessage{
-				Key:       []byte("key"),
-				Topic:     "topic1",
-				Value:     data,
-				Partition: 1,
-				Offset:    2,
-				Timestamp: time.Now(),
-			}
-
-			_, err = a.Handle(context.TODO(), m)
+			_, err := a.Handle(context.TODO(), tc.message)
 
 			if tc.error && err == nil {
 				t.Errorf("expected error, but got %v", err)
 			}
 
-			et := h.header.Get("Ce-Type")
-
-			expectedEventType := sourcesv1alpha1.KafkaEventType
-			if tc.expectedEventType != "" {
-				expectedEventType = tc.expectedEventType
+			// Check headers
+			for k, expected := range tc.expectedHeaders {
+				actual := h.header.Get(k)
+				if actual != expected {
+					t.Errorf("Expected header with key %s: '%q', but got '%q'", k, expected, actual)
+				}
 			}
 
-			if et != expectedEventType {
-				t.Errorf("Expected eventtype '%q', but got '%q'", tc.expectedEventType, et)
-			}
-			if tc.reqBody != string(h.body) {
-				t.Errorf("Expected request body '%q', but got '%q'", tc.reqBody, h.body)
+			// Check body
+			if tc.expectedBody != string(h.body) {
+				t.Errorf("Expected request body '%q', but got '%q'", tc.expectedBody, h.body)
 			}
 		})
 	}
+}
+
+func mustJsonMarshal(t *testing.T, val interface{}) []byte {
+	data, err := json.Marshal(val)
+	if err != nil {
+		t.Errorf("unexpected error, %v", err)
+	}
+	return data
 }
 
 func TestNewTLSConfig(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #846

## Proposed Changes

  * Kafka headers are added in the event as extension under the name `kafkaheader<headername>`