### PR TITLE
move to sources.knative.dev group

### DIFF
--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -24,7 +24,7 @@ The Apache CouchDB Event source enables Knative Eventing integration with
    an example:
 
    ```yaml
-   apiVersion: sources.eventing.knative.dev/v1alpha1
+   apiVersion: sources.knative.dev/v1alpha1
    kind: CouchDbSource
    metadata:
      name: couchdb-photographer

--- a/couchdb/source/config/201-clusterrole.yaml
+++ b/couchdb/source/config/201-clusterrole.yaml
@@ -48,7 +48,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - sources.eventing.knative.dev
+  - sources.knative.dev
   resources:
   - couchdbsources
   verbs:
@@ -60,7 +60,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - sources.eventing.knative.dev
+  - sources.knative.dev
   resources:
   - couchdbsources/status
   - couchdbsources/finalizers
@@ -97,7 +97,7 @@ metadata:
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
-      - "sources.eventing.knative.dev"
+      - "sources.knative.dev"
     resources:
       - "couchdbsources"
     verbs:

--- a/couchdb/source/config/201-webhook-clusterrole.yaml
+++ b/couchdb/source/config/201-webhook-clusterrole.yaml
@@ -69,7 +69,7 @@ rules:
 
   # Our own resources and statuses we care about.
   - apiGroups:
-      - "sources.eventing.knative.dev"
+      - "sources.knative.dev"
     resources:
       - "couchdbsources"
       - "couchdbsources/status"

--- a/couchdb/source/config/300-couchdbsource.yaml
+++ b/couchdb/source/config/300-couchdbsource.yaml
@@ -25,9 +25,9 @@ metadata:
       [
         { "type": "dev.knative.couchdb.changes" }
       ]
-  name: couchdbsources.sources.eventing.knative.dev
+  name: couchdbsources.sources.knative.dev
 spec:
-  group: sources.eventing.knative.dev
+  group: sources.knative.dev
   names:
     categories:
     - all

--- a/couchdb/source/pkg/apis/sources/v1alpha1/doc.go
+++ b/couchdb/source/pkg/apis/sources/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=knative.dev/eventing-contrib/couchdb/source/pkg/apis/sources
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=sources.eventing.knative.dev
+// +groupName=sources.knative.dev
 package v1alpha1

--- a/couchdb/source/pkg/apis/sources/v1alpha1/register.go
+++ b/couchdb/source/pkg/apis/sources/v1alpha1/register.go
@@ -21,7 +21,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=knative.dev/eventing-contrib/pkg/apis/sources
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=sources.eventing.knative.dev
+// +groupName=sources.knative.dev
 package v1alpha1
 
 import (
@@ -32,7 +32,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "sources.eventing.knative.dev", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "sources.knative.dev", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)

--- a/couchdb/source/pkg/apis/sources/v1alpha1/register_test.go
+++ b/couchdb/source/pkg/apis/sources/v1alpha1/register_test.go
@@ -26,7 +26,7 @@ import (
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func TestResource(t *testing.T) {
 	want := schema.GroupResource{
-		Group:    "sources.eventing.knative.dev",
+		Group:    "sources.knative.dev",
 		Resource: "foo",
 	}
 

--- a/couchdb/source/pkg/client/clientset/versioned/typed/sources/v1alpha1/fake/fake_couchdbsource.go
+++ b/couchdb/source/pkg/client/clientset/versioned/typed/sources/v1alpha1/fake/fake_couchdbsource.go
@@ -34,9 +34,9 @@ type FakeCouchDbSources struct {
 	ns   string
 }
 
-var couchdbsourcesResource = schema.GroupVersionResource{Group: "sources.eventing.knative.dev", Version: "v1alpha1", Resource: "couchdbsources"}
+var couchdbsourcesResource = schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1alpha1", Resource: "couchdbsources"}
 
-var couchdbsourcesKind = schema.GroupVersionKind{Group: "sources.eventing.knative.dev", Version: "v1alpha1", Kind: "CouchDbSource"}
+var couchdbsourcesKind = schema.GroupVersionKind{Group: "sources.knative.dev", Version: "v1alpha1", Kind: "CouchDbSource"}
 
 // Get takes name of the couchDbSource, and returns the corresponding couchDbSource object, and an error if there is any.
 func (c *FakeCouchDbSources) Get(name string, options v1.GetOptions) (result *v1alpha1.CouchDbSource, err error) {

--- a/couchdb/source/pkg/client/clientset/versioned/typed/sources/v1alpha1/sources_client.go
+++ b/couchdb/source/pkg/client/clientset/versioned/typed/sources/v1alpha1/sources_client.go
@@ -29,7 +29,7 @@ type SourcesV1alpha1Interface interface {
 	CouchDbSourcesGetter
 }
 
-// SourcesV1alpha1Client is used to interact with features provided by the sources.eventing.knative.dev group.
+// SourcesV1alpha1Client is used to interact with features provided by the sources.knative.dev group.
 type SourcesV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/couchdb/source/pkg/client/informers/externalversions/generic.go
+++ b/couchdb/source/pkg/client/informers/externalversions/generic.go
@@ -52,7 +52,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=sources.eventing.knative.dev, Version=v1alpha1
+	// Group=sources.knative.dev, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("couchdbsources"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Sources().V1alpha1().CouchDbSources().Informer()}, nil
 

--- a/couchdb/source/pkg/reconciler/resources/receive_adapter_test.go
+++ b/couchdb/source/pkg/reconciler/resources/receive_adapter_test.go
@@ -66,7 +66,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 			},
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         "sources.eventing.knative.dev/v1alpha1",
+					APIVersion:         "sources.knative.dev/v1alpha1",
 					Kind:               "CouchDbSource",
 					Name:               name,
 					UID:                "1234",


### PR DESCRIPTION
Fixes #866

## Proposed Changes

  * Move CouchDB source to sources.knative.dev API group
  
**Release Note**

```release-note
Moved CouchDBSource to `sources.knative.dev` API group. You have to migrate CouchDBSource from `sources.eventing.knative.dev` to `sources.knative.dev`
```