### PR TITLE
Remove kafka statefulset

### DIFF
--- a/kafka/source/config/500-controller.yaml
+++ b/kafka/source/config/500-controller.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: kafka-controller-manager
   namespace: knative-sources
@@ -21,10 +21,10 @@ metadata:
     contrib.eventing.knative.dev/release: devel
     control-plane: kafka-controller-manager
 spec:
+  replicas: 1
   selector:
     matchLabels: &labels
       control-plane: kafka-controller-manager
-  serviceName: kafka-controller-manager
   template:
     metadata:
       labels: *labels

--- a/kafka/source/config/500-controller.yaml
+++ b/kafka/source/config/500-controller.yaml
@@ -51,4 +51,44 @@ spec:
             memory: 20Mi
       serviceAccount: kafka-controller-manager
       terminationGracePeriodSeconds: 10
-
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka-controller-manager
+  namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel
+    control-plane: kafka-controller-manager
+spec:
+  replicas: 0
+  selector:
+    matchLabels: &labels
+      control-plane: kafka-controller-manager
+  serviceName: kafka-controller-manager
+  template:
+    metadata:
+      labels: *labels
+    spec:
+      serviceAccountName: kafka-controller-manager
+      containers:
+      - name: manager
+        image: knative.dev/eventing-contrib/kafka/source/cmd/controller
+        env:
+        - name: SYSTEM_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: METRICS_DOMAIN
+          value: knative.dev/sources
+        - name: CONFIG_OBSERVABILITY_NAME
+          value: config-observability
+        - name: KAFKA_RA_IMAGE
+          value: knative.dev/eventing-contrib/kafka/source/cmd/receive_adapter
+        volumeMounts:
+        resources:
+          requests:
+            cpu: 20m
+            memory: 20Mi
+      serviceAccount: kafka-controller-manager
+      terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Fixes #896

## Proposed Changes

  * replace stateful set w/ Deployment for the controller of the kafka source
  * and add one statefulset for backward compatibility with 0 replicas

**Release Note**
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->
```release-note
KafkaSource controller is now a Deployment. The statefulset is scaled down to 0 replicas
```


/assign @n3wscott 
/assign @lionelvillard 

