### PR TITLE
Now KafkaSource supports cloudevents Kafka Structured Encoding

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2166,6 +2166,7 @@
     "github.com/google/go-cmp/cmp",
     "github.com/google/go-cmp/cmp/cmpopts",
     "github.com/google/go-github/github",
+    "github.com/google/uuid",
     "github.com/gorilla/websocket",
     "github.com/kelseyhightower/envconfig",
     "github.com/knative/serving/pkg/apis/serving/v1beta1",

--- a/kafka/source/pkg/adapter/adapter_benchmark_test.go
+++ b/kafka/source/pkg/adapter/adapter_benchmark_test.go
@@ -22,16 +22,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
-	cloudevents "github.com/cloudevents/sdk-go"
 	"knative.dev/eventing/pkg/adapter"
 
 	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/pkg/cloudevents/client"
 	"go.uber.org/zap"
+
 	"knative.dev/eventing-contrib/pkg/kncloudevents"
 )
 
@@ -69,14 +68,7 @@ func BenchmarkHandle(b *testing.B) {
 			c, _ := kncloudevents.NewDefaultClient(sinkServer.URL)
 			return c
 		}(),
-		logger: zap.NewNop(),
-		eventsPool: &sync.Pool{
-			New: func() interface{} {
-				ev := &cloudevents.Event{}
-				ev.SetSpecVersion(cloudevents.VersionV1)
-				return ev
-			},
-		},
+		logger:        zap.NewNop(),
 		keyTypeMapper: getKeyTypeMapper(""),
 	}
 	b.SetParallelism(1)

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -172,7 +172,7 @@ function kafka_setup() {
   sed 's/namespace: .*/namespace: kafka/' ${STRIMZI_INSTALLATION_CONFIG_TEMPLATE} > ${STRIMZI_INSTALLATION_CONFIG}
   kubectl apply -f "${STRIMZI_INSTALLATION_CONFIG}" -n kafka
   kubectl apply -f ${KAFKA_INSTALLATION_CONFIG} -n kafka
-  kubectl apply -f ${KAFKA_TOPIC_INSTALLATION_CONFIG} -n kafka
+  # kubectl apply -f ${KAFKA_TOPIC_INSTALLATION_CONFIG} -n kafka
   wait_until_pods_running kafka || fail_test "Failed to start up a Kafka cluster"
 }
 

--- a/test/e2e/helpers/kafka_helper.go
+++ b/test/e2e/helpers/kafka_helper.go
@@ -28,13 +28,13 @@ import (
 )
 
 const (
-	strimziApiGroup   = "kafka.strimzi.io"
-	strimziApiVersion = "v1beta1"
-	strimziKafkaTopic = "KafkaTopic"
+	strimziApiGroup      = "kafka.strimzi.io"
+	strimziApiVersion    = "v1beta1"
+	strimziTopicResource = "kafkatopics"
 )
 
 var (
-	topicGVR = schema.GroupVersionResource{Group: strimziApiGroup, Version: strimziApiVersion, Resource: "kafkatopics"}
+	topicGVR = schema.GroupVersionResource{Group: strimziApiGroup, Version: strimziApiVersion, Resource: strimziTopicResource}
 )
 
 func MustPublishKafkaMessage(client *testlib.Client, bootstrapServer string, topic string, key string, headers map[string]string, value string) {
@@ -110,7 +110,7 @@ func MustPublishKafkaMessage(client *testlib.Client, bootstrapServer string, top
 func MustCreateTopic(client *testlib.Client, clusterName string, clusterNamespace string, topicName string) {
 	obj := unstructured.Unstructured{
 		Object: map[string]interface{}{
-			"apiVersion": strimziApiGroup + "/" + strimziApiVersion,
+			"apiVersion": topicGVR.GroupVersion().String(),
 			"kind":       "KafkaTopic",
 			"metadata": map[string]interface{}{
 				"name": topicName,

--- a/test/e2e/helpers/kafka_helper.go
+++ b/test/e2e/helpers/kafka_helper.go
@@ -130,11 +130,6 @@ func MustCreateTopic(client *testlib.Client, clusterName string, clusterNamespac
 	if err != nil {
 		client.T.Fatalf("Error while creating the topic %s: %v", topicName, err)
 	}
-}
 
-func MustDeleteTopic(client *testlib.Client, clusterNamespace string, topicName string) {
-	err := client.Dynamic.Resource(topicGVR).Namespace(clusterNamespace).Delete(topicName, &metav1.DeleteOptions{})
-	if err != nil {
-		client.T.Fatalf("Error while deleting the topic %s: %v", topicName, err)
-	}
+	client.Tracker.Add(topicGVR.Group, topicGVR.Version, topicGVR.Resource, clusterNamespace, topicName)
 }

--- a/test/e2e/kafka_source_test.go
+++ b/test/e2e/kafka_source_test.go
@@ -45,7 +45,6 @@ func testKafkaSource(t *testing.T, messageKey string, messageHeaders map[string]
 	loggerPodName := "e2e-kafka-source-event-logger"
 
 	defer lib.TearDown(client)
-	defer helpers.MustDeleteTopic(client, kafkaClusterNamespace, kafkaTopicName)
 
 	helpers.MustCreateTopic(client, kafkaClusterName, kafkaClusterNamespace, kafkaTopicName)
 


### PR DESCRIPTION
Following spec: https://github.com/cloudevents/spec/blob/v1.0/kafka-protocol-binding.md#33-structured-content-mode

Also fixed bad extension name when dumping kafka headers to event extensions

Fixes #842