### PR TITLE
Add support for leader election

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1841,7 +1841,6 @@
     "pkg/apis/messaging/v1beta1",
     "pkg/apis/sources",
     "pkg/apis/sources/v1alpha1",
-    "pkg/apis/sources/v1alpha2",
     "pkg/channel",
     "pkg/channel/fanout",
     "pkg/channel/multichannelfanout",
@@ -1865,8 +1864,6 @@
     "pkg/client/clientset/versioned/typed/messaging/v1beta1/fake",
     "pkg/client/clientset/versioned/typed/sources/v1alpha1",
     "pkg/client/clientset/versioned/typed/sources/v1alpha1/fake",
-    "pkg/client/clientset/versioned/typed/sources/v1alpha2",
-    "pkg/client/clientset/versioned/typed/sources/v1alpha2/fake",
     "pkg/client/informers/externalversions",
     "pkg/client/informers/externalversions/configs",
     "pkg/client/informers/externalversions/configs/v1alpha1",
@@ -1882,7 +1879,6 @@
     "pkg/client/informers/externalversions/messaging/v1beta1",
     "pkg/client/informers/externalversions/sources",
     "pkg/client/informers/externalversions/sources/v1alpha1",
-    "pkg/client/informers/externalversions/sources/v1alpha2",
     "pkg/client/injection/client",
     "pkg/client/injection/client/fake",
     "pkg/client/injection/informers/eventing/v1alpha1/eventtype",
@@ -1895,7 +1891,6 @@
     "pkg/client/listers/messaging/v1alpha1",
     "pkg/client/listers/messaging/v1beta1",
     "pkg/client/listers/sources/v1alpha1",
-    "pkg/client/listers/sources/v1alpha2",
     "pkg/configmap",
     "pkg/defaultchannel",
     "pkg/kncloudevents",
@@ -1938,7 +1933,7 @@
 
 [[projects]]
   branch = "release-0.13"
-  digest = "1:f8d227da9c1b062805ff9b98c500f19f02c9015d7bcd3134bfac26829df537fb"
+  digest = "1:77db7d7e7364e6acb7fe627ddb377f94e5199b020be96aa0e8654cd864db2d7a"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1968,6 +1963,7 @@
     "injection/sharedmain",
     "kmeta",
     "kmp",
+    "leaderelection",
     "logging",
     "logging/logkey",
     "logging/testing",
@@ -2010,7 +2006,7 @@
     "webhook/resourcesemantics/validation",
   ]
   pruneopts = "T"
-  revision = "1033748a7ec0f07204774c163436291841855779"
+  revision = "2006e107e39eb0e661e4437ba76b16465162689e"
 
 [[projects]]
   branch = "master"

--- a/awssqs/cmd/controller/main.go
+++ b/awssqs/cmd/controller/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 func main() {
-	sharedmain.Main("controller",
+	sharedmain.Main("awssqs-controller",
 		awssqssource.NewController,
 	)
 }

--- a/awssqs/config/201-clusterrole.yaml
+++ b/awssqs/config/201-clusterrole.yaml
@@ -47,6 +47,19 @@ rules:
   - delete
 
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+
+- apiGroups:
   - sources.knative.dev
   resources:
   - awssqssources

--- a/awssqs/config/201-clusterrole.yaml
+++ b/awssqs/config/201-clusterrole.yaml
@@ -23,7 +23,7 @@ rules:
   - apps
   resources:
   - deployments
-  verbs:
+  verbs: &everything
   - get
   - list
   - watch
@@ -37,27 +37,13 @@ rules:
   resources:
   - events
   - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  verbs: *everything
 
 - apiGroups:
   - coordination.k8s.io
   resources:
   - leases
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  verbs: *everything
 
 - apiGroups:
   - sources.knative.dev

--- a/awssqs/config/500-controller.yaml
+++ b/awssqs/config/500-controller.yaml
@@ -54,6 +54,8 @@ spec:
               value: config-logging
             - name: CONFIG_OBSERVABILITY_NAME
               value: config-observability
+            - name: CONFIG_LEADERELECTION_NAME
+              value: config-leader-election-awssqs
             - name: METRICS_DOMAIN
               value: knative.dev/sources
             # AwsSqsSource RA image:

--- a/awssqs/config/config-leader-election.yaml
+++ b/awssqs/config/config-leader-election.yaml
@@ -61,5 +61,5 @@ data:
     # enabledComponents is a comma-delimited list of component names for which
     # leader election is enabled. Valid values are:
     #
-    # - controller
-    enabledComponents: "controller"
+    # - awssqs-controller
+    enabledComponents: "awssqs-controller"

--- a/awssqs/config/config-leader-election.yaml
+++ b/awssqs/config/config-leader-election.yaml
@@ -1,0 +1,65 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election-awssqs
+  namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel
+data:
+  # An inactive but valid configuration follows; see example.
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # resourceLock controls which API resource is used as the basis for the
+    # leader election lock. Valid values are:
+    #
+    # - leases -> use the coordination API
+    # - configmaps -> use configmaps
+    # - endpoints -> use endpoints
+    resourceLock: "leases"
+
+    # leaseDuration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    leaseDuration: "15s"
+    # renewDeadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renewDeadline: "10s"
+    # retryPeriod is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kuberntes controllers.
+    retryPeriod: "2s"
+    # enabledComponents is a comma-delimited list of component names for which
+    # leader election is enabled. Valid values are:
+    #
+    # - controller
+    enabledComponents: "controller"

--- a/couchdb/source/cmd/controller/main.go
+++ b/couchdb/source/cmd/controller/main.go
@@ -22,5 +22,5 @@ import (
 )
 
 func main() {
-	sharedmain.Main("couchdb_controller", reconciler.NewController)
+	sharedmain.Main("couchdb-controller", reconciler.NewController)
 }

--- a/couchdb/source/config/201-clusterrole.yaml
+++ b/couchdb/source/config/201-clusterrole.yaml
@@ -85,6 +85,12 @@ rules:
     - eventtypes
   verbs: *everything
 
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs: *everything
+
 ---
 # The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
 # See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.

--- a/couchdb/source/config/500-controller.yaml
+++ b/couchdb/source/config/500-controller.yaml
@@ -45,6 +45,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: knative.dev/sources
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election-couchdb
         - name: COUCHDB_RA_IMAGE
           value: knative.dev/eventing-contrib/couchdb/source/cmd/receive_adapter
         resources:

--- a/couchdb/source/config/config-leader-election.yaml
+++ b/couchdb/source/config/config-leader-election.yaml
@@ -25,7 +25,6 @@ data:
   leaseDuration: "15s"
   renewDeadline: "10s"
   retryPeriod: "2s"
-  enabledComponents: "couchdb-controller"
   _example: |
     ################################
     #                              #

--- a/couchdb/source/config/config-leader-election.yaml
+++ b/couchdb/source/config/config-leader-election.yaml
@@ -1,0 +1,66 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election-couchdb
+  namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel
+data:
+  # An inactive but valid configuration follows; see example.
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+  enabledComponents: "couchdb-controller"
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # resourceLock controls which API resource is used as the basis for the
+    # leader election lock. Valid values are:
+    #
+    # - leases -> use the coordination API
+    # - configmaps -> use configmaps
+    # - endpoints -> use endpoints
+    resourceLock: "leases"
+
+    # leaseDuration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    leaseDuration: "15s"
+    # renewDeadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renewDeadline: "10s"
+    # retryPeriod is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kuberntes controllers.
+    retryPeriod: "2s"
+    # enabledComponents is a comma-delimited list of component names for which
+    # leader election is enabled. Valid values are:
+    #
+    # - couchdb-controller
+    enabledComponents: "couchdb-controller"

--- a/github/cmd/controller/main.go
+++ b/github/cmd/controller/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	component = "github_controller"
+	component = "github-controller"
 )
 
 func main() {

--- a/github/config/201-clusterrole.yaml
+++ b/github/config/201-clusterrole.yaml
@@ -90,6 +90,12 @@ rules:
   - eventtypes
   verbs: *everything
 
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs: *everything
+
 ---
 # The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
 # See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.

--- a/github/config/500-controller.yaml
+++ b/github/config/500-controller.yaml
@@ -42,6 +42,8 @@ spec:
           value: config-logging
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election-github
         - name: METRICS_DOMAIN
           value: knative.dev/sources
         - name: GH_RA_IMAGE

--- a/github/config/config-leader-election.yaml
+++ b/github/config/config-leader-election.yaml
@@ -1,0 +1,65 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election-github
+  namespace: knative-sources
+  labels:
+    contrib.eventing.knative.dev/release: devel
+data:
+  # An inactive but valid configuration follows; see example.
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # resourceLock controls which API resource is used as the basis for the
+    # leader election lock. Valid values are:
+    #
+    # - leases -> use the coordination API
+    # - configmaps -> use configmaps
+    # - endpoints -> use endpoints
+    resourceLock: "leases"
+
+    # leaseDuration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    leaseDuration: "15s"
+    # renewDeadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renewDeadline: "10s"
+    # retryPeriod is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kuberntes controllers.
+    retryPeriod: "2s"
+    # enabledComponents is a comma-delimited list of component names for which
+    # leader election is enabled. Valid values are:
+    #
+    # - github-controller
+    enabledComponents: "github-controller"

--- a/kafka/channel/cmd/channel_controller/main.go
+++ b/kafka/channel/cmd/channel_controller/main.go
@@ -22,7 +22,7 @@ import (
 	"knative.dev/eventing-contrib/kafka/channel/pkg/reconciler/controller"
 )
 
-const component = "kafkachannel_controller"
+const component = "kafkachannel-controller"
 
 func main() {
 	sharedmain.Main(component, controller.NewController)

--- a/kafka/channel/cmd/channel_dispatcher/main.go
+++ b/kafka/channel/cmd/channel_dispatcher/main.go
@@ -26,7 +26,7 @@ import (
 	controller "knative.dev/eventing-contrib/kafka/channel/pkg/reconciler/dispatcher"
 )
 
-const component = "kafkachannel_dispatcher"
+const component = "kafkachannel-dispatcher"
 
 func main() {
 	ctx := signals.NewContext()

--- a/kafka/channel/cmd/webhook/main.go
+++ b/kafka/channel/cmd/webhook/main.go
@@ -87,7 +87,7 @@ func main() {
 		SecretName:  "messaging-webhook-certs",
 	})
 
-	sharedmain.WebhookMainWithContext(ctx, "kafkachannel_webhook",
+	sharedmain.WebhookMainWithContext(ctx, "kafkachannel-webhook",
 		certificates.NewController,
 		NewDefaultingAdmissionController,
 		NewValidationAdmissionController,

--- a/kafka/channel/config/200-controller-clusterrole.yaml
+++ b/kafka/channel/config/200-controller-clusterrole.yaml
@@ -105,3 +105,8 @@ rules:
     resources:
       - rolebindings
     verbs: *everything
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs: *everything

--- a/kafka/channel/config/200-dispatcher-clusterrole.yaml
+++ b/kafka/channel/config/200-dispatcher-clusterrole.yaml
@@ -68,3 +68,14 @@ rules:
     verbs:
       - create
       - patch
+  - apiGroups:
+      - "coordination.k8s.io"
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - update

--- a/kafka/channel/config/400-leader-election-config.yaml
+++ b/kafka/channel/config/400-leader-election-config.yaml
@@ -1,0 +1,64 @@
+# Copyright 20 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election-kafka
+  namespace: knative-eventing
+data:
+  # An inactive but valid configuration follows; see example.
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # resourceLock controls which API resource is used as the basis for the
+    # leader election lock. Valid values are:
+    #
+    # - leases -> use the coordination API
+    # - configmaps -> use configmaps
+    # - endpoints -> use endpoints
+    resourceLock: "leases"
+
+    # leaseDuration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    leaseDuration: "15s"
+    # renewDeadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renewDeadline: "10s"
+    # retryPeriod is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kuberntes controllers.
+    retryPeriod: "2s"
+    # enabledComponents is a comma-delimited list of component names for which
+    # leader election is enabled. Valid values are:
+    #
+    # - kafkachannel_dispatcher
+    # - kafkachannel_controller
+    enabledComponents: "kafkachannel_dispatcher,kafkachannel_controller"

--- a/kafka/channel/config/400-leader-election-config.yaml
+++ b/kafka/channel/config/400-leader-election-config.yaml
@@ -59,6 +59,6 @@ data:
     # enabledComponents is a comma-delimited list of component names for which
     # leader election is enabled. Valid values are:
     #
-    # - kafkachannel_dispatcher
-    # - kafkachannel_controller
-    enabledComponents: "kafkachannel_dispatcher,kafkachannel_controller"
+    # - kafkachannel-dispatcher
+    # - kafkachannel-controller
+    enabledComponents: "kafkachannel-dispatcher,kafkachannel-controller"

--- a/kafka/channel/config/500-controller.yaml
+++ b/kafka/channel/config/500-controller.yaml
@@ -42,6 +42,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: CONFIG_LEADERELECTION_NAME
+              value: config-leader-election-kafka
             - name: DISPATCHER_IMAGE
               value: knative.dev/eventing-contrib/kafka/channel/cmd/channel_dispatcher
           ports:

--- a/kafka/channel/pkg/reconciler/controller/resources/dispatcher.go
+++ b/kafka/channel/pkg/reconciler/controller/resources/dispatcher.go
@@ -108,6 +108,9 @@ func makeEnv(args DispatcherArgs) []corev1.EnvVar {
 	}, {
 		Name:  "CONFIG_LOGGING_NAME",
 		Value: "config-logging",
+	}, {
+		Name:  "CONFIG_LEADERELECTION_NAME",
+		Value: "config-leader-election-kafka",
 	}}
 
 	if args.DispatcherScope == "namespace" {

--- a/kafka/channel/pkg/reconciler/controller/resources/dispatcher_test.go
+++ b/kafka/channel/pkg/reconciler/controller/resources/dispatcher_test.go
@@ -74,7 +74,11 @@ func TestNewDispatcher(t *testing.T) {
 							}, {
 								Name:  "CONFIG_LOGGING_NAME",
 								Value: "config-logging",
-							}},
+							}, {
+								Name:  "CONFIG_LEADERELECTION_NAME",
+								Value: "config-leader-election-kafka",
+							},
+							},
 							Ports: []corev1.ContainerPort{{
 								Name:          "metrics",
 								ContainerPort: 9090,
@@ -152,6 +156,9 @@ func TestNewNamespaceDispatcher(t *testing.T) {
 							}, {
 								Name:  "CONFIG_LOGGING_NAME",
 								Value: "config-logging",
+							}, {
+								Name:  "CONFIG_LEADERELECTION_NAME",
+								Value: "config-leader-election-kafka",
 							}, {
 								Name: "NAMESPACE",
 								ValueFrom: &corev1.EnvVarSource{

--- a/kafka/docs/metrics.md
+++ b/kafka/docs/metrics.md
@@ -16,8 +16,8 @@ Add the following job entries under
 **data**.**prometheus.yml**.**scrape_configs**:
 
 ```yaml
-# kafkachannel_controller
-- job_name: kafkachannel_controller
+# kafkachannel-controller
+- job_name: kafkachannel-controller
   scrape_interval: 3s
   scrape_timeout: 3s
   kubernetes_sd_configs:
@@ -41,8 +41,8 @@ Add the following job entries under
     - source_labels: [__meta_kubernetes_service_name]
       target_label: service
 
-# kafkachannel_dispatcher
-- job_name: kafkachannel_dispatcher
+# kafkachannel-dispatcher
+- job_name: kafkachannel-dispatcher
   scrape_interval: 3s
   scrape_timeout: 3s
   kubernetes_sd_configs:
@@ -66,8 +66,8 @@ Add the following job entries under
     - source_labels: [__meta_kubernetes_service_name]
       target_label: service
 
-# kafkachannel_webhook
-- job_name: kafkachannel_webhook
+# kafkachannel-webhook
+- job_name: kafkachannel-webhook
   scrape_interval: 3s
   scrape_timeout: 3s
   kubernetes_sd_configs:
@@ -111,8 +111,8 @@ kubectl port-forward -n knative-monitoring \
 
 Access Prometheus targets endpoint
 [http://localhost:9090/targets](http://localhost:9090/targets). Now, the
-**kafkachannel_controller**, **kafkachannel_dispatcher** and
-**kafkachannel_webhook** jobs should be up.
+**kafkachannel-controller**, **kafkachannel-dispatcher** and
+**kafkachannel-webhook** jobs should be up.
 
 ## Check KafkaChannel controller metrics
 

--- a/kafka/source/config/201-clusterrole.yaml
+++ b/kafka/source/config/201-clusterrole.yaml
@@ -66,6 +66,11 @@ rules:
   resources:
   - eventtypes
   verbs: *everything
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs: *everything
 
 ---
 # The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".

--- a/kafka/source/config/500-controller.yaml
+++ b/kafka/source/config/500-controller.yaml
@@ -42,6 +42,8 @@ spec:
           value: knative.dev/sources
         - name: CONFIG_OBSERVABILITY_NAME
           value: config-observability
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election-kafka
         - name: KAFKA_RA_IMAGE
           value: knative.dev/eventing-contrib/kafka/source/cmd/receive_adapter
         volumeMounts:

--- a/kafka/source/config/config-leader-election.yaml
+++ b/kafka/source/config/config-leader-election.yaml
@@ -1,0 +1,63 @@
+# Copyright 20 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election-kafka
+  namespace: knative-sources
+data:
+  # An inactive but valid configuration follows; see example.
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # resourceLock controls which API resource is used as the basis for the
+    # leader election lock. Valid values are:
+    #
+    # - leases -> use the coordination API
+    # - configmaps -> use configmaps
+    # - endpoints -> use endpoints
+    resourceLock: "leases"
+
+    # leaseDuration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    leaseDuration: "15s"
+    # renewDeadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renewDeadline: "10s"
+    # retryPeriod is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kuberntes controllers.
+    retryPeriod: "2s"
+    # enabledComponents is a comma-delimited list of component names for which
+    # leader election is enabled. Valid values are:
+    #
+    # - kafka-controller
+    enabledComponents: "kafka-controller"

--- a/prometheus/cmd/controller/main.go
+++ b/prometheus/cmd/controller/main.go
@@ -22,5 +22,5 @@ import (
 )
 
 func main() {
-	sharedmain.Main("prometheussource_controller", reconciler.NewController)
+	sharedmain.Main("prometheussource-controller", reconciler.NewController)
 }

--- a/prometheus/config/201-clusterrole.yaml
+++ b/prometheus/config/201-clusterrole.yaml
@@ -85,6 +85,12 @@ rules:
     - eventtypes
   verbs: *everything
 
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs: *everything
+
 ---
 # The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
 # See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.

--- a/prometheus/config/500-controller.yaml
+++ b/prometheus/config/500-controller.yaml
@@ -45,6 +45,8 @@ spec:
           value: config-observability
         - name: METRICS_DOMAIN
           value: knative.dev/sources
+        - name: CONFIG_LEADERELECTION_NAME
+          value: config-leader-election-prometheus
         - name: PROMETHEUS_RA_IMAGE
           value: knative.dev/eventing-contrib/prometheus/cmd/receive_adapter
         resources:

--- a/prometheus/config/config-leader-election.yaml
+++ b/prometheus/config/config-leader-election.yaml
@@ -1,0 +1,63 @@
+# Copyright 20 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-leader-election-prometheus
+  namespace: knative-sources
+data:
+  # An inactive but valid configuration follows; see example.
+  resourceLock: "leases"
+  leaseDuration: "15s"
+  renewDeadline: "10s"
+  retryPeriod: "2s"
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # resourceLock controls which API resource is used as the basis for the
+    # leader election lock. Valid values are:
+    #
+    # - leases -> use the coordination API
+    # - configmaps -> use configmaps
+    # - endpoints -> use endpoints
+    resourceLock: "leases"
+
+    # leaseDuration is how long non-leaders will wait to try to acquire the
+    # lock; 15 seconds is the value used by core kubernetes controllers.
+    leaseDuration: "15s"
+    # renewDeadline is how long a leader will try to renew the lease before
+    # giving up; 10 seconds is the value used by core kubernetes controllers.
+    renewDeadline: "10s"
+    # retryPeriod is how long the leader election client waits between tries of
+    # actions; 2 seconds is the value used by core kuberntes controllers.
+    retryPeriod: "2s"
+    # enabledComponents is a comma-delimited list of component names for which
+    # leader election is enabled. Valid values are:
+    #
+    # - prometheussource-controller
+    enabledComponents: "prometheussource-controller"

--- a/vendor/knative.dev/pkg/Gopkg.lock
+++ b/vendor/knative.dev/pkg/Gopkg.lock
@@ -980,7 +980,7 @@
   version = "kubernetes-1.16.4"
 
 [[projects]]
-  digest = "1:1aaf879947e3abf264929bb0220acced357f85da5ac0f58b10f0f8a5719a41ef"
+  digest = "1:e49d4f18068a8b4e5ac2ae52ec9363e8509f17de8c1569a41663ef1632fc4aeb"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/apitesting",
@@ -1025,6 +1025,7 @@
     "pkg/util/sets",
     "pkg/util/sets/types",
     "pkg/util/strategicpatch",
+    "pkg/util/uuid",
     "pkg/util/validation",
     "pkg/util/validation/field",
     "pkg/util/wait",
@@ -1039,7 +1040,7 @@
   version = "kubernetes-1.16.4"
 
 [[projects]]
-  digest = "1:b03297e45cd203dee7e9449141555d3973d04d5323ece6b4e20562b80185767e"
+  digest = "1:b485876cac57a0612f78c907bde4e34c3f327e35e705f7f59d3bd7c5cd78a688"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -1229,6 +1230,8 @@
     "tools/clientcmd/api",
     "tools/clientcmd/api/latest",
     "tools/clientcmd/api/v1",
+    "tools/leaderelection",
+    "tools/leaderelection/resourcelock",
     "tools/metrics",
     "tools/pager",
     "tools/record",
@@ -1456,6 +1459,7 @@
     "k8s.io/apimachinery/pkg/util/runtime",
     "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/util/sets/types",
+    "k8s.io/apimachinery/pkg/util/uuid",
     "k8s.io/apimachinery/pkg/util/validation",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/apimachinery/pkg/version",
@@ -1486,6 +1490,8 @@
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/leaderelection",
+    "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/metrics",
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/util/retry",

--- a/vendor/knative.dev/pkg/leaderelection/config.go
+++ b/vendor/knative.dev/pkg/leaderelection/config.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leaderelection
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+const ConfigMapNameEnv = "CONFIG_LEADERELECTION_NAME"
+
+var (
+	errEmptyLeaderElectionConfig = errors.New("empty leader election configuration")
+	validResourceLocks           = sets.NewString("leases", "configmaps", "endpoints")
+)
+
+// NewConfigFromMap returns a Config for the given map, or an error.
+func NewConfigFromMap(data map[string]string) (*Config, error) {
+	config := &Config{
+		EnabledComponents: sets.NewString(),
+	}
+
+	if resourceLock := data["resourceLock"]; !validResourceLocks.Has(resourceLock) {
+		return nil, fmt.Errorf(`resourceLock: invalid value %q: valid values are "leases","configmaps","endpoints"`, resourceLock)
+	} else {
+		config.ResourceLock = resourceLock
+	}
+
+	if leaseDuration, err := time.ParseDuration(data["leaseDuration"]); err != nil {
+		return nil, fmt.Errorf("leaseDuration: invalid duration: %q", data["leaseDuration"])
+	} else {
+		config.LeaseDuration = leaseDuration
+	}
+
+	if renewDeadline, err := time.ParseDuration(data["renewDeadline"]); err != nil {
+		return nil, fmt.Errorf("renewDeadline: invalid duration: %q", data["renewDeadline"])
+	} else {
+		config.RenewDeadline = renewDeadline
+	}
+
+	if retryPeriod, err := time.ParseDuration(data["retryPeriod"]); err != nil {
+		return nil, fmt.Errorf("retryPeriod: invalid duration: %q", data["retryPeriod"])
+	} else {
+		config.RetryPeriod = retryPeriod
+	}
+
+	// enabledComponents are not validated here, because they are dependent on
+	// the component. Components should provide additional validation for this
+	// field.
+	if enabledComponents, ok := data["enabledComponents"]; ok {
+		tokens := strings.Split(enabledComponents, ",")
+		config.EnabledComponents = sets.NewString(tokens...)
+	}
+
+	return config, nil
+}
+
+// NewConfigFromConfigMap returns a new Config from the given ConfigMap.
+func NewConfigFromConfigMap(configMap *corev1.ConfigMap) (*Config, error) {
+	if configMap == nil {
+		config := defaultConfig()
+		return config, nil
+	}
+
+	return NewConfigFromMap(configMap.Data)
+}
+
+// Config represents the leader election config for a set of components
+// contained within a single namespace. Typically these will correspond to a
+// single source repository, viz: serving or eventing.
+type Config struct {
+	ResourceLock      string
+	LeaseDuration     time.Duration
+	RenewDeadline     time.Duration
+	RetryPeriod       time.Duration
+	EnabledComponents sets.String
+}
+
+func (c *Config) GetComponentConfig(name string) ComponentConfig {
+	if c.EnabledComponents.Has(name) {
+		return ComponentConfig{
+			LeaderElect:   true,
+			ResourceLock:  c.ResourceLock,
+			LeaseDuration: c.LeaseDuration,
+			RenewDeadline: c.RenewDeadline,
+			RetryPeriod:   c.RetryPeriod,
+		}
+	}
+
+	return defaultComponentConfig()
+}
+
+func defaultConfig() *Config {
+	return &Config{
+		ResourceLock:      "leases",
+		LeaseDuration:     15 * time.Second,
+		RenewDeadline:     10 * time.Second,
+		RetryPeriod:       2 * time.Second,
+		EnabledComponents: sets.NewString(),
+	}
+}
+
+// ComponentConfig represents the leader election config for a single component.
+type ComponentConfig struct {
+	LeaderElect   bool
+	ResourceLock  string
+	LeaseDuration time.Duration
+	RenewDeadline time.Duration
+	RetryPeriod   time.Duration
+}
+
+func defaultComponentConfig() ComponentConfig {
+	return ComponentConfig{
+		LeaderElect: false,
+	}
+}
+
+// ConfigMapName returns the name of the configmap to read for leader election
+// settings.
+func ConfigMapName() string {
+	cm := os.Getenv(ConfigMapNameEnv)
+	if cm == "" {
+		return "config-leader-election"
+	}
+	return cm
+}
+
+// UniqueID returns a unique ID for use with a leader elector that prevents from
+// pods running on the same host from colliding with one another.
+func UniqueID() (string, error) {
+	id, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+
+	return (id + "_" + string(uuid.NewUUID())), nil
+}


### PR DESCRIPTION
Fixes knative/pkg#1007

## Proposed Changes

Add (inactive) leader election configurations for:

- Kafka channel
- Kafka source
- Prometheus source
- Github source
- Couchdb source
- AWS SQS

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add support for leader election to:

- Kafka channel
- Kafka source
- Prometheus source
- Github source
- Couchdb source
- AWS SQS
```
