### PR TITLE
Add support for DeadLetterSink in KafkaChannel

### DIFF
--- a/test/e2e/broker_dls_test.go
+++ b/test/e2e/broker_dls_test.go
@@ -1,0 +1,35 @@
+// +build e2e
+
+/*
+Copyright 2020 The Knative Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/eventing/test/e2e/helpers"
+)
+
+// TestBrokerDeadLetterSink tests Broker's DeadLetterSink
+func TestBrokerDeadLetterSink(t *testing.T) {
+	// Only test KafkaChannel
+	channelTestRunner.ChannelsToTest = []metav1.TypeMeta{
+		{APIVersion: "messaging.knative.dev/v1alpha1", Kind: "KafkaChannel"},
+	}
+
+	helpers.TestBrokerWithConfig(t, channelTestRunner)
+}


### PR DESCRIPTION
Fixes #754

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Add support for deadLetterSink in KafkaChannel
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Subscription.spec.delivery.deadLetterSink field is now supported by KafkaChannel
```

**Docs**


<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
