### PR TITLE
Migrate awssqsSource to sources.knative.dev

### DIFF
--- a/awssqs/config/201-clusterrole.yaml
+++ b/awssqs/config/201-clusterrole.yaml
@@ -47,7 +47,7 @@ rules:
   - delete
 
 - apiGroups:
-  - sources.eventing.knative.dev
+  - sources.knative.dev
   resources:
   - awssqssources
   verbs:
@@ -57,7 +57,7 @@ rules:
   - update
   - patch
 - apiGroups:
-  - sources.eventing.knative.dev
+  - sources.knative.dev
   resources:
   - awssqssources/status
   - awssqssources/finalizers
@@ -107,7 +107,7 @@ metadata:
     duck.knative.dev/source: "true"
 rules:
   - apiGroups:
-      - "sources.eventing.knative.dev"
+      - "sources.knative.dev"
     resources:
       - "awssqssources"
     verbs:

--- a/awssqs/config/300-awssqssource.yaml
+++ b/awssqs/config/300-awssqssource.yaml
@@ -24,9 +24,9 @@ metadata:
       [
         { "type": "aws.sqs.message" }
       ]
-  name: awssqssources.sources.eventing.knative.dev
+  name: awssqssources.sources.knative.dev
 spec:
-  group: sources.eventing.knative.dev
+  group: sources.knative.dev
   names:
     categories:
     - all

--- a/awssqs/pkg/apis/sources/v1alpha1/doc.go
+++ b/awssqs/pkg/apis/sources/v1alpha1/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=knative.dev/eventing-contrib/pkg/apis/sources
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=sources.eventing.knative.dev
+// +groupName=sources.knative.dev
 package v1alpha1

--- a/awssqs/pkg/apis/sources/v1alpha1/register.go
+++ b/awssqs/pkg/apis/sources/v1alpha1/register.go
@@ -19,7 +19,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=knative.dev/eventing-contrib/pkg/apis/sources
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=sources.eventing.knative.dev
+// +groupName=sources.knative.dev
 package v1alpha1
 
 import (
@@ -29,7 +29,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "sources.eventing.knative.dev", Version: "v1alpha1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "sources.knative.dev", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/awssqs/pkg/apis/sources/v1alpha1/register_test.go
+++ b/awssqs/pkg/apis/sources/v1alpha1/register_test.go
@@ -25,7 +25,7 @@ import (
 // Resource takes an unqualified resource and returns a Group qualified GroupResource
 func TestResource(t *testing.T) {
 	want := schema.GroupResource{
-		Group:    "sources.eventing.knative.dev",
+		Group:    "sources.knative.dev",
 		Resource: "foo",
 	}
 

--- a/awssqs/pkg/client/clientset/versioned/typed/sources/v1alpha1/fake/fake_awssqssource.go
+++ b/awssqs/pkg/client/clientset/versioned/typed/sources/v1alpha1/fake/fake_awssqssource.go
@@ -34,9 +34,9 @@ type FakeAwsSqsSources struct {
 	ns   string
 }
 
-var awssqssourcesResource = schema.GroupVersionResource{Group: "sources.eventing.knative.dev", Version: "v1alpha1", Resource: "awssqssources"}
+var awssqssourcesResource = schema.GroupVersionResource{Group: "sources.knative.dev", Version: "v1alpha1", Resource: "awssqssources"}
 
-var awssqssourcesKind = schema.GroupVersionKind{Group: "sources.eventing.knative.dev", Version: "v1alpha1", Kind: "AwsSqsSource"}
+var awssqssourcesKind = schema.GroupVersionKind{Group: "sources.knative.dev", Version: "v1alpha1", Kind: "AwsSqsSource"}
 
 // Get takes name of the awsSqsSource, and returns the corresponding awsSqsSource object, and an error if there is any.
 func (c *FakeAwsSqsSources) Get(name string, options v1.GetOptions) (result *v1alpha1.AwsSqsSource, err error) {

--- a/awssqs/pkg/client/clientset/versioned/typed/sources/v1alpha1/sources_client.go
+++ b/awssqs/pkg/client/clientset/versioned/typed/sources/v1alpha1/sources_client.go
@@ -29,7 +29,7 @@ type SourcesV1alpha1Interface interface {
 	AwsSqsSourcesGetter
 }
 
-// SourcesV1alpha1Client is used to interact with features provided by the sources.eventing.knative.dev group.
+// SourcesV1alpha1Client is used to interact with features provided by the sources.knative.dev group.
 type SourcesV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/awssqs/pkg/client/informers/externalversions/generic.go
+++ b/awssqs/pkg/client/informers/externalversions/generic.go
@@ -52,7 +52,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=sources.eventing.knative.dev, Version=v1alpha1
+	// Group=sources.knative.dev, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("awssqssources"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Sources().V1alpha1().AwsSqsSources().Informer()}, nil
 

--- a/awssqs/pkg/client/injection/reconciler/sources/v1alpha1/awssqssource/controller.go
+++ b/awssqs/pkg/client/injection/reconciler/sources/v1alpha1/awssqssource/controller.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	defaultControllerAgentName = "awssqssource-controller"
-	defaultFinalizerName       = "awssqssources.sources.eventing.knative.dev"
+	defaultFinalizerName       = "awssqssources.sources.knative.dev"
 	defaultQueueName           = "awssqssources"
 )
 

--- a/awssqs/samples/awssqs-source.yaml
+++ b/awssqs/samples/awssqs-source.yaml
@@ -1,7 +1,7 @@
 # Replace the following before applying this file:
 #   QUEUE_URL: Replace with the AWS SQS queue.
 
-apiVersion: sources.eventing.knative.dev/v1alpha1
+apiVersion: sources.knative.dev/v1alpha1
 kind: AwsSqsSource
 metadata:
   name: awssqs-sample-source


### PR DESCRIPTION
A follow up with the other apigroup migrations
----

# Release Notes
`awssqsSource used to be under sources.eventing.knative.dev now moved to  sources.knative.dev. No other functional changes. `
