### PR TITLE
Fix link to Eventing setup in NATSS

### DIFF
--- a/natss/config/README.md
+++ b/natss/config/README.md
@@ -22,7 +22,7 @@ They do not offer:
 ## Deployment steps
 
 1. Setup
-   [Knative Eventing](https://knative.dev/eventing/blob/master/DEVELOPMENT.md).
+   [Knative Eventing](https://github.com/knative/eventing-contrib/blob/master/DEVELOPMENT.md).
 1. If not done already, install a [NATS Streaming](./broker/README.md)
 1. Apply the NATSS configuration:
 


### PR DESCRIPTION
Fixes broken link from https://github.com/knative/eventing-contrib/pull/811
