### PR TITLE
do not prefix extension headers with ce

### DIFF
--- a/kafka/channel/pkg/dispatcher/dispatcher.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher.go
@@ -394,7 +394,7 @@ func attachKafkaHeaders(message sarama.ProducerMessage, event cloudevents.Event)
 	// Only setting string extensions.
 	for k, v := range event.Extensions() {
 		if vs, ok := v.(string); ok {
-			addHeader(&message, "ce_"+k, vs)
+			addHeader(&message, k, vs)
 		}
 	}
 	return message

--- a/kafka/channel/pkg/dispatcher/dispatcher_test.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher_test.go
@@ -442,7 +442,7 @@ func TestToKafkaMessage(t *testing.T) {
 				Value: []byte("ignoreme"),
 			},
 			{
-				Key:   []byte("ce_k1"),
+				Key:   []byte("k1"),
 				Value: []byte("v1"),
 			},
 		},


### PR DESCRIPTION
Fixes #904

## Proposed Changes

  * When serializing cloud events extensions, do not prefix them with ce_
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
When serializing cloud events into kafka message, do not prefix extensions with ce_
```