### PR TITLE
Support for GitHubSource + auto-TLS

### DIFF
--- a/github/pkg/apis/sources/v1alpha1/githubsource_types.go
+++ b/github/pkg/apis/sources/v1alpha1/githubsource_types.go
@@ -79,9 +79,12 @@ type GitHubSourceSpec struct {
 	// +optional
 	GitHubAPIURL string `json:"githubAPIURL,omitempty"`
 
-	// Secure can be set to true to configure the webhook to use https.
+	// Secure can be set to true to configure the webhook to use https,
+	// or false to use http.  Omitting it relies on the scheme of the
+	// Knative Service created (e.g. if auto-TLS is enabled it should
+	// do the right thing).
 	// +optional
-	Secure bool `json:"secure,omitempty"`
+	Secure *bool `json:"secure,omitempty"`
 }
 
 // SecretValueFromSource represents the source of a secret value

--- a/github/pkg/apis/sources/v1alpha1/zz_generated.deepcopy.go
+++ b/github/pkg/apis/sources/v1alpha1/zz_generated.deepcopy.go
@@ -102,6 +102,11 @@ func (in *GitHubSourceSpec) DeepCopyInto(out *GitHubSourceSpec) {
 		*out = new(v1beta1.Destination)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Secure != nil {
+		in, out := &in.Secure, &out.Secure
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
This makes the `secure:` bit in spec a pointer so that we can distinguish between `false` and unspecified.  When unspecified, we rely on the scheme of the underlying Knative Service.

- 🐛 Fix bug
Fixes: https://github.com/knative/eventing-contrib/issues/995