### PR TITLE
Don't advance the consumer group when events can't be delivered.

### DIFF
--- a/kafka/channel/pkg/dispatcher/dispatcher.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher.go
@@ -81,7 +81,9 @@ type consumerMessageHandler struct {
 
 func (c consumerMessageHandler) Handle(ctx context.Context, message *sarama.ConsumerMessage) (bool, error) {
 	event := fromKafkaMessage(ctx, message)
-	return true, c.dispatcher.DispatchEventWithDelivery(ctx, *event, c.sub.SubscriberURI, c.sub.ReplyURI, &c.sub.Delivery)
+	err := c.dispatcher.DispatchEventWithDelivery(ctx, *event, c.sub.SubscriberURI, c.sub.ReplyURI, &c.sub.Delivery)
+	// NOTE: only return `true` here if DispatchEventWithDelivery actually delivered the message.
+	return err == nil, err
 }
 
 var _ kafka.KafkaConsumerHandler = (*consumerMessageHandler)(nil)


### PR DESCRIPTION
Fixes reported issue in #eventing

We shouldn't advance a consumer group in Kafka until the downstream has accepted it, or we may drop events.

NOTE: no tests seemed to cover this case. I'm happy to try adding a test in a bit, but Alejandro Saucedo in slack wanted to see the change.

## Proposed Changes

- `Handle()` is supposed to return `true` only when the message has been successfully delivered, but the channel hard-wired it to always return true, even if the delivery returned an error (failure).

**Release Note**

```release-note
- 🐛 🧽 Fixed a case where the Kafka channel could drop messages if the recipient was unavailable.
```

**Docs**

No documentation changes needed, as the intended behavior of the Kafka channel was to not drop messages.
