### PR TITLE
Fix #867: migrate camel source to sources.knative.dev

### DIFF
--- a/camel/source/config/201-clusterrole.yaml
+++ b/camel/source/config/201-clusterrole.yaml
@@ -50,7 +50,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - sources.eventing.knative.dev
+  - sources.knative.dev
   resources:
   - camelsources
   verbs:
@@ -62,7 +62,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - sources.eventing.knative.dev
+  - sources.knative.dev
   resources:
   - camelsources/status
   - camelsources/finalizers
@@ -95,7 +95,7 @@ metadata:
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
-      - "sources.eventing.knative.dev"
+      - "sources.knative.dev"
     resources:
       - "camelsources"
     verbs:

--- a/camel/source/config/203-camel-source-observer-cluster-role.yaml
+++ b/camel/source/config/203-camel-source-observer-cluster-role.yaml
@@ -21,7 +21,7 @@ metadata:
     duck.knative.dev/source: "true"
 rules:
 - apiGroups:
-  - sources.eventing.knative.dev
+  - sources.knative.dev
   resources:
   - camelsources
   verbs:

--- a/camel/source/config/300-camelsource.yaml
+++ b/camel/source/config/300-camelsource.yaml
@@ -15,15 +15,14 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  creationTimestamp: null
   labels:
     contrib.eventing.knative.dev/release: devel
     eventing.knative.dev/source: "true"
     duck.knative.dev/source: "true"
     knative.dev/crd-install: "true"
-  name: camelsources.sources.eventing.knative.dev
+  name: camelsources.sources.knative.dev
 spec:
-  group: sources.eventing.knative.dev
+  group: sources.knative.dev
   names:
     categories:
     - all

--- a/camel/source/pkg/apis/sources/v1alpha1/doc.go
+++ b/camel/source/pkg/apis/sources/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=knative.dev/eventing-contrib/pkg/apis/sources
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=sources.eventing.knative.dev
+// +groupName=sources.knative.dev
 package v1alpha1

--- a/camel/source/pkg/apis/sources/v1alpha1/register.go
+++ b/camel/source/pkg/apis/sources/v1alpha1/register.go
@@ -21,7 +21,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=knative.dev/eventing-contrib/pkg/apis/sources
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=sources.eventing.knative.dev
+// +groupName=sources.knative.dev
 package v1alpha1
 
 import (
@@ -31,7 +31,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "sources.eventing.knative.dev", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "sources.knative.dev", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/camel/source/pkg/apis/sources/v1alpha1/register_test.go
+++ b/camel/source/pkg/apis/sources/v1alpha1/register_test.go
@@ -25,7 +25,7 @@ import (
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func TestResource(t *testing.T) {
 	want := schema.GroupResource{
-		Group:    "sources.eventing.knative.dev",
+		Group:    "sources.knative.dev",
 		Resource: "foo",
 	}
 

--- a/camel/source/pkg/client/clientset/versioned/typed/sources/v1alpha1/fake/fake_camelsource.go
+++ b/camel/source/pkg/client/clientset/versioned/typed/sources/v1alpha1/fake/fake_camelsource.go
@@ -34,9 +34,9 @@ type FakeCamelSources struct {
 	ns   string
 }
 
-var camelsourcesResource = schema.GroupVersionResource{Group: "sources.eventing.knative.dev", Version: "v1alpha1", Resource: "camelsources"}
+var camelsourcesResource = schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1alpha1", Resource: "camelsources"}
 
-var camelsourcesKind = schema.GroupVersionKind{Group: "sources.eventing.knative.dev", Version: "v1alpha1", Kind: "CamelSource"}
+var camelsourcesKind = schema.GroupVersionKind{Group: "sources.knative.dev", Version: "v1alpha1", Kind: "CamelSource"}
 
 // Get takes name of the camelSource, and returns the corresponding camelSource object, and an error if there is any.
 func (c *FakeCamelSources) Get(name string, options v1.GetOptions) (result *v1alpha1.CamelSource, err error) {

--- a/camel/source/pkg/client/clientset/versioned/typed/sources/v1alpha1/sources_client.go
+++ b/camel/source/pkg/client/clientset/versioned/typed/sources/v1alpha1/sources_client.go
@@ -29,7 +29,7 @@ type SourcesV1alpha1Interface interface {
 	CamelSourcesGetter
 }
 
-// SourcesV1alpha1Client is used to interact with features provided by the sources.eventing.knative.dev group.
+// SourcesV1alpha1Client is used to interact with features provided by the sources.knative.dev group.
 type SourcesV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/camel/source/pkg/client/informers/externalversions/generic.go
+++ b/camel/source/pkg/client/informers/externalversions/generic.go
@@ -52,7 +52,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=sources.eventing.knative.dev, Version=v1alpha1
+	// Group=sources.knative.dev, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("camelsources"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Sources().V1alpha1().CamelSources().Informer()}, nil
 

--- a/camel/source/samples/camel_source_hello_world.yaml
+++ b/camel/source/samples/camel_source_hello_world.yaml
@@ -2,7 +2,7 @@
 #
 # Full documentation and other examples at: https://knative.dev/docs/eventing/samples/apache-camel-source/
 #
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: CamelSource
 metadata:
   name: camel-timer-source


### PR DESCRIPTION
Fixes #867

## Proposed Changes

  * Migrate apis to sources.knative.dev

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
action required: CamelSources have changed API group ("sources.eventing.knative.dev" -> "sources.knative.dev") and should be manually migrated
```