### PR TITLE
only see if image has changed before redeploy

### DIFF
--- a/kafka/channel/pkg/reconciler/controller/kafkachannel.go
+++ b/kafka/channel/pkg/reconciler/controller/kafkachannel.go
@@ -401,8 +401,8 @@ func (r *Reconciler) reconcileDispatcher(ctx context.Context, dispatcherNamespac
 		logging.FromContext(ctx).Error("Unable to get the dispatcher deployment", zap.Error(err))
 		kc.Status.MarkServiceUnknown("DispatcherDeploymentFailed", "Failed to get dispatcher deployment: %v", err)
 		return nil, err
-	} else if !reflect.DeepEqual(expected.Spec, d.Spec) {
-		logging.FromContext(ctx).Info("Deployment is not what we expect it to be, updating Deployment")
+	} else if !reflect.DeepEqual(expected.Spec.Template.Spec.Containers[0].Image, d.Spec.Template.Spec.Containers[0].Image) {
+		r.Logger.Infof("Deployment image is not what we expect it to be, updating Deployment Got: %q Expect: %q", expected.Spec.Template.Spec.Containers[0].Image, d.Spec.Template.Spec.Containers[0].Image)
 		d, err := r.KubeClientSet.AppsV1().Deployments(dispatcherNamespace).Update(expected)
 		if err == nil {
 			r.Recorder.Event(kc, corev1.EventTypeNormal, dispatcherDeploymentUpdated, "Dispatcher deployment updated")


### PR DESCRIPTION
## Proposed Changes

  * Deployment is getting interpreted as being out of date, because the template
    we use gets a bunch of stuff defaulted into it. SO, just look at a different image (which typically is the one that changes) and redeploy then. This is causing unnecessary churn and noise in the logs and us updating the deployment unnecessarily.
  *
  *

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
```