### PR TITLE
Fix the apiVersion used in the GitHubSource filters.

### DIFF
--- a/pkg/apis/sources/register.go
+++ b/pkg/apis/sources/register.go
@@ -17,5 +17,5 @@ limitations under the License.
 package sources
 
 const (
-	GroupName = "sources.eventing.knative.dev"
+	GroupName = "sources.knative.dev"
 )


### PR DESCRIPTION
- 🐛 This fixes the filter used with the OwnerReferences on all of the GitHubSource informers (and possibly more in other contrib sources).

Fixes: https://github.com/knative/eventing-contrib/issues/997

