### PR TITLE
do not pass kafka headers into cloudevents extensions

### DIFF
--- a/kafka/channel/pkg/dispatcher/dispatcher.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher.go
@@ -353,13 +353,15 @@ func fromKafkaMessage(ctx context.Context, kafkaMessage *sarama.ConsumerMessage)
 		case "ce_dataschema":
 			event.SetDataSchema(v)
 		default:
-			// Extensions. Strip ce_ first before calling IsAlphaNumeric
-			// because _ is not valid...
-			// TODO: Should we even allow headers to be added as extensions
-			// if they do not have the ce_ prefix.
-			strippedHeader := strings.TrimPrefix(h, "ce_")
-			if IsAlphaNumeric(strippedHeader) {
-				event.SetExtension(strippedHeader, v)
+			// Possible Extensions. Note that we only add headers
+			// that start with ce_ to make sure we don't add any
+			// additional kafka headers as extensions.
+			if strings.HasPrefix(h, "ce_") {
+				// if they do not have the ce_ prefix.
+				strippedHeader := strings.TrimPrefix(h, "ce_")
+				if IsAlphaNumeric(strippedHeader) {
+					event.SetExtension(strippedHeader, v)
+				}
 			}
 		}
 	}

--- a/kafka/channel/pkg/dispatcher/dispatcher_test.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher_test.go
@@ -390,6 +390,10 @@ func TestFromKafkaMessage(t *testing.T) {
 				Key:   []byte("ce_extensionfield"),
 				Value: []byte("testextension"),
 			},
+			{
+				Key:   []byte("anotherkafkaheader"),
+				Value: []byte("notpassedthrough"),
+			},
 		},
 		Value: data,
 	}


### PR DESCRIPTION
Fixes #904 

## Proposed Changes

  * Do not pass kafka headers as extension attributes

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
do not expose internal kafka headers into cloud events extensions.
```