### PR TITLE
GitHub webhook rbac clusterrole

### DIFF
--- a/github/config/202-clusterrolebinding.yaml
+++ b/github/config/202-clusterrolebinding.yaml
@@ -42,7 +42,7 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: eventing-sources-github-controller
+  name: github-webhook
 
 ---
 

--- a/github/config/202-clusterrolebinding.yaml
+++ b/github/config/202-clusterrolebinding.yaml
@@ -32,6 +32,23 @@ roleRef:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: eventing-sources-github-webhook
+  labels:
+    contrib.eventing.knative.dev/release: devel
+subjects:
+  - kind: ServiceAccount
+    name: github-webhook
+    namespace: knative-sources
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: eventing-sources-github-controller
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: eventing-sources-github-addressable-resolver
   labels:
     contrib.eventing.knative.dev/release: devel

--- a/github/config/203-webhook-clusterrole.yaml
+++ b/github/config/203-webhook-clusterrole.yaml
@@ -1,0 +1,91 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: github-webhook
+  labels:
+    contrib.eventing.knative.dev/release: devel
+rules:
+# Sources admin
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - githubsources
+  verbs: &everything
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+
+# Sources finalizer
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - githubsources/finalizers
+  verbs: *everything
+
+# Source statuses update
+- apiGroups:
+  - sources.eventing.knative.dev
+  resources:
+  - githubsources/status
+  verbs:
+  - get
+  - update
+  - patch
+
+# Deployments admin
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs: *everything
+
+# Knative Services admin
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  verbs: *everything
+
+# Secrets read
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+
+# Events admin
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - configmaps
+  verbs: *everything
+
+# EventTypes admin
+- apiGroups:
+  - eventing.knative.dev
+  resources:
+  - eventtypes
+  verbs: *everything


### PR DESCRIPTION
Building off #874 create and use a separate github-webhook clusterrole instead of reusing the controller-clusterrole