### PR TITLE
EventTypes from listers.

### DIFF
--- a/github/pkg/reconciler/controller.go
+++ b/github/pkg/reconciler/controller.go
@@ -33,6 +33,7 @@ import (
 
 	//knative.dev/eventing imports
 	"knative.dev/eventing-contrib/github/pkg/apis/sources/v1alpha1"
+	eventtypeinformer "knative.dev/eventing/pkg/client/injection/informers/eventing/v1alpha1/eventtype"
 	"knative.dev/eventing/pkg/reconciler"
 
 	//knative.dev/pkg imports
@@ -55,11 +56,13 @@ func NewController(
 
 	githubInformer := githubinformer.Get(ctx)
 	serviceInformer := kserviceinformer.Get(ctx)
+	eventTypeInformer := eventtypeinformer.Get(ctx)
 
 	r := &Reconciler{
 		Base:                reconciler.NewBase(ctx, controllerAgentName, cmw),
 		servingLister:       serviceInformer.Lister(),
 		servingClientSet:    serviceclient.Get(ctx),
+		eventTypeLister:     eventTypeInformer.Lister(),
 		webhookClient:       gitHubWebhookClient{},
 		receiveAdapterImage: raImage,
 	}
@@ -74,6 +77,11 @@ func NewController(
 
 	serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controller.FilterGroupKind(v1alpha1.Kind("GitHubSource")),
+		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
+	})
+
+	eventTypeInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+		FilterFunc: controller.FilterGroupKind(v1alpha1.Kind("CouchDbSource")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 


### PR DESCRIPTION
- 🧽 Update or clean up current behavior

I'd removed this in my previous PR, but I realized looking through couchdb that the reason the eventTypeInformer was unused (other than events) is because the github source was breaking our pattern of listing/fetching through the lister instead of the client (which it gets through reconciler.Base).

This reverts the informer event bits, and makes the object fetches go through the lister for consistency with out best practices.