### PR TITLE
not forcing a specific version

### DIFF
--- a/kafka/channel/pkg/dispatcher/dispatcher.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher.go
@@ -329,7 +329,7 @@ func (d *KafkaDispatcher) getChannelReferenceFromHost(host string) (eventingchan
 }
 
 func fromKafkaMessage(ctx context.Context, kafkaMessage *sarama.ConsumerMessage) *cloudevents.Event {
-	event := cloudevents.NewEvent(cloudevents.VersionV1)
+	event := &Event{}
 	for _, header := range kafkaMessage.Headers {
 		h := string(header.Key)
 		v := string(header.Value)
@@ -366,7 +366,7 @@ func fromKafkaMessage(ctx context.Context, kafkaMessage *sarama.ConsumerMessage)
 		}
 	}
 	event.SetData(kafkaMessage.Value)
-	return &event
+	return event
 }
 
 func toKafkaMessage(ctx context.Context, channel eventingchannels.ChannelReference, event cloudevents.Event, topicFunc TopicFunc) *sarama.ProducerMessage {

--- a/kafka/channel/pkg/dispatcher/dispatcher_test.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher_test.go
@@ -366,6 +366,50 @@ func TestDispatcher_UpdateConfig(t *testing.T) {
 }
 
 func TestFromKafkaMessage(t *testing.T) {
+	testCases := map[string]struct {
+		message         *sarama.ConsumerMessage
+		want            *cloudevents.Event
+	}{
+		"1.0": {
+			message: &sarama.ConsumerMessage{
+			Headers: []*sarama.RecordHeader{
+		{
+			Key:   []byte("ce_k1"),
+			Value: []byte("v1"),
+		},
+		{
+			Key:   []byte("ce_id"),
+			Value: []byte("im-a-snowflake"),
+		},
+		{
+			Key:   []byte("ce_source"),
+			Value: []byte("testsource"),
+		},
+		{
+			Key:   []byte("ce_type"),
+			Value: []byte("testtype"),
+		},
+		{
+			Key:   []byte("ce_extensionfield"),
+			Value: []byte("testextension"),
+		},
+		{
+			Key:   []byte("anotherkafkaheader"),
+			Value: []byte("notpassedthrough"),
+		},
+		},
+			Value: []byte("data"),
+		},
+		want: cloudevents.NewEvent(cloudevents.VersionV1)
+			want.SetExtension("k1", "v1")
+			want.SetSource("testsource")
+			want.SetType("testtype")
+			want.SetID("im-a-snowflake")
+			want.SetExtension("extensionfield", "testextension")
+			want.SetData(data)
+
+
+
 	data := []byte("data")
 	ctx := context.Background()
 	kafkaMessage := &sarama.ConsumerMessage{


### PR DESCRIPTION
We now force 1.0 events, even we have "older" ones already in Kafka ... (due to ingress of the channel)

```
anic: invalid version "0.3", expecting "1.0"

goroutine 30 [running]:
knative.dev/eventing-contrib/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents.(*Event).SetSpecVersion(0xc0007e1f80, 0xc0007f0118, 0x3)
	/go/src/knative.dev/eventing-contrib/vendor/github.com/cloudevents/sdk-go/pkg/cloudevents/event_writer.go:29 +0x4e9
knative.dev/eventing-contrib/kafka/channel/pkg/dispatcher.fromKafkaMessage(0x203b820, 0xc000874700, 0xc0000bbae0, 0x17)
	/go/src/knative.dev/eventing-contrib/kafka/channel/pkg/dispatcher/dispatcher.go:340 +0x36a
knative.dev/eventing-contrib/kafka/channel/pkg/dispatcher.consumerMessageHandler.Handle(0xc00073dbea, 0x6, 0xc000329e00, 0x24, 0xc000329e00, 0x24, 0xc000329ec0, 0x2c, 0x0, 0x0, ...)
	/go/src/knative.dev/eventing-contrib/kafka/channel/pkg/dispatcher/dispatcher.go:82 +0x5a
knative.dev/eventing-contrib/kafka/common/pkg/kafka.(*saramaConsumerHandler).ConsumeClaim(0xc0007e4b40, 0x205a300, 0xc000870e00, 0x20496a0, 0xc0008735f0, 0x2b, 0x0)
	/go/src/knative.dev/eventing-contrib/kafka/common/pkg/kafka/consumer_handler.go:76 +0x26a
knative.dev/eventing-contrib/vendor/github.com/Shopify/sarama.(*consumerGroupSession).consume(0xc000870e00, 0xc000057a10, 0x2b, 0x0)
	/go/src/knative.dev/eventing-contrib/vendor/github.com/Shopify/sarama/consumer_group.go:633 +0x27f
knative.dev/eventing-contrib/vendor/github.com/Shopify/sarama.newConsumerGroupSession.func2(0xc000870e00, 0xc000057a10, 0x2b, 0xc000000000)
	/go/src/knative.dev/eventing-contrib/vendor/github.com/Shopify/sarama/consumer_group.go:562 +0x95
created by knative.dev/eventing-contrib/vendor/github.com/Shopify/sarama.newConsumerGroupSession
	/go/src/knative.dev/eventing-contrib/vendor/github.com/Shopify/sarama/consumer_group.go:554 +0x526
```

## Proposed Changes

  * not forcing 1.0 only

