### PR TITLE
strip ce_ headers before adding extensions

### DIFF
--- a/kafka/channel/pkg/dispatcher/dispatcher_test.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher_test.go
@@ -371,7 +371,7 @@ func TestFromKafkaMessage(t *testing.T) {
 	kafkaMessage := &sarama.ConsumerMessage{
 		Headers: []*sarama.RecordHeader{
 			{
-				Key:   []byte("k1"),
+				Key:   []byte("ce_k1"),
 				Value: []byte("v1"),
 			},
 			{
@@ -386,6 +386,10 @@ func TestFromKafkaMessage(t *testing.T) {
 				Key:   []byte("ce_type"),
 				Value: []byte("testtype"),
 			},
+			{
+				Key:   []byte("ce_extensionfield"),
+				Value: []byte("testextension"),
+			},
 		},
 		Value: data,
 	}
@@ -394,6 +398,7 @@ func TestFromKafkaMessage(t *testing.T) {
 	want.SetSource("testsource")
 	want.SetType("testtype")
 	want.SetID("im-a-snowflake")
+	want.SetExtension("extensionfield", "testextension")
 	want.SetData(data)
 
 	var got *cloudevents.Event
@@ -442,7 +447,7 @@ func TestToKafkaMessage(t *testing.T) {
 				Value: []byte("ignoreme"),
 			},
 			{
-				Key:   []byte("k1"),
+				Key:   []byte("ce_k1"),
 				Value: []byte("v1"),
 			},
 		},


### PR DESCRIPTION
Fixes #904 

## Proposed Changes

  * When writing CE extension attributes, prefix them with ce_ prefix and when reading, strip it out.
 * Fixes couple of bugs:
  - Because of the IsAlphaNumeric function, the extensions would *NOT* be ever round tripped through Kafka
  - Because they were prefixed on the way in, they would have had wrong values in any case.

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```