### PR TITLE
Ported KafkaSource to bindings api

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -160,9 +160,10 @@
   version = "v0.2.1"
 
 [[projects]]
-  digest = "1:057b1bb73cf9a503259344a26be36e952431324e9b756476849331faff855253"
+  digest = "1:a67f2a10845f71cba502dfa3b0bf51b8bfab013baec82d9105248012bb502a6f"
   name = "github.com/cloudevents/sdk-go"
   packages = [
+    ".",
     "legacy",
     "legacy/pkg/cloudevents",
     "legacy/pkg/cloudevents/client",
@@ -176,6 +177,24 @@
     "legacy/pkg/cloudevents/transport",
     "legacy/pkg/cloudevents/transport/http",
     "legacy/pkg/cloudevents/types",
+    "pkg/binding",
+    "pkg/binding/buffering",
+    "pkg/binding/format",
+    "pkg/binding/spec",
+    "pkg/binding/transformer",
+    "pkg/client",
+    "pkg/context",
+    "pkg/event",
+    "pkg/event/datacodec",
+    "pkg/event/datacodec/json",
+    "pkg/event/datacodec/text",
+    "pkg/event/datacodec/xml",
+    "pkg/extensions",
+    "pkg/observability",
+    "pkg/protocol",
+    "pkg/protocol/http",
+    "pkg/protocol/kafka_sarama",
+    "pkg/types",
   ]
   pruneopts = "NUT"
   revision = "f248e160418f3e881491fdc3a60ea83660e30b37"
@@ -923,6 +942,14 @@
   pruneopts = "NUT"
   revision = "9c95632b3e8562be6df690c639a3f5a6f40d3004"
   version = "v12.7.0"
+
+[[projects]]
+  digest = "1:af354641f23332b1a8d5d361d11b5a9171589e412a67d499633706c611acc064"
+  name = "github.com/valyala/bytebufferpool"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "e746df99fe4a3986f4d4f79e13c1e0117ce9c2f7"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:02e30e07738464b40c5c6fa23a84ee639a36203a09d87f23baa5dfe814b22840"
@@ -1855,7 +1882,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4c7a494c3b5c8c78e11a444cbfd8a7e37eae42ebbf9ef149894f7708cd722b54"
+  digest = "1:4afcd9bc3e6363846ca1caaa615af7d2394df5c2ca0cfa6db1853c82f3f30b19"
   name = "knative.dev/eventing"
   packages = [
     "pkg/adapter",
@@ -1963,11 +1990,11 @@
     "test/test_images/transformevents",
   ]
   pruneopts = "UT"
-  revision = "be3c74c3195a74dcaa3eecff014e7d9fa4668dac"
+  revision = "8ce1b8084c9055ae24c7b0d8ca22f99d6907558d"
 
 [[projects]]
   branch = "master"
-  digest = "1:73d6a1f3f7a178275499102ae27b5177a91aaccc57e3a0328e628cb3ced708f8"
+  digest = "1:7fce3b5a8d117763efbf4b6b9862940a5472d276022b0b324b39b70ef4fa77bd"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -2041,11 +2068,11 @@
     "webhook/resourcesemantics/validation",
   ]
   pruneopts = "T"
-  revision = "be54585f8f04fe39ce6b6d28d78809818b724734"
+  revision = "42d1b005c814b8f9ea786ff89c90c91448c1417a"
 
 [[projects]]
   branch = "master"
-  digest = "1:73213c4432c04764cf0f770e61c9dc9191420d57f39b538df940df97ef2082ff"
+  digest = "1:8dc739cc25ba035aff7ddc063361c396f96a236f887d5fc70353502cb5447cc1"
   name = "knative.dev/serving"
   packages = [
     "pkg/apis/autoscaling",
@@ -2085,7 +2112,7 @@
     "pkg/client/listers/serving/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "54766747d729079cb0c08cd197947af8f76dc42c"
+  revision = "0264fb04288d994cbfd847feea9491d86d739f6d"
 
 [[projects]]
   branch = "master"
@@ -2096,7 +2123,7 @@
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "01c075fbeae4b089793fcca6fc855d31e1628cad"
+  revision = "244b563932f959a3e18c1e03cffed8798f52d59d"
 
 [[projects]]
   digest = "1:fc6463b2db1240176327f3c259d3c7101e8340e2e8a6368fc39d69e9967bd8af"
@@ -2182,11 +2209,16 @@
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/sqs",
+    "github.com/cloudevents/sdk-go",
     "github.com/cloudevents/sdk-go/legacy",
     "github.com/cloudevents/sdk-go/legacy/pkg/cloudevents",
     "github.com/cloudevents/sdk-go/legacy/pkg/cloudevents/client",
     "github.com/cloudevents/sdk-go/legacy/pkg/cloudevents/transport/http",
     "github.com/cloudevents/sdk-go/legacy/pkg/cloudevents/types",
+    "github.com/cloudevents/sdk-go/pkg/binding",
+    "github.com/cloudevents/sdk-go/pkg/protocol/http",
+    "github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama",
+    "github.com/cloudevents/sdk-go/pkg/types",
     "github.com/emicklei/go-restful",
     "github.com/go-kivik/couchdb",
     "github.com/go-kivik/kivik",

--- a/kafka/source/cmd/receive_adapter/main.go
+++ b/kafka/source/cmd/receive_adapter/main.go
@@ -22,5 +22,5 @@ import (
 )
 
 func main() {
-	adapter.Main("kafkasource", kadapter.NewEnvConfig, kadapter.NewAdapter)
+	adapter.MainBindings("kafkasource", kadapter.NewEnvConfig, kadapter.NewAdapter)
 }

--- a/kafka/source/cmd/receive_adapter/main.go
+++ b/kafka/source/cmd/receive_adapter/main.go
@@ -22,5 +22,5 @@ import (
 )
 
 func main() {
-	adapter.MainBindings("kafkasource", kadapter.NewEnvConfig, kadapter.NewAdapter)
+	adapter.MainMessageAdapter("kafkasource", kadapter.NewEnvConfig, kadapter.NewAdapter)
 }

--- a/kafka/source/pkg/adapter/adapter.go
+++ b/kafka/source/pkg/adapter/adapter.go
@@ -167,7 +167,7 @@ func (a *Adapter) Handle(ctx context.Context, msg *sarama.ConsumerMessage) (bool
 		return false, err
 	}
 
-	err = a.ConsumerMessageToHttpRequest(ctx, msg, req)
+	err = a.ConsumerMessageToHttpRequest(ctx, msg, req, a.logger)
 	if err != nil {
 		return true, err
 	}

--- a/kafka/source/pkg/adapter/adapter.go
+++ b/kafka/source/pkg/adapter/adapter.go
@@ -82,7 +82,10 @@ type Adapter struct {
 	keyTypeMapper     func([]byte) interface{}
 }
 
-func NewAdapter(ctx context.Context, processed adapter.EnvConfigAccessor, httpMessageSender *kncloudevents.HttpMessageSender, reporter source.StatsReporter) adapter.Adapter {
+var _ adapter.MessageAdapter = (*Adapter)(nil)
+var _ adapter.MessageAdapterConstructor = NewAdapter
+
+func NewAdapter(ctx context.Context, processed adapter.EnvConfigAccessor, httpMessageSender *kncloudevents.HttpMessageSender, reporter source.StatsReporter) adapter.MessageAdapter {
 	logger := logging.FromContext(ctx).Desugar()
 	config := processed.(*adapterConfig)
 

--- a/kafka/source/pkg/adapter/adapter.go
+++ b/kafka/source/pkg/adapter/adapter.go
@@ -17,29 +17,20 @@ limitations under the License.
 package kafka
 
 import (
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/binary"
-	"encoding/json"
-	"fmt"
-	"math"
-	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
 	"knative.dev/eventing/pkg/adapter"
+	"knative.dev/eventing/pkg/kncloudevents"
 	"knative.dev/pkg/source"
-
-	"knative.dev/eventing-contrib/kafka/common/pkg/kafka"
-	sourcesv1alpha1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1"
 
 	"context"
 
+	"knative.dev/eventing-contrib/kafka/common/pkg/kafka"
+
 	"github.com/Shopify/sarama"
-	cloudevents "github.com/cloudevents/sdk-go/legacy"
-	"github.com/cloudevents/sdk-go/legacy/pkg/cloudevents/client"
 	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
 )
@@ -82,23 +73,23 @@ func NewEnvConfig() adapter.EnvConfigAccessor {
 }
 
 type Adapter struct {
-	config        *adapterConfig
-	ceClient      client.Client
-	reporter      source.StatsReporter
-	logger        *zap.Logger
-	keyTypeMapper func([]byte) interface{}
+	config             *adapterConfig
+	httpBindingsSender *kncloudevents.HttpBindingSender
+	reporter           source.StatsReporter
+	logger             *zap.Logger
+	keyTypeMapper      func([]byte) interface{}
 }
 
-func NewAdapter(ctx context.Context, processed adapter.EnvConfigAccessor, ceClient client.Client, reporter source.StatsReporter) adapter.Adapter {
+func NewAdapter(ctx context.Context, processed adapter.EnvConfigAccessor, httpBindingsSender *kncloudevents.HttpBindingSender, reporter source.StatsReporter) adapter.Adapter {
 	logger := logging.FromContext(ctx).Desugar()
 	config := processed.(*adapterConfig)
 
 	return &Adapter{
-		config:        config,
-		ceClient:      ceClient,
-		reporter:      reporter,
-		logger:        logger,
-		keyTypeMapper: getKeyTypeMapper(config.KeyType),
+		config:             config,
+		httpBindingsSender: httpBindingsSender,
+		reporter:           reporter,
+		logger:             logger,
+		keyTypeMapper:      getKeyTypeMapper(config.KeyType),
 	}
 }
 
@@ -166,39 +157,17 @@ func (a *Adapter) Start(stopCh <-chan struct{}) error {
 // --------------------------------------------------------------------
 
 func (a *Adapter) Handle(ctx context.Context, msg *sarama.ConsumerMessage) (bool, error) {
-	var err error
-	event := cloudevents.NewEvent(cloudevents.VersionV1)
-
-	if strings.Contains(getContentType(msg), "application/cloudevents+json") {
-		err = json.Unmarshal(msg.Value, &event)
-	} else {
-		// Check if payload is a valid json
-		if !json.Valid(msg.Value) {
-			return true, nil // Message is malformed, commit the offset so it won't be reprocessed
-		}
-
-		event.SetID(makeEventId(msg.Partition, msg.Offset))
-		event.SetTime(msg.Timestamp)
-		event.SetType(sourcesv1alpha1.KafkaEventType)
-		event.SetSource(sourcesv1alpha1.KafkaEventSource(a.config.Namespace, a.config.Name, msg.Topic))
-		event.SetSubject(makeEventSubject(msg.Partition, msg.Offset))
-		event.SetDataContentType(cloudevents.ApplicationJSON)
-
-		dumpKafkaMetaToEvent(&event, a.keyTypeMapper, msg)
-
-		err = event.SetData(msg.Value)
-	}
-
+	req, err := a.httpBindingsSender.NewCloudEventRequest()
 	if err != nil {
-		return true, err // Message is malformed, commit the offset so it won't be reprocessed
+		return false, err
 	}
 
-	// Check before writing log since event.String() allocates and uses a lot of time
-	if ce := a.logger.Check(zap.DebugLevel, "debugging"); ce != nil {
-		a.logger.Debug("Sending cloud event", zap.String("event", event.String()))
+	err = a.ConsumerMessageToHttpRequest(ctx, msg, req)
+	if err != nil {
+		return true, err
 	}
 
-	rctx, _, err := a.ceClient.Send(ctx, event)
+	res, err := a.httpBindingsSender.Send(ctx, req)
 
 	if err != nil {
 		a.logger.Debug("Error while sending the message", zap.Error(err))
@@ -207,13 +176,11 @@ func (a *Adapter) Handle(ctx context.Context, msg *sarama.ConsumerMessage) (bool
 
 	reportArgs := &source.ReportArgs{
 		Namespace:     a.config.Namespace,
-		EventSource:   event.Source(),
-		EventType:     event.Type(),
 		Name:          a.config.Name,
 		ResourceGroup: resourceGroup,
 	}
 
-	_ = a.reporter.ReportEventCount(reportArgs, cloudevents.HTTPTransportContextFrom(rctx).StatusCode)
+	_ = a.reporter.ReportEventCount(reportArgs, res.StatusCode)
 	return true, nil
 }
 
@@ -250,89 +217,6 @@ func newTLSConfig(clientCert, clientKey, caCert string) (*tls.Config, error) {
 	}
 
 	return config, nil
-}
-
-func makeEventId(partition int32, offset int64) string {
-	return fmt.Sprintf("partition:%s/offset:%s", strconv.Itoa(int(partition)), strconv.FormatInt(offset, 10))
-}
-
-// KafkaEventSubject returns the Kafka CloudEvent subject of the message.
-func makeEventSubject(partition int32, offset int64) string {
-	return fmt.Sprintf("partition:%d#%d", partition, offset)
-}
-
-func getContentType(msg *sarama.ConsumerMessage) string {
-	for _, h := range msg.Headers {
-		if bytes.Equal(h.Key, []byte("content-type")) {
-			return string(h.Value)
-		}
-	}
-	return ""
-}
-
-var replaceBadCharacters = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString
-
-func dumpKafkaMetaToEvent(event *cloudevents.Event, keyTypeMapper func([]byte) interface{}, msg *sarama.ConsumerMessage) {
-	if msg.Key != nil {
-		event.SetExtension("key", keyTypeMapper(msg.Key))
-	}
-	for _, h := range msg.Headers {
-		event.SetExtension("kafkaheader"+replaceBadCharacters(string(h.Key), ""), string(h.Value))
-	}
-}
-
-func getKeyTypeMapper(keyType string) func([]byte) interface{} {
-	var keyTypeMapper func([]byte) interface{}
-	switch keyType {
-	case "int":
-		keyTypeMapper = func(by []byte) interface{} {
-			// Took from https://github.com/axbaretto/kafka/blob/master/clients/src/main/java/org/apache/kafka/common/serialization/LongDeserializer.java
-			if len(by) == 4 {
-				var res int32
-				for _, b := range by {
-					res <<= 8
-					res |= int32(b & 0xFF)
-				}
-				return res
-			} else if len(by) == 8 {
-				var res int64
-				for _, b := range by {
-					res <<= 8
-					res |= int64(b & 0xFF)
-				}
-				return res
-			} else {
-				// Fallback to byte array
-				return by
-			}
-		}
-	case "float":
-		keyTypeMapper = func(by []byte) interface{} {
-			// BigEndian is specified in https://kafka.apache.org/protocol#protocol_types
-			// Number is converted to string because
-			if len(by) == 4 {
-				intermediate := binary.BigEndian.Uint32(by)
-				fl := math.Float32frombits(intermediate)
-				return strconv.FormatFloat(float64(fl), 'f', -1, 64)
-			} else if len(by) == 8 {
-				intermediate := binary.BigEndian.Uint64(by)
-				fl := math.Float64frombits(intermediate)
-				return strconv.FormatFloat(fl, 'f', -1, 64)
-			} else {
-				// Fallback to byte array
-				return by
-			}
-		}
-	case "byte-array":
-		keyTypeMapper = func(bytes []byte) interface{} {
-			return bytes
-		}
-	default:
-		keyTypeMapper = func(bytes []byte) interface{} {
-			return string(bytes)
-		}
-	}
-	return keyTypeMapper
 }
 
 // verifyCertSkipHostname verifies certificates in the same way that the

--- a/kafka/source/pkg/adapter/adapter_benchmark_test.go
+++ b/kafka/source/pkg/adapter/adapter_benchmark_test.go
@@ -17,16 +17,18 @@ limitations under the License.
 package kafka
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
-	"net/http/httptest"
 	"strconv"
 	"testing"
 	"time"
 
 	"knative.dev/eventing/pkg/adapter"
 	"knative.dev/eventing/pkg/kncloudevents"
+	"knative.dev/pkg/source"
 
 	"github.com/Shopify/sarama"
 	"go.uber.org/zap"
@@ -34,31 +36,46 @@ import (
 
 // Run with go test -v ./kafka/source/pkg/adapter/ -gcflags="-N -l" -test.benchtime 2s -benchmem -run=Handle -bench=.
 
-type benchHandler struct{}
+type RoundTripFunc func(req *http.Request) *http.Response
 
-func (b benchHandler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
-	writer.WriteHeader(http.StatusOK)
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(fn),
+	}
 }
 
 func BenchmarkHandle(b *testing.B) {
-	// Start receiving server
-	sinkServer := httptest.NewServer(benchHandler{})
-	defer sinkServer.Close()
+	sinkUrl := "http://localhost:8080" // This address doesn't matter, it's not used b/c we mock the client transport
 
 	data, err := json.Marshal(map[string]string{"key": "value"})
 	if err != nil {
 		b.Errorf("unexpected error, %v", err)
 	}
 
-	s, err := kncloudevents.NewHttpMessageSender(nil, sinkServer.URL)
+	s := kncloudevents.HttpMessageSender{
+		Client: NewTestClient(func(req *http.Request) *http.Response {
+			return &http.Response{
+				StatusCode: 202,
+				Header:     make(http.Header),
+				Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
+			}
+		}),
+		Target: sinkUrl,
+	}
 	if err != nil {
 		b.Fatal(err)
 	}
 
+	statsReporter, _ := source.NewStatsReporter()
+
 	a := &Adapter{
 		config: &adapterConfig{
 			EnvConfig: adapter.EnvConfig{
-				SinkURI:   sinkServer.URL,
+				SinkURI:   sinkUrl,
 				Namespace: "test",
 			},
 			Topics:           "topic1,topic2",
@@ -67,9 +84,10 @@ func BenchmarkHandle(b *testing.B) {
 			Name:             "test",
 			Net:              AdapterNet{},
 		},
-		httpMessageSender: s,
+		httpMessageSender: &s,
 		logger:            zap.NewNop(),
 		keyTypeMapper:     getKeyTypeMapper(""),
+		reporter:          statsReporter,
 	}
 	b.SetParallelism(1)
 	b.Run("Baseline", func(b *testing.B) {

--- a/kafka/source/pkg/adapter/message.go
+++ b/kafka/source/pkg/adapter/message.go
@@ -1,0 +1,141 @@
+package kafka
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	nethttp "net/http"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/Shopify/sarama"
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/bindings/http"
+	"github.com/cloudevents/sdk-go/pkg/bindings/kafka_sarama"
+
+	sourcesv1alpha1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1"
+)
+
+var transformerFactories = binding.TransformerFactories{}
+
+func (a *Adapter) ConsumerMessageToHttpRequest(ctx context.Context, cm *sarama.ConsumerMessage, req *nethttp.Request) error {
+	msg, err := kafka_sarama.NewMessage(cm)
+	if err != nil {
+		return err
+	}
+
+	if msg.Encoding() != binding.EncodingUnknown {
+		// Message is a CloudEvent -> Encode directly to HTTP
+		return http.EncodeHttpRequest(ctx, msg, req, transformerFactories)
+	}
+
+	// Message is not a CloudEvent -> We need to translate it to a valid CloudEvent
+	kafkaMsg := msg.(*kafka_sarama.Message)
+
+	var event cloudevents.Event
+
+	event.SetID(makeEventId(cm.Partition, cm.Offset))
+	event.SetTime(cm.Timestamp)
+	event.SetType(sourcesv1alpha1.KafkaEventType)
+	event.SetSource(sourcesv1alpha1.KafkaEventSource(a.config.Namespace, a.config.Name, cm.Topic))
+	event.SetSubject(makeEventSubject(cm.Partition, cm.Offset))
+
+	dumpKafkaMetaToEvent(&event, a.keyTypeMapper, kafkaMsg)
+
+	if kafkaMsg.ContentType != "" {
+		event.SetDataContentType(kafkaMsg.ContentType)
+	}
+
+	err = event.SetData(kafkaMsg.Value)
+	if err != nil {
+		return err
+	}
+
+	return http.EncodeHttpRequest(ctx, binding.EventMessage(event), req, transformerFactories)
+}
+
+func makeEventId(partition int32, offset int64) string {
+	var str strings.Builder
+	str.WriteString("partition:")
+	str.WriteString(strconv.Itoa(int(partition)))
+	str.WriteString("/offset:")
+	str.WriteString(strconv.FormatInt(offset, 10))
+	return str.String()
+}
+
+// KafkaEventSubject returns the Kafka CloudEvent subject of the message.
+func makeEventSubject(partition int32, offset int64) string {
+	var str strings.Builder
+	str.WriteString("partition:")
+	str.WriteString(strconv.Itoa(int(partition)))
+	str.WriteByte('#')
+	str.WriteString(strconv.FormatInt(offset, 10))
+	return str.String()
+}
+
+var replaceBadCharacters = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString
+
+func dumpKafkaMetaToEvent(event *cloudevents.Event, keyTypeMapper func([]byte) interface{}, msg *kafka_sarama.Message) {
+	if msg.Key != nil {
+		event.SetExtension("key", keyTypeMapper(msg.Key))
+	}
+	for k, v := range msg.Headers {
+		event.SetExtension("kafkaheader"+replaceBadCharacters(k, ""), string(v))
+	}
+}
+
+func getKeyTypeMapper(keyType string) func([]byte) interface{} {
+	var keyTypeMapper func([]byte) interface{}
+	switch keyType {
+	case "int":
+		keyTypeMapper = func(by []byte) interface{} {
+			// Took from https://github.com/axbaretto/kafka/blob/master/clients/src/main/java/org/apache/kafka/common/serialization/LongDeserializer.java
+			if len(by) == 4 {
+				var res int32
+				for _, b := range by {
+					res <<= 8
+					res |= int32(b & 0xFF)
+				}
+				return res
+			} else if len(by) == 8 {
+				var res int64
+				for _, b := range by {
+					res <<= 8
+					res |= int64(b & 0xFF)
+				}
+				return res
+			} else {
+				// Fallback to byte array
+				return by
+			}
+		}
+	case "float":
+		keyTypeMapper = func(by []byte) interface{} {
+			// BigEndian is specified in https://kafka.apache.org/protocol#protocol_types
+			// Number is converted to string because
+			if len(by) == 4 {
+				intermediate := binary.BigEndian.Uint32(by)
+				fl := math.Float32frombits(intermediate)
+				return strconv.FormatFloat(float64(fl), 'f', -1, 64)
+			} else if len(by) == 8 {
+				intermediate := binary.BigEndian.Uint64(by)
+				fl := math.Float64frombits(intermediate)
+				return strconv.FormatFloat(fl, 'f', -1, 64)
+			} else {
+				// Fallback to byte array
+				return by
+			}
+		}
+	case "byte-array":
+		keyTypeMapper = func(bytes []byte) interface{} {
+			return bytes
+		}
+	default:
+		keyTypeMapper = func(bytes []byte) interface{} {
+			return string(bytes)
+		}
+	}
+	return keyTypeMapper
+}

--- a/kafka/source/pkg/adapter/message.go
+++ b/kafka/source/pkg/adapter/message.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package kafka
 
 import (

--- a/third_party/VENDOR-LICENSE
+++ b/third_party/VENDOR-LICENSE
@@ -7509,6 +7509,34 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ===========================================================
+Import: knative.dev/eventing-contrib/vendor/github.com/valyala/bytebufferpool
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Aliaksandr Valialkin, VertaMedia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+
+
+===========================================================
 Import: knative.dev/eventing-contrib/vendor/github.com/xanzy/go-gitlab
 
                                  Apache License

--- a/vendor/github.com/cloudevents/sdk-go/alias.go
+++ b/vendor/github.com/cloudevents/sdk-go/alias.go
@@ -1,0 +1,145 @@
+package cloudevents
+
+// Package cloudevents alias' common functions and types to improve discoverability and reduce
+// the number of imports for simple HTTP clients.
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/client"
+	"github.com/cloudevents/sdk-go/pkg/context"
+	"github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/cloudevents/sdk-go/pkg/observability"
+	"github.com/cloudevents/sdk-go/pkg/protocol"
+	"github.com/cloudevents/sdk-go/pkg/protocol/http"
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+// Client
+
+type ClientOption client.Option
+type Client = client.Client
+
+// Event
+
+type Event = event.Event
+
+// Context
+
+type EventContext = event.EventContext
+type EventContextV1 = event.EventContextV1
+type EventContextV03 = event.EventContextV03
+
+// Custom Types
+
+type Timestamp = types.Timestamp
+type URIRef = types.URIRef
+
+// HTTP Protocol
+
+type HTTPOption http.Option
+
+type HTTPProtocol = http.Protocol
+
+// Encoding
+
+type Encoding = binding.Encoding
+
+// Message
+
+type Message = binding.Message
+
+const (
+	// ReadEncoding
+
+	ApplicationXML                  = event.ApplicationXML
+	ApplicationJSON                 = event.ApplicationJSON
+	TextPlain                       = event.TextPlain
+	ApplicationCloudEventsJSON      = event.ApplicationCloudEventsJSON
+	ApplicationCloudEventsBatchJSON = event.ApplicationCloudEventsBatchJSON
+	Base64                          = event.Base64
+
+	// Event Versions
+
+	VersionV1  = event.CloudEventsVersionV1
+	VersionV03 = event.CloudEventsVersionV03
+
+	// Encoding
+
+	EncodingBinary     = binding.EncodingBinary
+	EncodingStructured = binding.EncodingStructured
+)
+
+var (
+
+	// ContentType Helpers
+
+	StringOfApplicationJSON                 = event.StringOfApplicationJSON
+	StringOfApplicationXML                  = event.StringOfApplicationXML
+	StringOfTextPlain                       = event.StringOfTextPlain
+	StringOfApplicationCloudEventsJSON      = event.StringOfApplicationCloudEventsJSON
+	StringOfApplicationCloudEventsBatchJSON = event.StringOfApplicationCloudEventsBatchJSON
+	StringOfBase64                          = event.StringOfBase64
+
+	// Client Creation
+
+	NewClient             = client.New
+	NewClientObserved     = client.NewObserved
+	NewDefaultClient      = client.NewDefault
+	NewHTTPReceiveHandler = client.NewHTTPReceiveHandler
+
+	// Client Options
+
+	WithEventDefaulter   = client.WithEventDefaulter
+	WithUUIDs            = client.WithUUIDs
+	WithTimeNow          = client.WithTimeNow
+	WithTracePropagation = client.WithTracePropagation()
+
+	// Event Creation
+
+	NewEvent  = event.New
+	NewResult = protocol.NewResult
+
+	NewHTTPResult = http.NewResult
+
+	// Message Creation
+
+	ToMessage = binding.ToMessage
+
+	// HTTP Messages
+
+	WriteHTTPRequest = http.WriteRequest
+
+	// Tracing
+
+	EnableTracing = observability.EnableTracing
+
+	// Context
+
+	ContextWithTarget      = context.WithTarget
+	TargetFromContext      = context.TargetFrom
+	WithEncodingBinary     = binding.WithForceBinary
+	WithEncodingStructured = binding.WithForceStructured
+
+	// Custom Types
+
+	ParseTimestamp = types.ParseTimestamp
+	ParseURIRef    = types.ParseURIRef
+	ParseURI       = types.ParseURI
+
+	// HTTP Protocol
+
+	NewHTTP = http.New
+
+	// HTTP Protocol Options
+
+	WithTarget          = http.WithTarget
+	WithHeader          = http.WithHeader
+	WithShutdownTimeout = http.WithShutdownTimeout
+	//WithEncoding           = http.WithEncoding
+	//WithStructuredEncoding = http.WithStructuredEncoding // TODO: expose new way
+	WithPort          = http.WithPort
+	WithPath          = http.WithPath
+	WithMiddleware    = http.WithMiddleware
+	WithListener      = http.WithListener
+	WithHTTPTransport = http.WithHTTPTransport
+)

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/binary_writer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/binary_writer.go
@@ -1,0 +1,39 @@
+package binding
+
+import (
+	"context"
+	"io"
+
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+)
+
+// BinaryWriter is used to visit a binary Message and generate a new representation.
+//
+// Protocols that supports binary encoding should implement this interface to implement direct
+// binary to binary encoding and event to binary encoding.
+//
+// Start() and End() methods are invoked every time this BinaryWriter implementation is used to visit a Message
+type BinaryWriter interface {
+	// Method invoked at the beginning of the visit. Useful to perform initial memory allocations
+	Start(ctx context.Context) error
+
+	// Set a standard attribute.
+	//
+	// The value can either be the correct golang type for the attribute, or a canonical
+	// string encoding. See package types to perform the needed conversions
+	SetAttribute(attribute spec.Attribute, value interface{}) error
+
+	// Set an extension attribute.
+	//
+	// The value can either be the correct golang type for the attribute, or a canonical
+	// string encoding. See package types to perform the needed conversions
+	SetExtension(name string, value interface{}) error
+
+	// SetData receives an io.Reader for the data attribute.
+	// io.Reader is not invoked when the data attribute is empty
+	SetData(data io.Reader) error
+
+	// End method is invoked only after the whole encoding process ends successfully.
+	// If it fails, it's never invoked. It can be used to finalize the message.
+	End(ctx context.Context) error
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/buffering/acks_before_finish_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/buffering/acks_before_finish_message.go
@@ -1,0 +1,33 @@
+package buffering
+
+import (
+	"sync/atomic"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+)
+
+type acksMessage struct {
+	binding.Message
+	requiredAcks int32
+}
+
+func (m *acksMessage) GetWrappedMessage() binding.Message {
+	return m.Message
+}
+
+func (m *acksMessage) Finish(err error) error {
+	remainingAcks := atomic.AddInt32(&m.requiredAcks, -1)
+	if remainingAcks == 0 {
+		return m.Message.Finish(err)
+	}
+	return nil
+}
+
+var _ binding.MessageWrapper = (*acksMessage)(nil)
+
+// WithAcksBeforeFinish returns a wrapper for m that calls m.Finish()
+// only after the specified number of acks are received.
+// Use it when you need to dispatch a Message using several Sender instances
+func WithAcksBeforeFinish(m binding.Message, requiredAcks int) binding.Message {
+	return &acksMessage{Message: m, requiredAcks: int32(requiredAcks)}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/buffering/binary_buffer_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/buffering/binary_buffer_message.go
@@ -1,0 +1,106 @@
+package buffering
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/valyala/bytebufferpool"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+)
+
+var binaryMessagePool bytebufferpool.Pool
+
+// binaryBufferedMessage implements a binary-mode message as a simple struct.
+// This message implementation is used by CopyMessage and BufferMessage
+type binaryBufferedMessage struct {
+	metadata   map[spec.Attribute]interface{}
+	extensions map[string]interface{}
+	body       *bytebufferpool.ByteBuffer
+}
+
+func (m *binaryBufferedMessage) Start(ctx context.Context) error {
+	m.metadata = make(map[spec.Attribute]interface{}, 4)
+	m.extensions = make(map[string]interface{})
+	return nil
+}
+
+func (m *binaryBufferedMessage) End(ctx context.Context) error {
+	return nil
+}
+
+func (m *binaryBufferedMessage) GetParent() binding.Message {
+	return nil
+}
+
+func (m *binaryBufferedMessage) ReadEncoding() binding.Encoding {
+	return binding.EncodingBinary
+}
+
+func (m *binaryBufferedMessage) ReadStructured(context.Context, binding.StructuredWriter) error {
+	return binding.ErrNotStructured
+}
+
+func (m *binaryBufferedMessage) ReadBinary(ctx context.Context, b binding.BinaryWriter) (err error) {
+	err = b.Start(ctx)
+	if err != nil {
+		return
+	}
+	for k, v := range m.metadata {
+		err = b.SetAttribute(k, v)
+		if err != nil {
+			return
+		}
+	}
+	for k, v := range m.extensions {
+		err = b.SetExtension(k, v)
+		if err != nil {
+			return
+		}
+	}
+	if m.body != nil {
+		err = b.SetData(bytes.NewReader(m.body.Bytes()))
+		if err != nil {
+			return
+		}
+	}
+	return b.End(ctx)
+}
+
+func (b *binaryBufferedMessage) Finish(error) error {
+	if b.body != nil {
+		binaryMessagePool.Put(b.body)
+	}
+	return nil
+}
+
+// Binary Encoder
+func (b *binaryBufferedMessage) SetData(data io.Reader) error {
+	buf := binaryMessagePool.Get()
+	w, err := io.Copy(buf, data)
+	if err != nil {
+		return err
+	}
+	if w == 0 {
+		binaryMessagePool.Put(buf)
+		return nil
+	}
+	b.body = buf
+	return nil
+}
+
+func (b *binaryBufferedMessage) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	// If spec version we need to change to right context struct
+	b.metadata[attribute] = value
+	return nil
+}
+
+func (b *binaryBufferedMessage) SetExtension(name string, value interface{}) error {
+	b.extensions[name] = value
+	return nil
+}
+
+var _ binding.Message = (*binaryBufferedMessage)(nil) // Test it conforms to the interface
+var _ binding.BinaryWriter = (*binaryBufferedMessage)(nil)

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/buffering/copy_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/buffering/copy_message.go
@@ -1,0 +1,53 @@
+package buffering
+
+import (
+	"context"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+)
+
+// BufferMessage works the same as CopyMessage and it also bounds the original Message
+// lifecycle to the newly created message: calling Finish() on the returned message calls m.Finish().
+// transformers can be nil and this function guarantees that they are invoked only once during the encoding process.
+func BufferMessage(ctx context.Context, m binding.Message, transformers binding.TransformerFactories) (binding.Message, error) {
+	result, err := CopyMessage(ctx, m, transformers)
+	if err != nil {
+		return nil, err
+	}
+	return binding.WithFinish(result, func(err error) { _ = m.Finish(err) }), nil
+}
+
+// CopyMessage reads m once and creates an in-memory copy depending on the encoding of m.
+// The returned copy is not dependent on any transport and can be visited many times.
+// When the copy can be forgot, the copied message must be finished with Finish() message to release the memory.
+// transformers can be nil and this function guarantees that they are invoked only once during the encoding process.
+func CopyMessage(ctx context.Context, m binding.Message, transformers binding.TransformerFactories) (binding.Message, error) {
+	originalMessageEncoding := m.ReadEncoding()
+
+	if originalMessageEncoding == binding.EncodingUnknown {
+		return nil, binding.ErrUnknownEncoding
+	}
+	if originalMessageEncoding == binding.EncodingEvent {
+		e, err := binding.ToEvent(ctx, m, transformers...)
+		if err != nil {
+			return nil, err
+		}
+		return (*binding.EventMessage)(e), nil
+	}
+
+	sm := structBufferedMessage{}
+	bm := binaryBufferedMessage{}
+
+	encoding, err := binding.DirectWrite(ctx, m, &sm, &bm, transformers)
+	if encoding == binding.EncodingStructured {
+		return &sm, err
+	} else if encoding == binding.EncodingBinary {
+		return &bm, err
+	} else {
+		e, err := binding.ToEvent(ctx, m, transformers...)
+		if err != nil {
+			return nil, err
+		}
+		return (*binding.EventMessage)(e), nil
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/buffering/struct_buffer_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/buffering/struct_buffer_message.go
@@ -1,0 +1,57 @@
+package buffering
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/valyala/bytebufferpool"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+)
+
+var structMessagePool bytebufferpool.Pool
+
+// structBufferedMessage implements a structured-mode message as a simple struct.
+// This message implementation is used by CopyMessage and BufferMessage
+type structBufferedMessage struct {
+	Format format.Format
+	Bytes  *bytebufferpool.ByteBuffer
+}
+
+func (m *structBufferedMessage) GetParent() binding.Message {
+	return nil
+}
+
+func (m *structBufferedMessage) ReadEncoding() binding.Encoding {
+	return binding.EncodingStructured
+}
+
+// Structured copies structured data to a StructuredWriter
+func (m *structBufferedMessage) ReadStructured(ctx context.Context, enc binding.StructuredWriter) error {
+	return enc.SetStructuredEvent(ctx, m.Format, bytes.NewReader(m.Bytes.B))
+}
+
+// Binary returns ErrNotBinary
+func (m structBufferedMessage) ReadBinary(context.Context, binding.BinaryWriter) error {
+	return binding.ErrNotBinary
+}
+
+func (m *structBufferedMessage) Finish(error) error {
+	structMessagePool.Put(m.Bytes)
+	return nil
+}
+
+func (m *structBufferedMessage) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error {
+	m.Bytes = structMessagePool.Get()
+	_, err := io.Copy(m.Bytes, event)
+	if err != nil {
+		return err
+	}
+	m.Format = format
+	return nil
+}
+
+var _ binding.Message = (*structBufferedMessage)(nil)          // Test it conforms to the interface
+var _ binding.StructuredWriter = (*structBufferedMessage)(nil) // Test it conforms to the interface

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/chan.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/chan.go
@@ -1,0 +1,52 @@
+package binding
+
+import (
+	"context"
+	"errors"
+	"io"
+)
+
+// ChanSender implements Sender by sending Messages on a channel.
+type ChanSender chan<- Message
+
+// ChanReceiver implements Receiver by receiving Messages from a channel.
+type ChanReceiver <-chan Message
+
+func (s ChanSender) Send(ctx context.Context, m Message) (err error) {
+	defer func() {
+		err2 := m.Finish(err)
+		if err == nil {
+			err = err2
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case s <- m:
+		return nil
+	}
+}
+
+func (s ChanSender) Close(ctx context.Context) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errors.New("send on closed channel")
+		}
+	}()
+	close(s)
+	return nil
+}
+
+func (r ChanReceiver) Receive(ctx context.Context) (Message, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case m, ok := <-r:
+		if !ok {
+			return nil, io.EOF
+		}
+		return m, nil
+	}
+}
+
+func (r ChanReceiver) Close(ctx context.Context) error { return nil }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/doc.go
@@ -1,0 +1,64 @@
+package binding
+
+/*
+
+Package binding defines interfaces for protocol bindings.
+
+NOTE: Most applications that emit or consume events should use the ../client
+package, which provides a simpler API to the underlying binding.
+
+The interfaces in this package provide extra encoding and protocol information
+to allow efficient forwarding and end-to-end reliable delivery between a
+Receiver and a Sender belonging to different bindings. This is useful for
+intermediary applications that route or forward events, but not necessary for
+most "endpoint" applications that emit or consume events.
+
+Protocol Bindings
+
+A protocol binding usually implements a Message, a Sender and Receiver, a StructuredWriter and a BinaryWriter (depending on the supported encodings of the protocol) and an Write[ProtocolMessage] method.
+
+Read and write events
+
+The core of this package is the binding.Message interface.
+Through binding.MessageReader It defines how to read a protocol specific message for an
+encoded event in structured mode or binary mode.
+The entity who receives a protocol specific data structure representing a message
+(e.g. an HttpRequest) encapsulates it in a binding.Message implementation using a NewMessage method (e.g. http.NewMessage).
+Then the entity that wants to send the binding.Message back on the wire,
+translates it back to the protocol specific data structure (e.g. a Kafka ConsumerMessage), using
+the writers BinaryWriter and StructuredWriter specific to that protocol.
+Binding implementations exposes their writers
+through a specific Write[ProtocolMessage] function (e.g. kafka.EncodeProducerMessage),
+in order to simplify the encoding process.
+
+The encoding process can be customized in order to mutate the final result with binding.TransformerFactory.
+A bunch of these are provided directly by the binding/transformer module.
+
+Usually binding.Message implementations can be encoded only one time, because the encoding process drain the message itself.
+In order to consume a message several times, the binding/buffering module provides several APIs to buffer the Message.
+
+A message can be converted to an event.Event using binding.ToEvent() method.
+An event.Event can be used as Message casting it to binding.EventMessage.
+
+In order to simplify the encoding process for each protocol, this package provide several utility methods like binding.Write and binding.DirectWrite.
+The binding.Write method tries to preserve the structured/binary encoding, in order to be as much efficient as possible.
+
+Messages can be eventually wrapped to change their behaviours and binding their lifecycle, like the binding.FinishMessage.
+Every Message wrapper implements the MessageWrapper interface
+
+Sender and Receiver
+
+A Receiver receives protocol specific messages and wraps them to into binding.Message implementations.
+
+A Sender converts arbitrary Message implementations to a protocol-specific form using the protocol specific Write method
+and sends them.
+
+Message and ExactlyOnceMessage provide methods to allow acknowledgments to
+propagate when a reliable messages is forwarded from a Receiver to a Sender.
+QoS 0 (unreliable), 1 (at-least-once) and 2 (exactly-once) are supported.
+
+Transport
+
+A binding implementation providing Sender and Receiver implementations can be used as a Transport through the BindingTransport adapter.
+
+*/

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/encoding.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/encoding.go
@@ -1,0 +1,26 @@
+package binding
+
+import "errors"
+
+// Encoding enum specifies the type of encodings supported by binding interfaces
+type Encoding int
+
+const (
+	// Binary encoding as specified in https://github.com/cloudevents/spec/blob/master/spec.md#message
+	EncodingBinary Encoding = iota
+	// Structured encoding as specified in https://github.com/cloudevents/spec/blob/master/spec.md#message
+	EncodingStructured
+	// Message is an instance of EventMessage or it contains EventMessage nested (through MessageWrapper)
+	EncodingEvent
+	// When the encoding is unknown (which means that the message is a non-event)
+	EncodingUnknown
+)
+
+// Error to specify that or the Message is not an event or it is encoded with an unknown encoding
+var ErrUnknownEncoding = errors.New("unknown Message encoding")
+
+// ErrNotStructured returned by Message.Structured for non-structured messages.
+var ErrNotStructured = errors.New("message is not in structured mode")
+
+// ErrNotBinary returned by Message.Binary for non-binary messages.
+var ErrNotBinary = errors.New("message is not in binary mode")

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/event_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/event_message.go
@@ -1,0 +1,90 @@
+package binding
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/cloudevents/sdk-go/pkg/event"
+)
+
+const (
+	FORMAT_EVENT_STRUCTURED = "FORMAT_EVENT_STRUCTURED"
+)
+
+// EventMessage type-converts a event.Event object to implement Message.
+// This allows local event.Event objects to be sent directly via Sender.Send()
+//     s.Send(ctx, binding.EventMessage(e))
+// When an event is wrapped into a EventMessage, the original event could be
+// potentially mutated. If you need to use the Event again, after wrapping it into
+// an Event message, you should copy it before
+type EventMessage event.Event
+
+func ToMessage(e *event.Event) Message {
+	return (*EventMessage)(e)
+}
+
+func (m *EventMessage) ReadEncoding() Encoding {
+	return EncodingEvent
+}
+
+func (m *EventMessage) ReadStructured(ctx context.Context, builder StructuredWriter) error {
+	f := GetOrDefaultFromCtx(ctx, FORMAT_EVENT_STRUCTURED, format.JSON).(format.Format)
+	b, err := f.Marshal((*event.Event)(m))
+	if err != nil {
+		return err
+	}
+	return builder.SetStructuredEvent(ctx, f, bytes.NewReader(b))
+}
+
+func (m *EventMessage) ReadBinary(ctx context.Context, b BinaryWriter) (err error) {
+	err = b.Start(ctx)
+	if err != nil {
+		return err
+	}
+	err = eventContextToBinaryWriter(m.Context, b)
+	if err != nil {
+		return err
+	}
+	// Pass the body
+	body := (*event.Event)(m).Data()
+	if len(body) > 0 {
+		err = b.SetData(bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
+	}
+	return b.End(ctx)
+}
+
+func eventContextToBinaryWriter(c event.EventContext, b BinaryWriter) (err error) {
+	// Pass all attributes
+	sv := spec.VS.Version(c.GetSpecVersion())
+	for _, a := range sv.Attributes() {
+		value := a.Get(c)
+		if value != nil {
+			err = b.SetAttribute(a, value)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	// Pass all extensions
+	for k, v := range c.GetExtensions() {
+		err = b.SetExtension(k, v)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (*EventMessage) Finish(error) error { return nil }
+
+var _ Message = (*EventMessage)(nil) // Test it conforms to the interface
+
+// Configure which format to use when marshalling the event to structured mode
+func UseFormatForEvent(ctx context.Context, f format.Format) context.Context {
+	return context.WithValue(ctx, FORMAT_EVENT_STRUCTURED, f)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/finish_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/finish_message.go
@@ -1,0 +1,27 @@
+package binding
+
+type finishMessage struct {
+	Message
+	finish func(error)
+}
+
+func (m *finishMessage) GetWrappedMessage() Message {
+	return m.Message
+}
+
+func (m *finishMessage) Finish(err error) error {
+	err2 := m.Message.Finish(err) // Finish original message first
+	if m.finish != nil {
+		m.finish(err) // Notify callback
+	}
+	return err2
+}
+
+var _ MessageWrapper = (*finishMessage)(nil)
+
+// WithFinish returns a wrapper for m that calls finish() and
+// m.Finish() in its Finish().
+// Allows code to be notified when a message is Finished.
+func WithFinish(m Message, finish func(error)) Message {
+	return &finishMessage{Message: m, finish: finish}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/format/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/format/doc.go
@@ -1,0 +1,8 @@
+package format
+
+/*
+Package format formats structured events.
+
+The "application/cloudevents+json" format is built-in and always
+available. Other formats may be added.
+*/

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/format/format.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/format/format.go
@@ -1,0 +1,97 @@
+package format
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cloudevents/sdk-go/pkg/event"
+)
+
+// Format marshals and unmarshals structured events to bytes.
+type Format interface {
+	// MediaType identifies the format
+	MediaType() string
+	// Marshal event to bytes
+	Marshal(*event.Event) ([]byte, error)
+	// Unmarshal bytes to event
+	Unmarshal([]byte, *event.Event) error
+}
+
+// UnknownFormat allows an event with an unknown format string to be forwarded,
+// but Marshal() and Unmarshal will always fail.
+type UnknownFormat string
+
+func (uf UnknownFormat) MediaType() string                    { return string(uf) }
+func (uf UnknownFormat) Marshal(*event.Event) ([]byte, error) { return nil, unknown(uf.MediaType()) }
+func (uf UnknownFormat) Unmarshal([]byte, *event.Event) error { return unknown(uf.MediaType()) }
+
+// Prefix for event-format media types.
+const Prefix = "application/cloudevents"
+
+// IsFormat returns true if mediaType begins with "application/cloudevents"
+func IsFormat(mediaType string) bool { return strings.HasPrefix(mediaType, Prefix) }
+
+// JSON is the built-in "application/cloudevents+json" format.
+var JSON = jsonFmt{}
+
+type jsonFmt struct{}
+
+func (jsonFmt) MediaType() string { return event.ApplicationCloudEventsJSON }
+
+func (jsonFmt) Marshal(e *event.Event) ([]byte, error) { return json.Marshal(e) }
+func (jsonFmt) Unmarshal(b []byte, e *event.Event) error {
+	err := json.Unmarshal(b, e)
+	if err != nil {
+		return err
+	}
+
+	// Extensions to go types when unparsed
+	for k, v := range e.Extensions() {
+		var vParsed interface{}
+		switch v.(type) {
+		case json.RawMessage:
+			err = json.Unmarshal(v.(json.RawMessage), &vParsed)
+			if err != nil {
+				return err
+			}
+			e.SetExtension(k, vParsed)
+		}
+	}
+
+	return nil
+}
+
+// built-in formats
+var formats map[string]Format
+
+func init() {
+	formats = map[string]Format{}
+	Add(JSON)
+}
+
+// Lookup returns the format for mediaType, or nil if not found.
+func Lookup(mediaType string) Format { return formats[mediaType] }
+
+func unknown(mediaType string) error {
+	return fmt.Errorf("unknown event format media-type %#v", mediaType)
+}
+
+// Add a new Format. It can be retrieved by Lookup(f.MediaType())
+func Add(f Format) { formats[f.MediaType()] = f }
+
+// Marshal an event to bytes using the mediaType event format.
+func Marshal(mediaType string, e *event.Event) ([]byte, error) {
+	if f := formats[mediaType]; f != nil {
+		return f.Marshal(e)
+	}
+	return nil, unknown(mediaType)
+}
+
+// Unmarshal bytes to an event using the mediaType event format.
+func Unmarshal(mediaType string, b []byte, e *event.Event) error {
+	if f := formats[mediaType]; f != nil {
+		return f.Unmarshal(b, e)
+	}
+	return unknown(mediaType)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/message.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/message.go
@@ -1,0 +1,99 @@
+package binding
+
+import "context"
+
+// The ReadStructured and ReadBinary methods allows to perform an optimized encoding of a Message to a specific data structure.
+// A Sender should try each method of interest and fall back to binding.ToEvent() if none are supported.
+// An out of the box algorithm is provided for writing a message: binding.Write().
+type MessageReader interface {
+	// Return the type of the message Encoding.
+	// The encoding should be preferably computed when the message is constructed.
+	ReadEncoding() Encoding
+
+	// ReadStructured transfers a structured-mode event to a StructuredWriter.
+	// It must return ErrNotStructured if message is not in structured mode.
+	//
+	// Returns a different err if something wrong happened while trying to read the structured event.
+	// In this case, the caller must Finish the message with appropriate error.
+	//
+	// This allows Senders to avoid re-encoding messages that are
+	// already in suitable structured form.
+	ReadStructured(context.Context, StructuredWriter) error
+
+	// ReadBinary transfers a binary-mode event to an BinaryWriter.
+	// It must return ErrNotBinary if message is not in binary mode.
+	//
+	// Returns a different err if something wrong happened while trying to read the binary event
+	// In this case, the caller must Finish the message with appropriate error
+	//
+	// This allows Senders to avoid re-encoding messages that are
+	// already in suitable binary form.
+	ReadBinary(context.Context, BinaryWriter) error
+}
+
+// Message is the interface to a binding-specific message containing an event.
+//
+// Reliable Delivery
+//
+// There are 3 reliable qualities of service for messages:
+//
+// 0/at-most-once/unreliable: messages can be dropped silently.
+//
+// 1/at-least-once: messages are not dropped without signaling an error
+// to the sender, but they may be duplicated in the event of a re-send.
+//
+// 2/exactly-once: messages are never dropped (without error) or
+// duplicated, as long as both sending and receiving ends maintain
+// some binding-specific delivery state. Whether this is persisted
+// depends on the configuration of the binding implementations.
+//
+// The Message interface supports QoS 0 and 1, the ExactlyOnceMessage interface
+// supports QoS 2
+//
+// Message includes the MessageReader interface to read messages. Every binding.Message implementation *must* specify if the message can be accessed one or more times.
+//
+// When a Message can be forgotten by the entity who produced the message, Message.Finish() *must* be invoked.
+type Message interface {
+	MessageReader
+
+	// Finish *must* be called when message from a Receiver can be forgotten by
+	// the receiver. A QoS 1 sender should not call Finish() until it gets an acknowledgment of
+	// receipt on the underlying transport.  For QoS 2 see ExactlyOnceMessage.
+	//
+	// Note that, depending on the Message implementation, forgetting to Finish the message
+	// could produce memory/resources leaks!
+	//
+	// Passing a non-nil err indicates sending or processing failed.
+	// A non-nil return indicates that the message was not accepted
+	// by the receivers peer.
+	Finish(error) error
+}
+
+// ExactlyOnceMessage is implemented by received Messages
+// that support QoS 2.  Only transports that support QoS 2 need to
+// implement or use this interface.
+type ExactlyOnceMessage interface {
+	Message
+
+	// Received is called by a forwarding QoS2 Sender when it gets
+	// acknowledgment of receipt (e.g. AMQP 'accept' or MQTT PUBREC)
+	//
+	// The receiver must call settle(nil) when it get's the ack-of-ack
+	// (e.g. AMQP 'settle' or MQTT PUBCOMP) or settle(err) if the
+	// transfer fails.
+	//
+	// Finally the Sender calls Finish() to indicate the message can be
+	// discarded.
+	//
+	// If sending fails, or if the sender does not support QoS 2, then
+	// Finish() may be called without any call to Received()
+	Received(settle func(error))
+}
+
+// Message Wrapper interface is used to walk through a decorated Message and unwrap it.
+type MessageWrapper interface {
+	Message
+
+	// Method to get the wrapped message
+	GetWrappedMessage() Message
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/spec/attributes.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/spec/attributes.go
@@ -1,0 +1,136 @@
+package spec
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cloudevents/sdk-go/pkg/event"
+
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+// Kind is a version-independent identifier for a CloudEvent context attribute.
+type Kind uint8
+
+const (
+	// Required cloudevents attributes
+	ID Kind = iota
+	Source
+	SpecVersion
+	Type
+	// Optional cloudevents attributes
+	DataContentType
+	DataSchema
+	Subject
+	Time
+)
+const nAttrs = int(Time) + 1
+
+var kindNames = [nAttrs]string{
+	"id",
+	"source",
+	"specversion",
+	"type",
+	"datacontenttype",
+	"dataschema",
+	"subject",
+	"time",
+}
+
+// String is a human-readable string, for a valid attribute name use Attribute.Name
+func (k Kind) String() string { return kindNames[k] }
+
+// IsRequired returns true for attributes defined as "required" by the CE spec.
+func (k Kind) IsRequired() bool { return k < DataContentType }
+
+// Attribute is a named attribute accessor.
+// The attribute name is specific to a Version.
+type Attribute interface {
+	Kind() Kind
+	// Name of the attribute with respect to the current spec Version() with prefix
+	PrefixedName() string
+	// Name of the attribute with respect to the current spec Version()
+	Name() string
+	// Version of the spec that this attribute belongs to
+	Version() Version
+	// Get the value of this attribute from an event context
+	Get(event.EventContextReader) interface{}
+	// Set the value of this attribute on an event context
+	Set(event.EventContextWriter, interface{}) error
+	// Delete this attribute from and event context, when possible
+	Delete(event.EventContextWriter) error
+}
+
+// accessor provides Kind, Get, Set.
+type accessor interface {
+	Kind() Kind
+	Get(event.EventContextReader) interface{}
+	Set(event.EventContextWriter, interface{}) error
+	Delete(event.EventContextWriter) error
+}
+
+var acc = [nAttrs]accessor{
+	&aStr{aKind(ID), event.EventContextReader.GetID, event.EventContextWriter.SetID},
+	&aStr{aKind(Source), event.EventContextReader.GetSource, event.EventContextWriter.SetSource},
+	&aStr{aKind(SpecVersion), event.EventContextReader.GetSpecVersion, event.EventContextWriter.SetSpecVersion},
+	&aStr{aKind(Type), event.EventContextReader.GetType, event.EventContextWriter.SetType},
+	&aStr{aKind(DataContentType), event.EventContextReader.GetDataContentType, event.EventContextWriter.SetDataContentType},
+	&aStr{aKind(DataSchema), event.EventContextReader.GetDataSchema, event.EventContextWriter.SetDataSchema},
+	&aStr{aKind(Subject), event.EventContextReader.GetSubject, event.EventContextWriter.SetSubject},
+	&aTime{aKind(Time), event.EventContextReader.GetTime, event.EventContextWriter.SetTime},
+}
+
+// aKind implements Kind()
+type aKind Kind
+
+func (kind aKind) Kind() Kind { return Kind(kind) }
+
+type aStr struct {
+	aKind
+	get func(event.EventContextReader) string
+	set func(event.EventContextWriter, string) error
+}
+
+func (a *aStr) Get(c event.EventContextReader) interface{} {
+	if s := a.get(c); s != "" {
+		return s
+	}
+	return nil // Treat blank as missing
+}
+
+func (a *aStr) Set(c event.EventContextWriter, v interface{}) error {
+	s, err := types.ToString(v)
+	if err != nil {
+		return fmt.Errorf("invalid value for %s: %#v", a.Kind(), v)
+	}
+	return a.set(c, s)
+}
+
+func (a *aStr) Delete(c event.EventContextWriter) error {
+	return a.set(c, "")
+}
+
+type aTime struct {
+	aKind
+	get func(event.EventContextReader) time.Time
+	set func(event.EventContextWriter, time.Time) error
+}
+
+func (a *aTime) Get(c event.EventContextReader) interface{} {
+	if v := a.get(c); !v.IsZero() {
+		return v
+	}
+	return nil // Treat zero time as missing.
+}
+
+func (a *aTime) Set(c event.EventContextWriter, v interface{}) error {
+	t, err := types.ToTime(v)
+	if err != nil {
+		return fmt.Errorf("invalid value for %s: %#v", a.Kind(), v)
+	}
+	return a.set(c, t)
+}
+
+func (a *aTime) Delete(c event.EventContextWriter) error {
+	return a.set(c, time.Time{})
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/spec/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/spec/doc.go
@@ -1,0 +1,9 @@
+package spec
+
+/*
+Package spec provides spec-version metadata.
+
+For use by code that maps events using (prefixed) attribute name strings.
+Supports handling multiple spec versions uniformly.
+
+*/

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/spec/spec.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/spec/spec.go
@@ -1,0 +1,188 @@
+package spec
+
+import (
+	"strings"
+
+	"github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+// Version provides meta-data for a single spec-version.
+type Version interface {
+	// String name of the version, e.g. "1.0"
+	String() string
+	// Prefix for attribute names.
+	Prefix() string
+	// Attribute looks up a prefixed attribute name (case insensitive).
+	// Returns nil if not found.
+	Attribute(prefixedName string) Attribute
+	// Attribute looks up the attribute from kind.
+	// Returns nil if not found.
+	AttributeFromKind(kind Kind) Attribute
+	// Attributes returns all the context attributes for this version.
+	Attributes() []Attribute
+	// Convert translates a context to this version.
+	Convert(event.EventContextConverter) event.EventContext
+	// NewContext returns a new context for this version.
+	NewContext() event.EventContext
+	// SetAttribute sets named attribute to value.
+	//
+	// Name is case insensitive.
+	// Does nothing if name does not start with prefix.
+	SetAttribute(context event.EventContextWriter, name string, value interface{}) error
+}
+
+// Versions contains all known versions with the same attribute prefix.
+type Versions struct {
+	prefix string
+	all    []Version
+	m      map[string]Version
+}
+
+// Versions returns the list of all known versions, most recent first.
+func (vs *Versions) Versions() []Version { return vs.all }
+
+// Version returns the named version.
+func (vs *Versions) Version(name string) Version {
+	return vs.m[name]
+}
+
+// Latest returns the latest Version
+func (vs *Versions) Latest() Version { return vs.all[0] }
+
+// PrefixedSpecVersionName returns the specversion attribute PrefixedName
+func (vs *Versions) PrefixedSpecVersionName() string { return vs.prefix + "specversion" }
+
+// Prefix is the lowercase attribute name prefix.
+func (vs *Versions) Prefix() string { return vs.prefix }
+
+type attribute struct {
+	accessor
+	name    string
+	version Version
+}
+
+func (a *attribute) PrefixedName() string { return a.version.Prefix() + a.name }
+func (a *attribute) Name() string         { return a.name }
+func (a *attribute) Version() Version     { return a.version }
+
+type version struct {
+	prefix  string
+	context event.EventContext
+	convert func(event.EventContextConverter) event.EventContext
+	attrMap map[string]Attribute
+	attrs   []Attribute
+}
+
+func (v *version) Attribute(name string) Attribute { return v.attrMap[strings.ToLower(name)] }
+func (v *version) Attributes() []Attribute         { return v.attrs }
+func (v *version) String() string                  { return v.context.GetSpecVersion() }
+func (v *version) Prefix() string                  { return v.prefix }
+func (v *version) NewContext() event.EventContext  { return v.context.Clone() }
+
+// HasPrefix is a case-insensitive prefix check.
+func (v *version) HasPrefix(name string) bool {
+	return strings.HasPrefix(strings.ToLower(name), v.prefix)
+}
+
+func (v *version) Convert(c event.EventContextConverter) event.EventContext { return v.convert(c) }
+
+func (v *version) SetAttribute(c event.EventContextWriter, name string, value interface{}) error {
+	if a := v.Attribute(name); a != nil { // Standard attribute
+		return a.Set(c, value)
+	}
+	name = strings.ToLower(name)
+	var err error
+	if strings.HasPrefix(name, v.prefix) { // Extension attribute
+		value, err = types.Validate(value)
+		if err == nil {
+			err = c.SetExtension(strings.TrimPrefix(name, v.prefix), value)
+		}
+	}
+	return err
+}
+
+func (v *version) AttributeFromKind(kind Kind) Attribute {
+	for _, a := range v.Attributes() {
+		if a.Kind() == kind {
+			return a
+		}
+	}
+	return nil
+}
+
+func newVersion(
+	prefix string,
+	context event.EventContext,
+	convert func(event.EventContextConverter) event.EventContext,
+	attrs ...*attribute,
+) *version {
+	v := &version{
+		prefix:  strings.ToLower(prefix),
+		context: context,
+		convert: convert,
+		attrMap: map[string]Attribute{},
+		attrs:   make([]Attribute, len(attrs)),
+	}
+	for i, a := range attrs {
+		a.version = v
+		v.attrs[i] = a
+		v.attrMap[strings.ToLower(a.PrefixedName())] = a
+	}
+	return v
+}
+
+// WithPrefix returns a set of versions with prefix added to all attribute names.
+func WithPrefix(prefix string) *Versions {
+	attr := func(name string, kind Kind) *attribute {
+		return &attribute{accessor: acc[kind], name: name}
+	}
+	vs := &Versions{
+		m:      map[string]Version{},
+		prefix: prefix,
+		all: []Version{
+			newVersion(prefix, event.EventContextV1{}.AsV1(),
+				func(c event.EventContextConverter) event.EventContext { return c.AsV1() },
+				attr("id", ID),
+				attr("source", Source),
+				attr("specversion", SpecVersion),
+				attr("type", Type),
+				attr("datacontenttype", DataContentType),
+				attr("dataschema", DataSchema),
+				attr("subject", Subject),
+				attr("time", Time),
+			),
+			newVersion(prefix, event.EventContextV03{}.AsV03(),
+				func(c event.EventContextConverter) event.EventContext { return c.AsV03() },
+				attr("specversion", SpecVersion),
+				attr("type", Type),
+				attr("source", Source),
+				attr("schemaurl", DataSchema),
+				attr("subject", Subject),
+				attr("id", ID),
+				attr("time", Time),
+				attr("datacontenttype", DataContentType),
+			),
+		},
+	}
+	for _, v := range vs.all {
+		vs.m[v.String()] = v
+	}
+	return vs
+}
+
+// New returns a set of versions
+func New() *Versions { return WithPrefix("") }
+
+// Built-in un-prefixed versions.
+var (
+	VS  *Versions
+	V03 Version
+	V1  Version
+)
+
+func init() {
+	VS = New()
+	V03 = VS.Version("0.3")
+	V1 = VS.Version("1.0")
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/structured_writer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/structured_writer.go
@@ -1,0 +1,17 @@
+package binding
+
+import (
+	"context"
+	"io"
+
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+)
+
+// StructuredWriter is used to visit a structured Message and generate a new representation.
+//
+// Protocols that supports structured encoding should implement this interface to implement direct
+// structured to structured encoding and event to structured encoding.
+type StructuredWriter interface {
+	// Event receives an io.Reader for the whole event.
+	SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/to_event.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/to_event.go
@@ -1,0 +1,128 @@
+package binding
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+// Generic error when a conversion of a Message to an Event fails
+var ErrCannotConvertToEvent = errors.New("cannot convert message to event")
+
+// Translates a Message with a valid Structured or Binary representation to an Event.
+// This function returns the Event generated from the Message and the original encoding of the message or
+// an error that points the conversion error.
+// transformers can be nil and this function guarantees that they are invoked only once during the encoding process.
+func ToEvent(ctx context.Context, message MessageReader, transformers ...TransformerFactory) (*event.Event, error) {
+	messageEncoding := message.ReadEncoding()
+	if messageEncoding == EncodingEvent {
+		for m := message; m != nil; {
+			if em, ok := m.(*EventMessage); ok {
+				e := (*event.Event)(em)
+				if transformers != nil {
+					var tf TransformerFactories
+					tf = transformers
+					if err := tf.EventTransformer()(e); err != nil {
+						return nil, err
+					}
+				}
+				return e, nil
+			}
+			if mw, ok := m.(MessageWrapper); ok {
+				m = mw.GetWrappedMessage()
+			} else {
+				break
+			}
+		}
+		return nil, ErrCannotConvertToEvent
+	}
+
+	e := event.New()
+	encoder := &messageToEventBuilder{event: &e}
+	if _, err := DirectWrite(
+		context.TODO(),
+		message,
+		encoder,
+		encoder,
+		[]TransformerFactory{},
+	); err != nil {
+		return nil, err
+	}
+	if transformers != nil {
+		var tf TransformerFactories
+		tf = transformers
+		if err := tf.EventTransformer()(&e); err != nil {
+			return nil, err
+		}
+	}
+	return &e, nil
+}
+
+type messageToEventBuilder struct {
+	event *event.Event
+}
+
+var _ StructuredWriter = (*messageToEventBuilder)(nil)
+var _ BinaryWriter = (*messageToEventBuilder)(nil)
+
+func (b *messageToEventBuilder) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error {
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, event)
+	if err != nil {
+		return err
+	}
+	return format.Unmarshal(buf.Bytes(), b.event)
+}
+
+func (b *messageToEventBuilder) Start(ctx context.Context) error {
+	return nil
+}
+
+func (b *messageToEventBuilder) End(ctx context.Context) error {
+	return nil
+}
+
+func (b *messageToEventBuilder) SetData(data io.Reader) error {
+	var buf bytes.Buffer
+	w, err := io.Copy(&buf, data)
+	if err != nil {
+		return err
+	}
+	if w != 0 {
+		b.event.DataEncoded = buf.Bytes()
+	}
+	return nil
+}
+
+func (b *messageToEventBuilder) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	// If spec version we need to change to right context struct
+	if attribute.Kind() == spec.SpecVersion {
+		str, err := types.ToString(value)
+		if err != nil {
+			return err
+		}
+		switch str {
+		case event.CloudEventsVersionV03:
+			b.event.Context = b.event.Context.AsV03()
+		case event.CloudEventsVersionV1:
+			b.event.Context = b.event.Context.AsV1()
+		}
+		return nil
+	}
+	return attribute.Set(b.event.Context, value)
+}
+
+func (b *messageToEventBuilder) SetExtension(name string, value interface{}) error {
+	value, err := types.Validate(value)
+	if err != nil {
+		return err
+	}
+	b.event.SetExtension(name, value)
+	return nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer.go
@@ -1,0 +1,82 @@
+package binding
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/event"
+)
+
+// Implements a transformation process while transferring the event from the Message implementation
+// to the provided encoder
+//
+// A transformer could optionally not provide an implementation for binary and/or structured encodings,
+// returning nil to the respective factory method.
+type TransformerFactory interface {
+	// Can return nil if the transformation doesn't support structured encoding directly
+	StructuredTransformer(encoder StructuredWriter) StructuredWriter
+
+	// Can return nil if the transformation doesn't support binary encoding directly
+	BinaryTransformer(encoder BinaryWriter) BinaryWriter
+
+	// Can return nil if the transformation doesn't support events
+	EventTransformer() EventTransformer
+}
+
+// Utility type alias to manage multiple TransformerFactory
+type TransformerFactories []TransformerFactory
+
+func (t TransformerFactories) StructuredTransformer(encoder StructuredWriter) StructuredWriter {
+	if encoder == nil {
+		return nil
+	}
+	res := encoder
+	for _, b := range t {
+		if b == nil {
+			continue
+		}
+		if r := b.StructuredTransformer(res); r != nil {
+			res = r
+		} else {
+			return nil // Structured not supported!
+		}
+	}
+	return res
+}
+
+func (t TransformerFactories) BinaryTransformer(encoder BinaryWriter) BinaryWriter {
+	if encoder == nil {
+		return nil
+	}
+	res := encoder
+	for i := range t {
+		b := t[len(t)-i-1]
+		if b == nil {
+			continue
+		}
+		if r := b.BinaryTransformer(res); r != nil {
+			res = r
+		} else {
+			return nil // Binary not supported!
+		}
+	}
+	return res
+}
+
+func (t TransformerFactories) EventTransformer() EventTransformer {
+	return func(e *event.Event) error {
+		for _, b := range t {
+			if b == nil {
+				continue
+			}
+			f := b.EventTransformer()
+			if f != nil {
+				err := f(e)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+}
+
+// EventTransformer mutates the provided Event
+type EventTransformer func(*event.Event) error

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/add_metadata.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/add_metadata.go
@@ -1,0 +1,128 @@
+package transformer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/cloudevents/sdk-go/pkg/event"
+)
+
+// Add cloudevents attribute (if missing) during the encoding process
+func AddAttribute(attributeKind spec.Kind, value interface{}) binding.TransformerFactory {
+	return addAttributeTransformerFactory{attributeKind: attributeKind, value: value}
+}
+
+// Add cloudevents extension (if missing) during the encoding process
+func AddExtension(name string, value interface{}) binding.TransformerFactory {
+	return addExtensionTransformerFactory{name: name, value: value}
+}
+
+type addAttributeTransformerFactory struct {
+	attributeKind spec.Kind
+	value         interface{}
+}
+
+func (a addAttributeTransformerFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
+	return nil
+}
+
+func (a addAttributeTransformerFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
+	return &addAttributeTransformer{
+		BinaryWriter:  encoder,
+		attributeKind: a.attributeKind,
+		value:         a.value,
+		found:         false,
+	}
+}
+
+func (a addAttributeTransformerFactory) EventTransformer() binding.EventTransformer {
+	return func(event *event.Event) error {
+		v := spec.VS.Version(event.SpecVersion())
+		if v == nil {
+			return fmt.Errorf("spec version %s invalid", event.SpecVersion())
+		}
+		if v.AttributeFromKind(a.attributeKind).Get(event.Context) == nil {
+			return v.AttributeFromKind(a.attributeKind).Set(event.Context, a.value)
+		}
+		return nil
+	}
+}
+
+type addExtensionTransformerFactory struct {
+	name  string
+	value interface{}
+}
+
+func (a addExtensionTransformerFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
+	return nil
+}
+
+func (a addExtensionTransformerFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
+	return &addExtensionTransformer{
+		BinaryWriter: encoder,
+		name:         a.name,
+		value:        a.value,
+		found:        false,
+	}
+}
+
+func (a addExtensionTransformerFactory) EventTransformer() binding.EventTransformer {
+	return func(event *event.Event) error {
+		if _, ok := event.Extensions()[a.name]; !ok {
+			return event.Context.SetExtension(a.name, a.value)
+		}
+		return nil
+	}
+}
+
+type addAttributeTransformer struct {
+	binding.BinaryWriter
+	attributeKind spec.Kind
+	value         interface{}
+	version       spec.Version
+	found         bool
+}
+
+func (b *addAttributeTransformer) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	if attribute.Kind() == b.attributeKind {
+		b.found = true
+	}
+	b.version = attribute.Version()
+	return b.BinaryWriter.SetAttribute(attribute, value)
+}
+
+func (b *addAttributeTransformer) End(ctx context.Context) error {
+	if !b.found {
+		err := b.BinaryWriter.SetAttribute(b.version.AttributeFromKind(b.attributeKind), b.value)
+		if err != nil {
+			return err
+		}
+	}
+	return b.BinaryWriter.End(ctx)
+}
+
+type addExtensionTransformer struct {
+	binding.BinaryWriter
+	name  string
+	value interface{}
+	found bool
+}
+
+func (b *addExtensionTransformer) SetExtension(name string, value interface{}) error {
+	if name == b.name {
+		b.found = true
+	}
+	return b.BinaryWriter.SetExtension(name, value)
+}
+
+func (b *addExtensionTransformer) End(ctx context.Context) error {
+	if !b.found {
+		err := b.BinaryWriter.SetExtension(b.name, b.value)
+		if err != nil {
+			return err
+		}
+	}
+	return b.BinaryWriter.End(ctx)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/default_metadata.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/default_metadata.go
@@ -1,0 +1,95 @@
+package transformer
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+var (
+	// Sets the cloudevents id attribute to a UUID.New()
+	SetUUID binding.TransformerFactory = setUUID{}
+	// Add the cloudevents time attribute, if missing, to time.Now()
+	AddTimeNow binding.TransformerFactory = addTimeNow{}
+)
+
+type setUUID struct{}
+
+func (a setUUID) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
+	return nil
+}
+
+func (a setUUID) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
+	return &setUUIDTransformer{
+		BinaryWriter: encoder,
+	}
+}
+
+func (a setUUID) EventTransformer() binding.EventTransformer {
+	return func(event *event.Event) error {
+		return event.Context.SetID(uuid.New().String())
+	}
+}
+
+type setUUIDTransformer struct {
+	binding.BinaryWriter
+}
+
+func (b *setUUIDTransformer) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	if attribute.Kind() == spec.ID {
+		return b.BinaryWriter.SetAttribute(attribute.Version().AttributeFromKind(spec.ID), uuid.New().String())
+	}
+	return b.BinaryWriter.SetAttribute(attribute, value)
+}
+
+type addTimeNow struct{}
+
+func (a addTimeNow) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
+	return nil
+}
+
+func (a addTimeNow) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
+	return &addTimeNowTransformer{
+		BinaryWriter: encoder,
+		found:        false,
+	}
+}
+
+func (a addTimeNow) EventTransformer() binding.EventTransformer {
+	return func(event *event.Event) error {
+		if event.Context.GetTime().IsZero() {
+			return event.Context.SetTime(time.Now())
+		}
+		return nil
+	}
+}
+
+type addTimeNowTransformer struct {
+	binding.BinaryWriter
+	version spec.Version
+	found   bool
+}
+
+func (b *addTimeNowTransformer) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	if attribute.Kind() == spec.Time {
+		b.found = true
+	}
+	b.version = attribute.Version()
+	return b.BinaryWriter.SetAttribute(attribute, value)
+}
+
+func (b *addTimeNowTransformer) End(ctx context.Context) error {
+	if !b.found {
+		err := b.BinaryWriter.SetAttribute(b.version.AttributeFromKind(spec.Time), types.Timestamp{Time: time.Now()})
+		if err != nil {
+			return err
+		}
+	}
+	return b.BinaryWriter.End(ctx)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/delete_metadata.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/delete_metadata.go
@@ -1,0 +1,92 @@
+package transformer
+
+import (
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/cloudevents/sdk-go/pkg/event"
+)
+
+// Delete cloudevents attribute during the encoding process
+func DeleteAttribute(attributeKind spec.Kind) binding.TransformerFactory {
+	return deleteAttributeTransformerFactory{attributeKind: attributeKind}
+}
+
+// Delete cloudevents extension during the encoding process
+func DeleteExtension(name string) binding.TransformerFactory {
+	return deleteExtensionTransformerFactory{name: name}
+}
+
+type deleteAttributeTransformerFactory struct {
+	attributeKind spec.Kind
+}
+
+func (a deleteAttributeTransformerFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
+	return nil
+}
+
+func (a deleteAttributeTransformerFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
+	return &deleteAttributeTransformer{
+		BinaryWriter:  encoder,
+		attributeKind: a.attributeKind,
+	}
+}
+
+func (a deleteAttributeTransformerFactory) EventTransformer() binding.EventTransformer {
+	return func(event *event.Event) error {
+		v := spec.VS.Version(event.SpecVersion())
+		if v == nil {
+			return fmt.Errorf("spec version %s invalid", event.SpecVersion())
+		}
+		if v.AttributeFromKind(a.attributeKind).Get(event.Context) != nil {
+			return v.AttributeFromKind(a.attributeKind).Delete(event.Context)
+		}
+		return nil
+	}
+}
+
+type deleteExtensionTransformerFactory struct {
+	name string
+}
+
+func (a deleteExtensionTransformerFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
+	return nil
+}
+
+func (a deleteExtensionTransformerFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
+	return &deleteExtensionTransformer{
+		BinaryWriter: encoder,
+		name:         a.name,
+	}
+}
+
+func (a deleteExtensionTransformerFactory) EventTransformer() binding.EventTransformer {
+	return func(event *event.Event) error {
+		return event.Context.SetExtension(a.name, nil)
+	}
+}
+
+type deleteAttributeTransformer struct {
+	binding.BinaryWriter
+	attributeKind spec.Kind
+}
+
+func (b *deleteAttributeTransformer) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	if attribute.Kind() == b.attributeKind {
+		return nil
+	}
+	return b.BinaryWriter.SetAttribute(attribute, value)
+}
+
+type deleteExtensionTransformer struct {
+	binding.BinaryWriter
+	name string
+}
+
+func (b *deleteExtensionTransformer) SetExtension(name string, value interface{}) error {
+	if b.name == name {
+		return nil
+	}
+	return b.BinaryWriter.SetExtension(name, value)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/set_metadata.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/set_metadata.go
@@ -1,0 +1,22 @@
+package transformer
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+)
+
+// Sets a cloudevents attribute (if missing) to defaultValue or update it with updater function
+func SetAttribute(attribute spec.Kind, defaultValue interface{}, updater func(interface{}) (interface{}, error)) []binding.TransformerFactory {
+	return []binding.TransformerFactory{
+		UpdateAttribute(attribute, updater),
+		AddAttribute(attribute, defaultValue),
+	}
+}
+
+// Sets a cloudevents extension (if missing) to defaultValue or update it with updater function
+func SetExtension(name string, defaultValue interface{}, updater func(interface{}) (interface{}, error)) []binding.TransformerFactory {
+	return []binding.TransformerFactory{
+		UpdateExtension(name, updater),
+		AddExtension(name, defaultValue),
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/update_metadata.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/update_metadata.go
@@ -1,0 +1,127 @@
+package transformer
+
+import (
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/cloudevents/sdk-go/pkg/event"
+)
+
+// Update cloudevents attribute (if present) using the provided function
+func UpdateAttribute(attributeKind spec.Kind, updater func(interface{}) (interface{}, error)) binding.TransformerFactory {
+	return updateAttributeTransformerFactory{attributeKind: attributeKind, updater: updater}
+}
+
+// Update cloudevents extension (if present) using the provided function
+func UpdateExtension(name string, updater func(interface{}) (interface{}, error)) binding.TransformerFactory {
+	return updateExtensionTransformerFactory{name: name, updater: updater}
+}
+
+type updateAttributeTransformerFactory struct {
+	attributeKind spec.Kind
+	updater       func(interface{}) (interface{}, error)
+}
+
+func (a updateAttributeTransformerFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
+	return nil
+}
+
+func (a updateAttributeTransformerFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
+	return &updateAttributeTransformer{
+		BinaryWriter:  encoder,
+		attributeKind: a.attributeKind,
+		updater:       a.updater,
+	}
+}
+
+func (a updateAttributeTransformerFactory) EventTransformer() binding.EventTransformer {
+	return func(event *event.Event) error {
+		v := spec.VS.Version(event.SpecVersion())
+		if v == nil {
+			return fmt.Errorf("spec version %s invalid", event.SpecVersion())
+		}
+		if val := v.AttributeFromKind(a.attributeKind).Get(event.Context); val != nil {
+			newVal, err := a.updater(val)
+			if err != nil {
+				return err
+			}
+			if newVal == nil {
+				return v.AttributeFromKind(a.attributeKind).Delete(event.Context)
+			} else {
+				return v.AttributeFromKind(a.attributeKind).Set(event.Context, newVal)
+			}
+		}
+		return nil
+	}
+}
+
+type updateExtensionTransformerFactory struct {
+	name    string
+	updater func(interface{}) (interface{}, error)
+}
+
+func (a updateExtensionTransformerFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
+	return nil
+}
+
+func (a updateExtensionTransformerFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
+	return &updateExtensionTransformer{
+		BinaryWriter: encoder,
+		name:         a.name,
+		updater:      a.updater,
+	}
+}
+
+func (a updateExtensionTransformerFactory) EventTransformer() binding.EventTransformer {
+	return func(event *event.Event) error {
+		if val, ok := event.Extensions()[a.name]; ok {
+			newVal, err := a.updater(val)
+			if err != nil {
+				return err
+			}
+			return event.Context.SetExtension(a.name, newVal)
+		}
+		return nil
+	}
+}
+
+type updateAttributeTransformer struct {
+	binding.BinaryWriter
+	attributeKind spec.Kind
+	updater       func(interface{}) (interface{}, error)
+}
+
+func (b *updateAttributeTransformer) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	if attribute.Kind() == b.attributeKind {
+		newVal, err := b.updater(value)
+		if err != nil {
+			return err
+		}
+		if newVal != nil {
+			return b.BinaryWriter.SetAttribute(attribute, newVal)
+		}
+		return nil
+	}
+	return b.BinaryWriter.SetAttribute(attribute, value)
+}
+
+type updateExtensionTransformer struct {
+	binding.BinaryWriter
+	name    string
+	updater func(interface{}) (interface{}, error)
+}
+
+func (b *updateExtensionTransformer) SetExtension(name string, value interface{}) error {
+	if name == b.name {
+		newVal, err := b.updater(value)
+		if err != nil {
+			return err
+		}
+		if newVal != nil {
+			return b.BinaryWriter.SetExtension(name, newVal)
+		}
+		return nil
+	}
+	return b.BinaryWriter.SetExtension(name, value)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/version.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/transformer/version.go
@@ -1,0 +1,44 @@
+package transformer
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/cloudevents/sdk-go/pkg/event"
+)
+
+// Converts the event context version to the specified one.
+func Version(version spec.Version) binding.TransformerFactory {
+	return versionTransformerFactory{version: version}
+}
+
+type versionTransformerFactory struct {
+	version spec.Version
+}
+
+func (v versionTransformerFactory) StructuredTransformer(binding.StructuredWriter) binding.StructuredWriter {
+	return nil // Not supported, must fallback to EventTransformer!
+}
+
+func (v versionTransformerFactory) BinaryTransformer(encoder binding.BinaryWriter) binding.BinaryWriter {
+	return binaryVersionTransformer{BinaryWriter: encoder, version: v.version}
+}
+
+func (v versionTransformerFactory) EventTransformer() binding.EventTransformer {
+	return func(e *event.Event) error {
+		e.Context = v.version.Convert(e.Context)
+		return nil
+	}
+}
+
+type binaryVersionTransformer struct {
+	binding.BinaryWriter
+	version spec.Version
+}
+
+func (b binaryVersionTransformer) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	if attribute.Kind() == spec.SpecVersion {
+		return b.BinaryWriter.SetAttribute(b.version.AttributeFromKind(spec.SpecVersion), b.version.String())
+	}
+	attributeInDifferentVersion := b.version.AttributeFromKind(attribute.Kind())
+	return b.BinaryWriter.SetAttribute(attributeInDifferentVersion, value)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/binding/write.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/binding/write.go
@@ -1,0 +1,148 @@
+package binding
+
+import (
+	"context"
+
+	"github.com/cloudevents/sdk-go/pkg/event"
+)
+
+const (
+	SKIP_DIRECT_STRUCTURED_ENCODING = "SKIP_DIRECT_STRUCTURED_ENCODING"
+	SKIP_DIRECT_BINARY_ENCODING     = "SKIP_DIRECT_BINARY_ENCODING"
+	PREFERRED_EVENT_ENCODING        = "PREFERRED_EVENT_ENCODING"
+)
+
+// Invokes the encoders. structuredWriter and binaryWriter could be nil if the protocol doesn't support it.
+// transformers can be nil and this function guarantees that they are invoked only once during the encoding process.
+//
+// Returns:
+// * EncodingStructured, nil if message is correctly encoded in structured encoding
+// * EncodingBinary, nil if message is correctly encoded in binary encoding
+// * EncodingStructured, err if message was structured but error happened during the encoding
+// * EncodingBinary, err if message was binary but error happened during the encoding
+// * EncodingUnknown, ErrUnknownEncoding if message is not a structured or a binary Message
+func DirectWrite(
+	ctx context.Context,
+	message MessageReader,
+	structuredWriter StructuredWriter,
+	binaryWriter BinaryWriter,
+	transformers TransformerFactories,
+) (Encoding, error) {
+	if structuredWriter != nil && !GetOrDefaultFromCtx(ctx, SKIP_DIRECT_STRUCTURED_ENCODING, false).(bool) {
+		// Wrap the transformers in the structured builder
+		structuredWriter = transformers.StructuredTransformer(structuredWriter)
+
+		// StructuredTransformer could return nil if one of transcoders doesn't support
+		// direct structured transcoding
+		if structuredWriter != nil {
+			if err := message.ReadStructured(ctx, structuredWriter); err == nil {
+				return EncodingStructured, nil
+			} else if err != ErrNotStructured {
+				return EncodingStructured, err
+			}
+		}
+	}
+
+	if binaryWriter != nil && !GetOrDefaultFromCtx(ctx, SKIP_DIRECT_BINARY_ENCODING, false).(bool) {
+		binaryWriter = transformers.BinaryTransformer(binaryWriter)
+		if binaryWriter != nil {
+			if err := message.ReadBinary(ctx, binaryWriter); err == nil {
+				return EncodingBinary, nil
+			} else if err != ErrNotBinary {
+				return EncodingBinary, err
+			}
+		}
+	}
+
+	return EncodingUnknown, ErrUnknownEncoding
+}
+
+// This is the full algorithm to encode a Message using transformers:
+// 1. It first tries direct encoding using DirectWrite
+// 2. If no direct encoding is possible, it uses ToEvent to generate an Event representation
+// 3. From the Event, the message is encoded back to the provided structured or binary encoders
+// You can tweak the encoding process using the context decorators WithForceStructured, WithForceStructured, etc.
+// transformers can be nil and this function guarantees that they are invoked only once during the encoding process.
+// Returns:
+// * EncodingStructured, nil if message is correctly encoded in structured encoding
+// * EncodingBinary, nil if message is correctly encoded in binary encoding
+// * EncodingUnknown, ErrUnknownEncoding if message.ReadEncoding() == EncodingUnknown
+// * _, err if error happened during the encoding
+func Write(
+	ctx context.Context,
+	message MessageReader,
+	structuredWriter StructuredWriter,
+	binaryWriter BinaryWriter,
+	transformers ...TransformerFactory,
+) (Encoding, error) {
+	enc := message.ReadEncoding()
+	var err error
+	// Skip direct encoding if the event is an event message
+	if enc != EncodingEvent {
+		enc, err = DirectWrite(ctx, message, structuredWriter, binaryWriter, transformers)
+		if enc != EncodingUnknown {
+			// Message directly encoded, nothing else to do here
+			return enc, err
+		}
+	}
+
+	var e *event.Event
+	e, err = ToEvent(ctx, message, transformers...)
+	if err != nil {
+		return enc, err
+	}
+
+	message = (*EventMessage)(e)
+
+	if GetOrDefaultFromCtx(ctx, PREFERRED_EVENT_ENCODING, EncodingBinary).(Encoding) == EncodingStructured {
+		if structuredWriter != nil {
+			return EncodingStructured, message.ReadStructured(ctx, structuredWriter)
+		}
+		if binaryWriter != nil {
+			return EncodingBinary, message.ReadBinary(ctx, binaryWriter)
+		}
+	} else {
+		if binaryWriter != nil {
+			return EncodingBinary, message.ReadBinary(ctx, binaryWriter)
+		}
+		if structuredWriter != nil {
+			return EncodingStructured, message.ReadStructured(ctx, structuredWriter)
+		}
+	}
+
+	return EncodingUnknown, ErrUnknownEncoding
+}
+
+// Skip direct structured to structured encoding during the encoding process
+func WithSkipDirectStructuredEncoding(ctx context.Context, skip bool) context.Context {
+	return context.WithValue(ctx, SKIP_DIRECT_STRUCTURED_ENCODING, skip)
+}
+
+// Skip direct binary to binary encoding during the encoding process
+func WithSkipDirectBinaryEncoding(ctx context.Context, skip bool) context.Context {
+	return context.WithValue(ctx, SKIP_DIRECT_BINARY_ENCODING, skip)
+}
+
+// Define the preferred encoding from event to message during the encoding process
+func WithPreferredEventEncoding(ctx context.Context, enc Encoding) context.Context {
+	return context.WithValue(ctx, PREFERRED_EVENT_ENCODING, enc)
+}
+
+// Force structured encoding during the encoding process
+func WithForceStructured(ctx context.Context) context.Context {
+	return context.WithValue(context.WithValue(ctx, PREFERRED_EVENT_ENCODING, EncodingStructured), SKIP_DIRECT_BINARY_ENCODING, true)
+}
+
+// Force binary encoding during the encoding process
+func WithForceBinary(ctx context.Context) context.Context {
+	return context.WithValue(context.WithValue(ctx, PREFERRED_EVENT_ENCODING, EncodingBinary), SKIP_DIRECT_STRUCTURED_ENCODING, true)
+}
+
+// Get a configuration value from the provided context
+func GetOrDefaultFromCtx(ctx context.Context, key string, def interface{}) interface{} {
+	if val := ctx.Value(key); val != nil {
+		return val
+	} else {
+		return def
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/client/client.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/client/client.go
@@ -1,0 +1,213 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+
+	"go.uber.org/zap"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	cecontext "github.com/cloudevents/sdk-go/pkg/context"
+	"github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/cloudevents/sdk-go/pkg/protocol"
+)
+
+// Client interface defines the runtime contract the CloudEvents client supports.
+type Client interface {
+	// Send will transmit the given event over the client's configured transport.
+	Send(ctx context.Context, event event.Event) error
+
+	// Request will transmit the given event over the client's configured
+	// transport and return any response event.
+	Request(ctx context.Context, event event.Event) (*event.Event, error)
+
+	// StartReceiver will register the provided function for callback on receipt
+	// of a cloudevent. It will also start the underlying protocol as it has
+	// been configured.
+	// This call is blocking.
+	// Valid fn signatures are:
+	// * func()
+	// * func() error
+	// * func(context.Context)
+	// * func(context.Context) protocol.Result
+	// * func(event.Event)
+	// * func(event.Event) protocol.Result
+	// * func(context.Context, event.Event)
+	// * func(context.Context, event.Event) protocol.Result
+	// * func(event.Event) *event.Event
+	// * func(event.Event) (*event.Event, protocol.Result)
+	// * func(context.Context, event.Event) *event.Event
+	// * func(context.Context, event.Event) (*event.Event, protocol.Result)
+	StartReceiver(ctx context.Context, fn interface{}) error
+}
+
+// New produces a new client with the provided transport object and applied
+// client options.
+func New(obj interface{}, opts ...Option) (Client, error) {
+	c := &ceClient{}
+
+	if p, ok := obj.(protocol.Sender); ok {
+		c.sender = p
+	}
+	if p, ok := obj.(protocol.Requester); ok {
+		c.requester = p
+	}
+	if p, ok := obj.(protocol.Responder); ok {
+		c.responder = p
+	}
+	if p, ok := obj.(protocol.Receiver); ok {
+		c.receiver = p
+	}
+	if p, ok := obj.(protocol.Opener); ok {
+		c.opener = p
+	}
+
+	if err := c.applyOptions(opts...); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+type ceClient struct {
+	sender    protocol.Sender
+	requester protocol.Requester
+	receiver  protocol.Receiver
+	responder protocol.Responder
+	// Optional.
+	opener protocol.Opener
+
+	outboundContextDecorators []func(context.Context) context.Context
+	invoker                   Invoker
+	receiverMu                sync.Mutex
+	eventDefaulterFns         []EventDefaulter
+}
+
+func (c *ceClient) applyOptions(opts ...Option) error {
+	for _, fn := range opts {
+		if err := fn(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *ceClient) Send(ctx context.Context, e event.Event) error {
+	if c.sender == nil {
+		return errors.New("sender not set")
+	}
+
+	for _, f := range c.outboundContextDecorators {
+		ctx = f(ctx)
+	}
+
+	if len(c.eventDefaulterFns) > 0 {
+		for _, fn := range c.eventDefaulterFns {
+			e = fn(ctx, e)
+		}
+	}
+
+	if err := e.Validate(); err != nil {
+		return err
+	}
+
+	return c.sender.Send(ctx, (*binding.EventMessage)(&e))
+}
+
+func (c *ceClient) Request(ctx context.Context, e event.Event) (*event.Event, error) {
+	if c.requester == nil {
+		return nil, errors.New("requester not set")
+	}
+	for _, f := range c.outboundContextDecorators {
+		ctx = f(ctx)
+	}
+
+	if len(c.eventDefaulterFns) > 0 {
+		for _, fn := range c.eventDefaulterFns {
+			e = fn(ctx, e)
+		}
+	}
+
+	if err := e.Validate(); err != nil {
+		return nil, err
+	}
+
+	// If provided a requester, use it to do request/response.
+	var resp *event.Event
+	msg, err := c.requester.Request(ctx, (*binding.EventMessage)(&e))
+	defer func() {
+		if err := msg.Finish(err); err != nil {
+			cecontext.LoggerFrom(ctx).Warnw("failed calling message.Finish", zap.Error(err))
+		}
+	}()
+	if err == nil {
+		fmt.Printf("%#v", msg)
+		if rs, err := binding.ToEvent(ctx, msg); err != nil {
+			cecontext.LoggerFrom(ctx).Infow("failed calling ToEvent", zap.Error(err), zap.Any("resp", msg))
+		} else {
+			resp = rs
+		}
+	}
+	return resp, err
+}
+
+// StartReceiver sets up the given fn to handle Receive.
+// See Client.StartReceiver for details. This is a blocking call.
+func (c *ceClient) StartReceiver(ctx context.Context, fn interface{}) error {
+	c.receiverMu.Lock()
+	defer c.receiverMu.Unlock()
+
+	if c.invoker != nil {
+		return fmt.Errorf("client already has a receiver")
+	}
+
+	invoker, err := newReceiveInvoker(fn, c.eventDefaulterFns...) // TODO: this will have to pick between a observed invoker or not.
+	if err != nil {
+		return err
+	}
+	if invoker.IsReceiver() && c.receiver == nil {
+		return fmt.Errorf("mismatched receiver callback without protocol.Receiver supported by protocol")
+	}
+	if invoker.IsResponder() && c.responder == nil {
+		return fmt.Errorf("mismatched receiver callback without protocol.Responder supported by protocol")
+	}
+	c.invoker = invoker
+
+	defer func() {
+		c.invoker = nil
+	}()
+
+	// Start the opener, if set.
+	if c.opener != nil {
+		go func() {
+			// TODO: handle error correctly here.
+			if err := c.opener.OpenInbound(ctx); err != nil {
+				panic(err)
+			}
+		}()
+	}
+
+	var msg binding.Message
+	var respFn protocol.ResponseFn
+	// Start Polling.
+	for {
+		if c.responder != nil {
+			msg, respFn, err = c.responder.Respond(ctx)
+		} else if c.receiver != nil {
+			msg, err = c.receiver.Receive(ctx)
+		} else {
+			return errors.New("responder and receiver not set")
+		}
+
+		if err == io.EOF { // Normal close
+			return nil
+		} else if err != nil {
+			return err
+		}
+		if err := c.invoker.Invoke(ctx, msg, respFn); err != nil {
+			return err
+		}
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/client/client_default.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/client/client_default.go
@@ -1,0 +1,26 @@
+package client
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/protocol/http"
+)
+
+// NewDefault provides the good defaults for the common case using an HTTP
+// Protocol client. The http transport has had WithBinaryEncoding http
+// transport option applied to it. The client will always send Binary
+// encoding but will inspect the outbound event context and match the version.
+// The WithTimeNow, and WithUUIDs client options are also applied to the
+// client, all outbound events will have a time and id set if not already
+// present.
+func NewDefault() (Client, error) {
+	p, err := http.New()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := NewObserved(p, WithTimeNow(), WithUUIDs())
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/client/client_observed.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/client/client_observed.go
@@ -1,0 +1,99 @@
+package client
+
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/cloudevents/sdk-go/pkg/extensions"
+	"github.com/cloudevents/sdk-go/pkg/observability"
+	"go.opencensus.io/trace"
+)
+
+// New produces a new client with the provided transport object and applied
+// client options.
+func NewObserved(protocol interface{}, opts ...Option) (Client, error) {
+	client, err := New(protocol, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &obsClient{client: client}
+
+	if err := c.applyOptions(opts...); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+type obsClient struct {
+	client Client
+
+	addTracing bool
+}
+
+func (c *obsClient) applyOptions(opts ...Option) error {
+	for _, fn := range opts {
+		if err := fn(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Send transmits the provided event on a preconfigured Protocol. Send returns
+// an error if there was an an issue validating the outbound event or the
+// transport returns an error.
+func (c *obsClient) Send(ctx context.Context, e event.Event) error {
+	ctx, r := observability.NewReporter(ctx, reportSend)
+	ctx, span := trace.StartSpan(ctx, observability.ClientSpanName, trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+	if span.IsRecordingEvents() {
+		span.AddAttributes(EventTraceAttributes(&e)...)
+	}
+
+	if c.addTracing {
+		e.Context = e.Context.Clone()
+		extensions.FromSpanContext(span.SpanContext()).AddTracingAttributes(&e)
+	}
+
+	err := c.client.Send(ctx, e)
+
+	if err != nil {
+		r.Error()
+	} else {
+		r.OK()
+	}
+	return err
+}
+
+func (c *obsClient) Request(ctx context.Context, e event.Event) (*event.Event, error) {
+	ctx, r := observability.NewReporter(ctx, reportRequest)
+	ctx, span := trace.StartSpan(ctx, observability.ClientSpanName, trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+	if span.IsRecordingEvents() {
+		span.AddAttributes(EventTraceAttributes(&e)...)
+	}
+
+	resp, err := c.client.Request(ctx, e)
+
+	if err != nil {
+		r.Error()
+	} else {
+		r.OK()
+	}
+	return resp, err
+}
+
+// StartReceiver sets up the given fn to handle Receive.
+// See Client.StartReceiver for details. This is a blocking call.
+func (c *obsClient) StartReceiver(ctx context.Context, fn interface{}) error {
+	ctx, r := observability.NewReporter(ctx, reportStartReceiver)
+
+	err := c.client.StartReceiver(ctx, fn)
+
+	if err != nil {
+		r.Error()
+	} else {
+		r.OK()
+	}
+	return err
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/client/defaulters.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/client/defaulters.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/cloudevents/sdk-go/pkg/event"
+
+	"github.com/google/uuid"
+)
+
+// EventDefaulter is the function signature for extensions that are able
+// to perform event defaulting.
+type EventDefaulter func(ctx context.Context, event event.Event) event.Event
+
+// DefaultIDToUUIDIfNotSet will inspect the provided event and assign a UUID to
+// context.ID if it is found to be empty.
+func DefaultIDToUUIDIfNotSet(ctx context.Context, event event.Event) event.Event {
+	if event.Context != nil {
+		if event.ID() == "" {
+			event.Context = event.Context.Clone()
+			event.SetID(uuid.New().String())
+		}
+	}
+	return event
+}
+
+// DefaultTimeToNowIfNotSet will inspect the provided event and assign a new
+// Timestamp to context.Time if it is found to be nil or zero.
+func DefaultTimeToNowIfNotSet(ctx context.Context, event event.Event) event.Event {
+	if event.Context != nil {
+		if event.Time().IsZero() {
+			event.Context = event.Context.Clone()
+			event.SetTime(time.Now())
+		}
+	}
+	return event
+}
+
+// NewDefaultDataContentTypeIfNotSet returns a defaulter that will inspect the
+// provided event and set the provided content type if content type is found
+// to be empty.
+func NewDefaultDataContentTypeIfNotSet(contentType string) EventDefaulter {
+	return func(ctx context.Context, event event.Event) event.Event {
+		if event.Context != nil {
+			if event.DataContentType() == "" {
+				event.SetDataContentType(contentType)
+			}
+		}
+		return event
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/client/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/client/doc.go
@@ -1,0 +1,6 @@
+/*
+Package client holds the recommended entry points for interacting with the CloudEvents Golang SDK. The client wraps
+a selected transport. The client adds validation and defaulting for sending events, and flexible receiver method
+registration. For full details, read the `client.Client` documentation.
+*/
+package client

--- a/vendor/github.com/cloudevents/sdk-go/pkg/client/http_receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/client/http_receiver.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"context"
+	"net/http"
+
+	thttp "github.com/cloudevents/sdk-go/pkg/protocol/http"
+)
+
+func NewHTTPReceiveHandler(ctx context.Context, p *thttp.Protocol, fn interface{}) (*EventReceiver, error) {
+	invoker, err := newReceiveInvoker(fn)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EventReceiver{
+		p:       p,
+		invoker: invoker,
+	}, nil
+}
+
+type EventReceiver struct {
+	p       *thttp.Protocol
+	invoker Invoker
+}
+
+func (r *EventReceiver) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	go func() {
+		r.p.ServeHTTP(rw, req)
+	}()
+
+	ctx := context.Background()
+	msg, respFn, err := r.p.Respond(ctx)
+	if err != nil {
+		// TODO
+	} else if err := r.invoker.Invoke(ctx, msg, respFn); err != nil {
+		// TODO
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/client/invoker.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/client/invoker.go
@@ -1,0 +1,82 @@
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/protocol"
+)
+
+type Invoker interface {
+	Invoke(context.Context, binding.Message, protocol.ResponseFn) error
+	IsReceiver() bool
+	IsResponder() bool
+}
+
+var _ Invoker = (*receiveInvoker)(nil)
+
+func newReceiveInvoker(fn interface{}, fns ...EventDefaulter) (Invoker, error) {
+	r := &receiveInvoker{
+		eventDefaulterFns: fns,
+	}
+
+	if fn, err := receiver(fn); err != nil {
+		return nil, err
+	} else {
+		r.fn = fn
+	}
+
+	return r, nil
+}
+
+type receiveInvoker struct {
+	fn                *receiverFn
+	eventDefaulterFns []EventDefaulter
+}
+
+func (r *receiveInvoker) Invoke(ctx context.Context, m binding.Message, respFn protocol.ResponseFn) (err error) {
+	defer func() {
+		if err2 := m.Finish(err); err2 == nil {
+			err = err2
+		}
+	}()
+
+	e, err := binding.ToEvent(ctx, m)
+	if err != nil {
+		return err
+	}
+
+	if e != nil && r.fn != nil {
+		resp, result := r.fn.invoke(ctx, *e)
+
+		// Apply the defaulter chain to the outgoing event.
+		if resp != nil && len(r.eventDefaulterFns) > 0 {
+			for _, fn := range r.eventDefaulterFns {
+				*resp = fn(ctx, *resp)
+			}
+			// Validate the event conforms to the CloudEvents Spec.
+			if verr := resp.Validate(); verr != nil {
+				return fmt.Errorf("cloudevent validation failed on response event: %v, %w", verr, err)
+			}
+		}
+		if respFn != nil {
+			var rm binding.Message
+			if resp != nil {
+				rm = (*binding.EventMessage)(resp)
+			}
+
+			return respFn(ctx, rm, result) // TODO: there is a chance this never gets called. Is that ok?
+		}
+	}
+
+	return nil
+}
+
+func (r *receiveInvoker) IsReceiver() bool {
+	return !r.fn.hasEventOut
+}
+
+func (r *receiveInvoker) IsResponder() bool {
+	return r.fn.hasEventOut
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/client/observability.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/client/observability.go
@@ -1,0 +1,94 @@
+package client
+
+import (
+	"context"
+	"github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/cloudevents/sdk-go/pkg/extensions"
+	"github.com/cloudevents/sdk-go/pkg/observability"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/trace"
+)
+
+var (
+	// LatencyMs measures the latency in milliseconds for the CloudEvents
+	// client methods.
+	LatencyMs = stats.Float64("cloudevents.io/sdk-go/client/latency", "The latency in milliseconds for the CloudEvents client methods.", "ms")
+)
+
+var (
+	// LatencyView is an OpenCensus view that shows client method latency.
+	LatencyView = &view.View{
+		Name:        "client/latency",
+		Measure:     LatencyMs,
+		Description: "The distribution of latency inside of client for CloudEvents.",
+		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
+		TagKeys:     observability.LatencyTags(),
+	}
+)
+
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
+
+const (
+	specversionAttr     = "cloudevents.specversion"
+	typeAttr            = "cloudevents.type"
+	sourceAttr          = "cloudevents.source"
+	subjectAttr         = "cloudevents.subject"
+	datacontenttypeAttr = "cloudevents.datacontenttype"
+
+	reportSend observed = iota
+	reportRequest
+	reportStartReceiver
+)
+
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
+	switch o {
+	case reportSend:
+		return "send"
+	case reportRequest:
+		return "request"
+	case reportStartReceiver:
+		return "start_receiver"
+	default:
+		return "unknown"
+	}
+}
+
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return LatencyMs
+}
+
+func EventTraceAttributes(e event.EventReader) []trace.Attribute {
+	as := []trace.Attribute{
+		trace.StringAttribute(specversionAttr, e.SpecVersion()),
+		trace.StringAttribute(typeAttr, e.Type()),
+		trace.StringAttribute(sourceAttr, e.Source()),
+	}
+	if sub := e.Subject(); sub != "" {
+		as = append(as, trace.StringAttribute(subjectAttr, sub))
+	}
+	if dct := e.DataContentType(); dct != "" {
+		as = append(as, trace.StringAttribute(datacontenttypeAttr, dct))
+	}
+	return as
+}
+
+// TraceSpan returns context and trace.Span based on event. Caller must call span.End()
+func TraceSpan(ctx context.Context, e event.Event) (context.Context, *trace.Span) {
+	var span *trace.Span
+	if ext, ok := extensions.GetDistributedTracingExtension(e); ok {
+		ctx, span = ext.StartChildSpan(ctx, observability.ClientSpanName, trace.WithSpanKind(trace.SpanKindServer))
+	}
+	if span == nil {
+		ctx, span = trace.StartSpan(ctx, observability.ClientSpanName, trace.WithSpanKind(trace.SpanKindServer))
+	}
+	if span.IsRecordingEvents() {
+		span.AddAttributes(EventTraceAttributes(&e)...)
+	}
+	return ctx, span
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/client/options.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/client/options.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"fmt"
+	"github.com/cloudevents/sdk-go/pkg/binding"
+)
+
+// Option is the function signature required to be considered an client.Option.
+type Option func(interface{}) error
+
+// WithEventDefaulter adds an event defaulter to the end of the defaulter chain.
+func WithEventDefaulter(fn EventDefaulter) Option {
+	return func(i interface{}) error {
+		if c, ok := i.(*ceClient); ok {
+			if fn == nil {
+				return fmt.Errorf("client option was given an nil event defaulter")
+			}
+			c.eventDefaulterFns = append(c.eventDefaulterFns, fn)
+		}
+		return nil
+	}
+}
+
+func WithForceBinary() Option {
+	return func(i interface{}) error {
+		if c, ok := i.(*ceClient); ok {
+			c.outboundContextDecorators = append(c.outboundContextDecorators, binding.WithForceBinary)
+		}
+		return nil
+	}
+}
+
+func WithForceStructured() Option {
+	return func(i interface{}) error {
+		if c, ok := i.(*ceClient); ok {
+			c.outboundContextDecorators = append(c.outboundContextDecorators, binding.WithForceStructured)
+		}
+		return nil
+	}
+}
+
+// WithUUIDs adds DefaultIDToUUIDIfNotSet event defaulter to the end of the
+// defaulter chain.
+func WithUUIDs() Option {
+	return func(i interface{}) error {
+		if c, ok := i.(*ceClient); ok {
+			c.eventDefaulterFns = append(c.eventDefaulterFns, DefaultIDToUUIDIfNotSet)
+		}
+		return nil
+	}
+}
+
+// WithTimeNow adds DefaultTimeToNowIfNotSet event defaulter to the end of the
+// defaulter chain.
+func WithTimeNow() Option {
+	return func(i interface{}) error {
+		if c, ok := i.(*ceClient); ok {
+			c.eventDefaulterFns = append(c.eventDefaulterFns, DefaultTimeToNowIfNotSet)
+		}
+		return nil
+	}
+}
+
+// WithTracePropagation enables trace propagation via the distributed tracing
+// extension.
+func WithTracePropagation() Option {
+	return func(i interface{}) error {
+		if c, ok := i.(*obsClient); ok {
+			c.addTracing = true
+		}
+		return nil
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/client/receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/client/receiver.go
@@ -1,0 +1,189 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/cloudevents/sdk-go/pkg/event"
+	"github.com/cloudevents/sdk-go/pkg/protocol"
+)
+
+// Receive is the signature of a fn to be invoked for incoming cloudevents.
+type ReceiveFull func(context.Context, event.Event) protocol.Result
+
+type receiverFn struct {
+	numIn   int
+	numOut  int
+	fnValue reflect.Value
+
+	hasContextIn bool
+	hasEventIn   bool
+
+	hasEventOut  bool
+	hasResultOut bool
+}
+
+const (
+	inParamUsage  = "expected a function taking either no parameters, one or more of (context.Context, event.Event) ordered"
+	outParamUsage = "expected a function returning one or mode of (*event.Event, protocol.Result) ordered"
+)
+
+var (
+	contextType  = reflect.TypeOf((*context.Context)(nil)).Elem()
+	eventType    = reflect.TypeOf((*event.Event)(nil)).Elem()
+	eventPtrType = reflect.TypeOf((*event.Event)(nil)) // want the ptr type
+	resultType   = reflect.TypeOf((*protocol.Result)(nil)).Elem()
+)
+
+// receiver creates a receiverFn wrapper class that is used by the client to
+// validate and invoke the provided function.
+// Valid fn signatures are:
+// * func()
+// * func() error
+// * func(context.Context)
+// * func(context.Context) transport.Result
+// * func(event.Event)
+// * func(event.Event) transport.Result
+// * func(context.Context, event.Event)
+// * func(context.Context, event.Event) transport.Result
+// * func(event.Event) *event.Event
+// * func(event.Event) (*event.Event, transport.Result)
+// * func(context.Context, event.Event, *event.Event
+// * func(context.Context, event.Event) (*event.Event, transport.Result)
+//
+func receiver(fn interface{}) (*receiverFn, error) {
+	fnType := reflect.TypeOf(fn)
+	if fnType.Kind() != reflect.Func {
+		return nil, errors.New("must pass a function to handle events")
+	}
+
+	r := &receiverFn{
+		fnValue: reflect.ValueOf(fn),
+		numIn:   fnType.NumIn(),
+		numOut:  fnType.NumOut(),
+	}
+
+	if err := r.validate(fnType); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+func (r *receiverFn) invoke(ctx context.Context, e event.Event) (*event.Event, protocol.Result) {
+	args := make([]reflect.Value, 0, r.numIn)
+
+	if r.numIn > 0 {
+		if r.hasContextIn {
+			args = append(args, reflect.ValueOf(ctx))
+		}
+		if r.hasEventIn {
+			args = append(args, reflect.ValueOf(e))
+		}
+	}
+	v := r.fnValue.Call(args)
+	var respOut protocol.Result
+	var eOut *event.Event
+	if r.numOut > 0 {
+		i := 0
+		if r.hasEventOut {
+			if eo, ok := v[i].Interface().(*event.Event); ok {
+				eOut = eo
+			}
+			i++ // <-- note, need to inc i.
+		}
+		if r.hasResultOut {
+			if resp, ok := v[i].Interface().(protocol.Result); ok {
+				respOut = resp
+			}
+		}
+	}
+	return eOut, respOut
+}
+
+// Verifies that the inputs to a function have a valid signature
+// Valid input is to be [0, all] of
+// context.Context, event.Event in this order.
+func (r *receiverFn) validateInParamSignature(fnType reflect.Type) error {
+	r.hasContextIn = false
+	r.hasEventIn = false
+
+	switch fnType.NumIn() {
+	case 2:
+		// has to be (context.Context, event.Event)
+		if !fnType.In(1).ConvertibleTo(eventType) {
+			return fmt.Errorf("%s; cannot convert parameter 2 from %s to event.Event", inParamUsage, fnType.In(1))
+		} else {
+			r.hasEventIn = true
+		}
+		fallthrough
+	case 1:
+		if !fnType.In(0).ConvertibleTo(contextType) {
+			if !fnType.In(0).ConvertibleTo(eventType) {
+				return fmt.Errorf("%s; cannot convert parameter 1 from %s to context.Context or event.Event", inParamUsage, fnType.In(0))
+			} else if r.hasEventIn {
+				return fmt.Errorf("%s; duplicate parameter of type event.Event", inParamUsage)
+			} else {
+				r.hasEventIn = true
+			}
+		} else {
+			r.hasContextIn = true
+		}
+		fallthrough
+	case 0:
+		return nil
+
+	default:
+		return fmt.Errorf("%s; function has too many parameters (%d)", inParamUsage, fnType.NumIn())
+	}
+}
+
+// Verifies that the outputs of a function have a valid signature
+// Valid output signatures to be [0, all] of
+// *event.Event, transport.Result in this order
+func (r *receiverFn) validateOutParamSignature(fnType reflect.Type) error {
+	r.hasEventOut = false
+	r.hasResultOut = false
+
+	switch fnType.NumOut() {
+	case 2:
+		// has to be (*event.Event, transport.Result)
+		if !fnType.Out(1).ConvertibleTo(resultType) {
+			return fmt.Errorf("%s; cannot convert parameter 2 from %s to event.Response", outParamUsage, fnType.Out(1))
+		} else {
+			r.hasResultOut = true
+		}
+		fallthrough
+	case 1:
+		if !fnType.Out(0).ConvertibleTo(resultType) {
+			if !fnType.Out(0).ConvertibleTo(eventPtrType) {
+				return fmt.Errorf("%s; cannot convert parameter 1 from %s to *event.Event or transport.Result", outParamUsage, fnType.Out(0))
+			} else {
+				r.hasEventOut = true
+			}
+		} else if r.hasResultOut {
+			return fmt.Errorf("%s; duplicate parameter of type event.Response", outParamUsage)
+		} else {
+			r.hasResultOut = true
+		}
+		fallthrough
+	case 0:
+		return nil
+	default:
+		return fmt.Errorf("%s; function has too many return types (%d)", outParamUsage, fnType.NumOut())
+	}
+}
+
+// validateReceiverFn validates that a function has the right number of in and
+// out params and that they are of allowed types.
+func (r *receiverFn) validate(fnType reflect.Type) error {
+	if err := r.validateInParamSignature(fnType); err != nil {
+		return err
+	}
+	if err := r.validateOutParamSignature(fnType); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/context/context.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/context/context.go
@@ -1,0 +1,52 @@
+package context
+
+import (
+	"context"
+	"net/url"
+)
+
+// Opaque key type used to store target
+type targetKeyType struct{}
+
+var targetKey = targetKeyType{}
+
+// WithTarget returns back a new context with the given target. Target is intended to be transport dependent.
+// For http transport, `target` should be a full URL and will be injected into the outbound http request.
+func WithTarget(ctx context.Context, target string) context.Context {
+	return context.WithValue(ctx, targetKey, target)
+}
+
+// TargetFrom looks in the given context and returns `target` as a parsed url if found and valid, otherwise nil.
+func TargetFrom(ctx context.Context) *url.URL {
+	c := ctx.Value(targetKey)
+	if c != nil {
+		if s, ok := c.(string); ok && s != "" {
+			if target, err := url.Parse(s); err == nil {
+				return target
+			}
+		}
+	}
+	return nil
+}
+
+// Opaque key type used to store topic
+type topicKeyType struct{}
+
+var topicKey = topicKeyType{}
+
+// WithTopic returns back a new context with the given topic. Topic is intended to be transport dependent.
+// For pubsub transport, `topic` should be a Pub/Sub Topic ID.
+func WithTopic(ctx context.Context, topic string) context.Context {
+	return context.WithValue(ctx, topicKey, topic)
+}
+
+// TopicFrom looks in the given context and returns `topic` as a string if found and valid, otherwise "".
+func TopicFrom(ctx context.Context) string {
+	c := ctx.Value(topicKey)
+	if c != nil {
+		if s, ok := c.(string); ok {
+			return s
+		}
+	}
+	return ""
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/context/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/context/doc.go
@@ -1,0 +1,5 @@
+/*
+Package context holds the last resort overrides and fyi objects that can be passed to clients and transports added to
+context.Context objects.
+*/
+package context

--- a/vendor/github.com/cloudevents/sdk-go/pkg/context/logger.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/context/logger.go
@@ -1,0 +1,43 @@
+package context
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+)
+
+// Opaque key type used to store logger
+type loggerKeyType struct{}
+
+var loggerKey = loggerKeyType{}
+
+// fallbackLogger is the logger is used when there is no logger attached to the context.
+var fallbackLogger *zap.SugaredLogger
+
+func init() {
+	if logger, err := zap.NewProduction(); err != nil {
+		// We failed to create a fallback logger.
+		fallbackLogger = zap.NewNop().Sugar()
+	} else {
+		fallbackLogger = logger.Named("fallback").Sugar()
+	}
+}
+
+// WithLogger returns a new context with the logger injected into the given context.
+func WithLogger(ctx context.Context, logger *zap.SugaredLogger) context.Context {
+	if logger == nil {
+		return context.WithValue(ctx, loggerKey, fallbackLogger)
+	}
+	return context.WithValue(ctx, loggerKey, logger)
+}
+
+// LoggerFrom returns the logger stored in context.
+func LoggerFrom(ctx context.Context) *zap.SugaredLogger {
+	l := ctx.Value(loggerKey)
+	if l != nil {
+		if logger, ok := l.(*zap.SugaredLogger); ok {
+			return logger
+		}
+	}
+	return fallbackLogger
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/content_type.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/content_type.go
@@ -1,0 +1,42 @@
+package event
+
+const (
+	TextPlain                       = "text/plain"
+	TextJSON                        = "text/json"
+	ApplicationJSON                 = "application/json"
+	ApplicationXML                  = "application/xml"
+	ApplicationCloudEventsJSON      = "application/cloudevents+json"
+	ApplicationCloudEventsBatchJSON = "application/cloudevents-batch+json"
+)
+
+// StringOfApplicationJSON returns a string pointer to "application/json"
+func StringOfApplicationJSON() *string {
+	a := ApplicationJSON
+	return &a
+}
+
+// StringOfApplicationXML returns a string pointer to "application/xml"
+func StringOfApplicationXML() *string {
+	a := ApplicationXML
+	return &a
+}
+
+// StringOfTextPlain returns a string pointer to "text/plain"
+func StringOfTextPlain() *string {
+	a := TextPlain
+	return &a
+}
+
+// StringOfApplicationCloudEventsJSON  returns a string pointer to
+// "application/cloudevents+json"
+func StringOfApplicationCloudEventsJSON() *string {
+	a := ApplicationCloudEventsJSON
+	return &a
+}
+
+// StringOfApplicationCloudEventsBatchJSON returns a string pointer to
+// "application/cloudevents-batch+json"
+func StringOfApplicationCloudEventsBatchJSON() *string {
+	a := ApplicationCloudEventsBatchJSON
+	return &a
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/data_content_encoding.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/data_content_encoding.go
@@ -1,0 +1,11 @@
+package event
+
+const (
+	Base64 = "base64"
+)
+
+// StringOfBase64 returns a string pointer to "Base64"
+func StringOfBase64() *string {
+	a := Base64
+	return &a
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/codec.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/codec.go
@@ -1,0 +1,96 @@
+package datacodec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/pkg/event/datacodec/json"
+	"github.com/cloudevents/sdk-go/pkg/event/datacodec/text"
+	"github.com/cloudevents/sdk-go/pkg/event/datacodec/xml"
+	"github.com/cloudevents/sdk-go/pkg/observability"
+)
+
+// Decoder is the expected function signature for decoding `in` to `out`. What
+// `in` is could be decoder dependent. For example, `in` could be bytes, or a
+// base64 string.
+type Decoder func(ctx context.Context, in, out interface{}) error
+
+// Encoder is the expected function signature for encoding `in` to bytes.
+// Returns an error if the encoder has an issue encoding `in`.
+type Encoder func(ctx context.Context, in interface{}) ([]byte, error)
+
+var decoder map[string]Decoder
+var encoder map[string]Encoder
+
+func init() {
+	decoder = make(map[string]Decoder, 10)
+	encoder = make(map[string]Encoder, 10)
+
+	AddDecoder("", json.Decode)
+	AddDecoder("application/json", json.Decode)
+	AddDecoder("text/json", json.Decode)
+	AddDecoder("application/xml", xml.Decode)
+	AddDecoder("text/xml", xml.Decode)
+	AddDecoder("text/plain", text.Decode)
+
+	AddEncoder("", json.Encode)
+	AddEncoder("application/json", json.Encode)
+	AddEncoder("text/json", json.Encode)
+	AddEncoder("application/xml", xml.Encode)
+	AddEncoder("text/xml", xml.Encode)
+	AddEncoder("text/plain", text.Encode)
+}
+
+// AddDecoder registers a decoder for a given content type. The codecs will use
+// these to decode the data payload from a cloudevent.Event object.
+func AddDecoder(contentType string, fn Decoder) {
+	decoder[contentType] = fn
+}
+
+// AddEncoder registers an encoder for a given content type. The codecs will
+// use these to encode the data payload for a cloudevent.Event object.
+func AddEncoder(contentType string, fn Encoder) {
+	encoder[contentType] = fn
+}
+
+// Decode looks up and invokes the decoder registered for the given content
+// type. An error is returned if no decoder is registered for the given
+// content type.
+func Decode(ctx context.Context, contentType string, in, out interface{}) error {
+	_, r := observability.NewReporter(ctx, reportDecode)
+	err := obsDecode(ctx, contentType, in, out)
+	if err != nil {
+		r.Error()
+	} else {
+		r.OK()
+	}
+	return err
+}
+
+func obsDecode(ctx context.Context, contentType string, in, out interface{}) error {
+	if fn, ok := decoder[contentType]; ok {
+		return fn(ctx, in, out)
+	}
+	return fmt.Errorf("[decode] unsupported content type: %q", contentType)
+}
+
+// Encode looks up and invokes the encoder registered for the given content
+// type. An error is returned if no encoder is registered for the given
+// content type.
+func Encode(ctx context.Context, contentType string, in interface{}) ([]byte, error) {
+	_, r := observability.NewReporter(ctx, reportEncode)
+	b, err := obsEncode(ctx, contentType, in)
+	if err != nil {
+		r.Error()
+	} else {
+		r.OK()
+	}
+	return b, err
+}
+
+func obsEncode(ctx context.Context, contentType string, in interface{}) ([]byte, error) {
+	if fn, ok := encoder[contentType]; ok {
+		return fn(ctx, in)
+	}
+	return nil, fmt.Errorf("[encode] unsupported content type: %q", contentType)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/doc.go
@@ -1,0 +1,5 @@
+/*
+Package datacodec holds the data codec registry and adds known encoders and decoders supporting media types such as
+`application/json` and `application/xml`.
+*/
+package datacodec

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/json/data.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/json/data.go
@@ -1,0 +1,97 @@
+package json
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+
+	"github.com/cloudevents/sdk-go/pkg/observability"
+)
+
+// Decode takes `in` as []byte, or base64 string, normalizes in to unquoted and
+// base64 decoded []byte if required, and then attempts to use json.Unmarshal
+// to convert those bytes to `out`. Returns and error if this process fails.
+func Decode(ctx context.Context, in, out interface{}) error {
+	_, r := observability.NewReporter(ctx, reportDecode)
+	err := obsDecode(ctx, in, out)
+	if err != nil {
+		r.Error()
+	} else {
+		r.OK()
+	}
+	return err
+}
+
+func obsDecode(ctx context.Context, in, out interface{}) error {
+	if in == nil {
+		return nil
+	}
+	if out == nil {
+		return fmt.Errorf("out is nil")
+	}
+
+	b, ok := in.([]byte) // TODO: I think there is fancy marshaling happening here. Fix with reflection?
+	if !ok {
+		var err error
+		b, err = json.Marshal(in)
+		if err != nil {
+			return fmt.Errorf("[json] failed to marshal in: %s", err.Error())
+		}
+	}
+
+	// TODO: the spec says json could be just data... At the moment we expect wrapped.
+	if len(b) > 1 && (b[0] == byte('"') || (b[0] == byte('\\') && b[1] == byte('"'))) {
+		s, err := strconv.Unquote(string(b))
+		if err != nil {
+			return fmt.Errorf("[json] failed to unquote in: %s", err.Error())
+		}
+		if len(s) > 0 && (s[0] == '{' || s[0] == '[') {
+			// looks like json, use it
+			b = []byte(s)
+		}
+	}
+
+	if err := json.Unmarshal(b, out); err != nil {
+		return fmt.Errorf("[json] found bytes \"%s\", but failed to unmarshal: %s", string(b), err.Error())
+	}
+	return nil
+}
+
+// Encode attempts to json.Marshal `in` into bytes. Encode will inspect `in`
+// and returns `in` unmodified if it is detected that `in` is already a []byte;
+// Or json.Marshal errors.
+func Encode(ctx context.Context, in interface{}) ([]byte, error) {
+	_, r := observability.NewReporter(ctx, reportEncode)
+	b, err := obsEncode(ctx, in)
+	if err != nil {
+		r.Error()
+	} else {
+		r.OK()
+	}
+	return b, err
+}
+
+func obsEncode(ctx context.Context, in interface{}) ([]byte, error) {
+	if in == nil {
+		return nil, nil
+	}
+
+	it := reflect.TypeOf(in)
+	switch it.Kind() {
+	case reflect.Slice:
+		if it.Elem().Kind() == reflect.Uint8 {
+
+			if b, ok := in.([]byte); ok && len(b) > 0 {
+				// check to see if it is a pre-encoded byte string.
+				if b[0] == byte('"') || b[0] == byte('{') || b[0] == byte('[') {
+					return b, nil
+				}
+			}
+
+		}
+	}
+
+	return json.Marshal(in)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/json/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/json/doc.go
@@ -1,0 +1,4 @@
+/*
+Package json holds the encoder/decoder implementation for `application/json`.
+*/
+package json

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/json/observability.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/json/observability.go
@@ -1,0 +1,51 @@
+package json
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/observability"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+var (
+	// LatencyMs measures the latency in milliseconds for the CloudEvents json
+	// data codec methods.
+	LatencyMs = stats.Float64("cloudevents.io/sdk-go/datacodec/json/latency", "The latency in milliseconds for the CloudEvents json data codec methods.", "ms")
+)
+
+var (
+	// LatencyView is an OpenCensus view that shows data codec json method latency.
+	LatencyView = &view.View{
+		Name:        "datacodec/json/latency",
+		Measure:     LatencyMs,
+		Description: "The distribution of latency inside of the json data codec for CloudEvents.",
+		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
+		TagKeys:     observability.LatencyTags(),
+	}
+)
+
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
+
+const (
+	reportEncode observed = iota
+	reportDecode
+)
+
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
+	switch o {
+	case reportEncode:
+		return "encode"
+	case reportDecode:
+		return "decode"
+	default:
+		return "unknown"
+	}
+}
+
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return LatencyMs
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/observability.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/observability.go
@@ -1,0 +1,51 @@
+package datacodec
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/observability"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+var (
+	// LatencyMs measures the latency in milliseconds for the CloudEvents generic
+	// codec data methods.
+	LatencyMs = stats.Float64("cloudevents.io/sdk-go/datacodec/latency", "The latency in milliseconds for the CloudEvents generic data codec methods.", "ms")
+)
+
+var (
+	// LatencyView is an OpenCensus view that shows data codec method latency.
+	LatencyView = &view.View{
+		Name:        "datacodec/latency",
+		Measure:     LatencyMs,
+		Description: "The distribution of latency inside of the generic data codec for CloudEvents.",
+		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
+		TagKeys:     observability.LatencyTags(),
+	}
+)
+
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
+
+const (
+	reportEncode observed = iota
+	reportDecode
+)
+
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
+	switch o {
+	case reportEncode:
+		return "encode"
+	case reportDecode:
+		return "decode"
+	default:
+		return "unknown"
+	}
+}
+
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return LatencyMs
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/text/text.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/text/text.go
@@ -1,0 +1,33 @@
+// Text codec converts []byte or string to string and vice-versa.
+package text
+
+import (
+	"context"
+	"fmt"
+)
+
+func Decode(_ context.Context, in, out interface{}) error {
+	p, _ := out.(*string)
+	if p == nil {
+		return fmt.Errorf("text.Decode out: want *string, got %T", out)
+	}
+	switch s := in.(type) {
+	case string:
+		*p = s
+	case []byte:
+		*p = string(s)
+	case nil: // treat nil like []byte{}
+		*p = ""
+	default:
+		return fmt.Errorf("text.Decode in: want []byte or string, got %T", in)
+	}
+	return nil
+}
+
+func Encode(_ context.Context, in interface{}) ([]byte, error) {
+	s, ok := in.(string)
+	if !ok {
+		return nil, fmt.Errorf("text.Encode in: want string, got %T", in)
+	}
+	return []byte(s), nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/xml/data.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/xml/data.go
@@ -1,0 +1,90 @@
+package xml
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"strconv"
+
+	"github.com/cloudevents/sdk-go/pkg/observability"
+)
+
+// Decode takes `in` as []byte, or base64 string, normalizes in to unquoted and
+// base64 decoded []byte if required, and then attempts to use xml.Unmarshal
+// to convert those bytes to `out`. Returns and error if this process fails.
+func Decode(ctx context.Context, in, out interface{}) error {
+	_, r := observability.NewReporter(ctx, reportDecode)
+	err := obsDecode(ctx, in, out)
+	if err != nil {
+		r.Error()
+	} else {
+		r.OK()
+	}
+	return err
+}
+
+func obsDecode(ctx context.Context, in, out interface{}) error {
+	if in == nil {
+		return nil
+	}
+
+	b, ok := in.([]byte)
+	if !ok {
+		var err error
+		b, err = xml.Marshal(in)
+		if err != nil {
+			return fmt.Errorf("[xml] failed to marshal in: %s", err.Error())
+		}
+	}
+
+	// If the message is encoded as a base64 block as a string, we need to
+	// decode that first before trying to unmarshal the bytes
+	if len(b) > 1 && (b[0] == byte('"') || (b[0] == byte('\\') && b[1] == byte('"'))) {
+		s, err := strconv.Unquote(string(b))
+		if err != nil {
+			return fmt.Errorf("[xml] failed to unquote quoted data: %s", err.Error())
+		}
+		if len(s) > 0 && s[0] == '<' {
+			// looks like xml, use it
+			b = []byte(s)
+		} else if len(s) > 0 {
+			// looks like base64, decode
+			bs, err := base64.StdEncoding.DecodeString(s)
+			if err != nil {
+				return fmt.Errorf("[xml] failed to decode base64 encoded string: %s", err.Error())
+			}
+			b = bs
+		}
+	}
+
+	if err := xml.Unmarshal(b, out); err != nil {
+		return fmt.Errorf("[xml] found bytes, but failed to unmarshal: %s %s", err.Error(), string(b))
+	}
+	return nil
+}
+
+// Encode attempts to xml.Marshal `in` into bytes. Encode will inspect `in`
+// and returns `in` unmodified if it is detected that `in` is already a []byte;
+// Or xml.Marshal errors.
+func Encode(ctx context.Context, in interface{}) ([]byte, error) {
+	_, r := observability.NewReporter(ctx, reportEncode)
+	b, err := obsEncode(ctx, in)
+	if err != nil {
+		r.Error()
+	} else {
+		r.OK()
+	}
+	return b, err
+}
+
+func obsEncode(ctx context.Context, in interface{}) ([]byte, error) {
+	if b, ok := in.([]byte); ok {
+		// check to see if it is a pre-encoded byte string.
+		if len(b) > 0 && b[0] == byte('"') {
+			return b, nil
+		}
+	}
+
+	return xml.Marshal(in)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/xml/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/xml/doc.go
@@ -1,0 +1,4 @@
+/*
+Package xml holds the encoder/decoder implementation for `application/xml`.
+*/
+package xml

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/xml/observability.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/datacodec/xml/observability.go
@@ -1,0 +1,51 @@
+package xml
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/observability"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+var (
+	// LatencyMs measures the latency in milliseconds for the CloudEvents xml data
+	// codec methods.
+	LatencyMs = stats.Float64("cloudevents.io/sdk-go/datacodec/xml/latency", "The latency in milliseconds for the CloudEvents xml data codec methods.", "ms")
+)
+
+var (
+	// LatencyView is an OpenCensus view that shows data codec xml method latency.
+	LatencyView = &view.View{
+		Name:        "datacodec/xml/latency",
+		Measure:     LatencyMs,
+		Description: "The distribution of latency inside of the xml data codec for CloudEvents.",
+		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
+		TagKeys:     observability.LatencyTags(),
+	}
+)
+
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
+
+const (
+	reportEncode observed = iota
+	reportDecode
+)
+
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
+	switch o {
+	case reportEncode:
+		return "encode"
+	case reportDecode:
+		return "decode"
+	default:
+		return "unknown"
+	}
+}
+
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return LatencyMs
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/doc.go
@@ -1,0 +1,4 @@
+/*
+Package cloudevents provides primitives to work with CloudEvents specification: https://github.com/cloudevents/spec.
+*/
+package event

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/event.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/event.go
@@ -1,0 +1,155 @@
+package event
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Event represents the canonical representation of a CloudEvent.
+type Event struct {
+	Context     EventContext
+	DataEncoded []byte
+	DataBinary  bool
+	FieldErrors map[string]error
+}
+
+const (
+	defaultEventVersion = CloudEventsVersionV1
+)
+
+func (e *Event) fieldError(field string, err error) {
+	if e.FieldErrors == nil {
+		e.FieldErrors = make(map[string]error, 0)
+	}
+	e.FieldErrors[field] = err
+}
+
+func (e *Event) fieldOK(field string) {
+	if e.FieldErrors != nil {
+		delete(e.FieldErrors, field)
+	}
+}
+
+// New returns a new Event, an optional version can be passed to change the
+// default spec version from 1.0 to the provided version.
+func New(version ...string) Event {
+	specVersion := defaultEventVersion
+	if len(version) >= 1 {
+		specVersion = version[0]
+	}
+	e := &Event{}
+	e.SetSpecVersion(specVersion)
+	return *e
+}
+
+// DEPRECATED: Access extensions directly via the e.Extensions() map.
+// Use functions in the types package to convert extension values.
+// For example replace this:
+//
+//     var i int
+//     err := e.ExtensionAs("foo", &i)
+//
+// With this:
+//
+//     i, err := types.ToInteger(e.Extensions["foo"])
+//
+func (e Event) ExtensionAs(name string, obj interface{}) error {
+	return e.Context.ExtensionAs(name, obj)
+}
+
+// Validate performs a spec based validation on this event.
+// Validation is dependent on the spec version specified in the event context.
+func (e Event) Validate() error {
+	if e.Context == nil {
+		return fmt.Errorf("every event conforming to the CloudEvents specification MUST include a context")
+	}
+
+	if e.FieldErrors != nil {
+		errs := make([]string, 0)
+		for f, e := range e.FieldErrors {
+			errs = append(errs, fmt.Sprintf("%q: %s,", f, e))
+		}
+		if len(errs) > 0 {
+			return fmt.Errorf("previous field errors: [%s]", strings.Join(errs, "\n"))
+		}
+	}
+
+	if err := e.Context.Validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// String returns a pretty-printed representation of the Event.
+func (e Event) String() string {
+	b := strings.Builder{}
+
+	b.WriteString("Validation: ")
+
+	valid := e.Validate()
+	if valid == nil {
+		b.WriteString("valid\n")
+	} else {
+		b.WriteString("invalid\n")
+	}
+	if valid != nil {
+		b.WriteString(fmt.Sprintf("Validation Error: \n%s\n", valid.Error()))
+	}
+
+	b.WriteString(e.Context.String())
+
+	if e.DataEncoded != nil {
+		if e.DataBinary {
+			b.WriteString("Data (binary),\n  ")
+		} else {
+			b.WriteString("Data,\n  ")
+		}
+		switch e.DataMediaType() {
+		case ApplicationJSON:
+			var prettyJSON bytes.Buffer
+			err := json.Indent(&prettyJSON, e.DataEncoded, "  ", "  ")
+			if err != nil {
+				b.Write(e.DataEncoded)
+			} else {
+				b.Write(prettyJSON.Bytes())
+			}
+		default:
+			b.Write(e.DataEncoded)
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func (e Event) Clone() Event {
+	out := Event{}
+	out.Context = e.Context.Clone()
+	out.DataEncoded = cloneBytes(e.DataEncoded)
+	out.DataBinary = e.DataBinary
+	out.FieldErrors = e.cloneFieldErrors()
+	return out
+}
+
+func cloneBytes(in []byte) []byte {
+	if in == nil {
+		return nil
+	}
+	out := make([]byte, len(in))
+	copy(out, in)
+	return out
+}
+
+func (e Event) cloneFieldErrors() map[string]error {
+	if e.FieldErrors == nil {
+		return nil
+	}
+	newFE := make(map[string]error, len(e.FieldErrors))
+	for k, v := range e.FieldErrors {
+		newFE[k] = v
+	}
+	return newFE
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/event_data.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/event_data.go
@@ -1,0 +1,112 @@
+package event
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+
+	"github.com/cloudevents/sdk-go/pkg/event/datacodec"
+)
+
+// Data is special. Break it out into it's own file.
+
+// SetData implements EventWriter.SetData
+func (e *Event) SetData(contentType string, obj interface{}) error {
+	e.SetDataContentType(contentType)
+
+	if e.SpecVersion() != CloudEventsVersionV1 {
+		return e.legacySetData(obj)
+	}
+
+	// Version 1.0 and above.
+	switch obj := obj.(type) {
+	case []byte:
+		e.DataEncoded = obj
+		e.DataBinary = true
+	default:
+		data, err := datacodec.Encode(context.Background(), e.DataMediaType(), obj)
+		if err != nil {
+			return err
+		}
+		e.DataEncoded = data
+		e.DataBinary = false
+	}
+
+	return nil
+}
+
+// Deprecated: Delete when we do not have to support Spec v0.3.
+func (e *Event) legacySetData(obj interface{}) error {
+	data, err := datacodec.Encode(context.Background(), e.DataMediaType(), obj)
+	if err != nil {
+		return err
+	}
+	if e.DeprecatedDataContentEncoding() == Base64 {
+		buf := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
+		base64.StdEncoding.Encode(buf, data)
+		e.DataEncoded = buf
+		e.DataBinary = false
+	} else {
+		data, err := datacodec.Encode(context.Background(), e.DataMediaType(), obj)
+		if err != nil {
+			return err
+		}
+		e.DataEncoded = data
+		e.DataBinary = false
+	}
+	return nil
+}
+
+const (
+	quotes = `"'`
+)
+
+func (e Event) Data() []byte {
+	return e.DataEncoded
+}
+
+// DataAs attempts to populate the provided data object with the event payload.
+// data should be a pointer type.
+func (e Event) DataAs(obj interface{}) error {
+	data := e.Data()
+
+	if len(data) == 0 {
+		// No data.
+		return nil
+	}
+
+	if e.SpecVersion() != CloudEventsVersionV1 {
+		var err error
+		if data, err = e.legacyConvertData(data); err != nil {
+			return err
+		}
+	}
+
+	return datacodec.Decode(context.Background(), e.DataMediaType(), data, obj)
+}
+
+func (e Event) legacyConvertData(data []byte) ([]byte, error) {
+	if e.Context.DeprecatedGetDataContentEncoding() == Base64 {
+		var bs []byte
+		// test to see if we need to unquote the data.
+		if data[0] == quotes[0] || data[0] == quotes[1] {
+			str, err := strconv.Unquote(string(data))
+			if err != nil {
+				return nil, err
+			}
+			bs = []byte(str)
+		} else {
+			bs = data
+		}
+
+		buf := make([]byte, base64.StdEncoding.DecodedLen(len(bs)))
+		n, err := base64.StdEncoding.Decode(buf, bs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode data from base64: %s", err.Error())
+		}
+		data = buf[:n]
+	}
+
+	return data, nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/event_interface.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/event_interface.go
@@ -1,0 +1,94 @@
+package event
+
+import (
+	"time"
+)
+
+// EventWriter is the interface for reading through an event from attributes.
+type EventReader interface {
+	// SpecVersion returns event.Context.GetSpecVersion().
+	SpecVersion() string
+	// Type returns event.Context.GetType().
+	Type() string
+	// Source returns event.Context.GetSource().
+	Source() string
+	// Subject returns event.Context.GetSubject().
+	Subject() string
+	// ID returns event.Context.GetID().
+	ID() string
+	// Time returns event.Context.GetTime().
+	Time() time.Time
+	// DataSchema returns event.Context.GetDataSchema().
+	DataSchema() string
+	// DataContentType returns event.Context.GetDataContentType().
+	DataContentType() string
+	// DataMediaType returns event.Context.GetDataMediaType().
+	DataMediaType() string
+	// DeprecatedDataContentEncoding returns event.Context.DeprecatedGetDataContentEncoding().
+	DeprecatedDataContentEncoding() string
+
+	// Extension Attributes
+
+	// Extensions returns the event.Context.GetExtensions().
+	// Extensions use the CloudEvents type system, details in package cloudevents/types.
+	Extensions() map[string]interface{}
+
+	// ExtensionAs returns event.Context.ExtensionAs(name, obj).
+	//
+	// DEPRECATED: Access extensions directly via the e.Extensions() map.
+	// Use functions in the types package to convert extension values.
+	// For example replace this:
+	//
+	//     var i int
+	//     err := e.ExtensionAs("foo", &i)
+	//
+	// With this:
+	//
+	//     i, err := types.ToInteger(e.Extensions["foo"])
+	//
+	ExtensionAs(string, interface{}) error
+
+	// Data Attribute
+
+	// Data returns the raw data buffer, it might be encoded depending on data
+	// content type.
+	Data() []byte
+
+	// DataAs attempts to populate the provided data object with the event payload.
+	// data should be a pointer type.
+	DataAs(interface{}) error
+}
+
+// EventWriter is the interface for writing through an event onto attributes.
+// If an error is thrown by a sub-component, EventWriter caches the error
+// internally and exposes errors with a call to event.Validate().
+type EventWriter interface {
+	// Context Attributes
+
+	// SetSpecVersion performs event.Context.SetSpecVersion.
+	SetSpecVersion(string)
+	// SetType performs event.Context.SetType.
+	SetType(string)
+	// SetSource performs event.Context.SetSource.
+	SetSource(string)
+	// SetSubject( performs event.Context.SetSubject.
+	SetSubject(string)
+	// SetID performs event.Context.SetID.
+	SetID(string)
+	// SetTime performs event.Context.SetTime.
+	SetTime(time.Time)
+	// SetDataSchema performs event.Context.SetDataSchema.
+	SetDataSchema(string)
+	// SetDataContentType performs event.Context.SetDataContentType.
+	SetDataContentType(string)
+	// DeprecatedSetDataContentEncoding performs event.Context.DeprecatedSetDataContentEncoding.
+	SetDataContentEncoding(string)
+
+	// Extension Attributes
+
+	// SetExtension performs event.Context.SetExtension.
+	SetExtension(string, interface{})
+
+	// SetData encodes the given payload with the given content type.
+	SetData(string, interface{}) error
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/event_marshal.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/event_marshal.go
@@ -1,0 +1,288 @@
+package event
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	errors2 "github.com/pkg/errors"
+
+	"github.com/cloudevents/sdk-go/pkg/observability"
+)
+
+// MarshalJSON implements a custom json marshal method used when this type is
+// marshaled using json.Marshal.
+func (e Event) MarshalJSON() ([]byte, error) {
+	_, r := observability.NewReporter(context.Background(), eventJSONObserved{o: reportMarshal, v: e.SpecVersion()})
+
+	if err := e.Validate(); err != nil {
+		r.Error()
+		return nil, err
+	}
+
+	var b []byte
+	var err error
+
+	switch e.SpecVersion() {
+	case CloudEventsVersionV03:
+		b, err = JsonEncodeLegacy(e)
+	case CloudEventsVersionV1:
+		b, err = JsonEncode(e)
+	default:
+		return nil, fmt.Errorf("unnknown spec version: %q", e.SpecVersion())
+	}
+
+	// Report the observable
+	if err != nil {
+		r.Error()
+		return nil, err
+	} else {
+		r.OK()
+	}
+
+	return b, nil
+}
+
+// UnmarshalJSON implements the json unmarshal method used when this type is
+// unmarshaled using json.Unmarshal.
+func (e *Event) UnmarshalJSON(b []byte) error {
+	raw := make(map[string]json.RawMessage)
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+
+	version := versionFromRawMessage(raw)
+
+	_, r := observability.NewReporter(context.Background(), eventJSONObserved{o: reportUnmarshal, v: version})
+
+	var err error
+	switch version {
+	case CloudEventsVersionV03:
+		err = e.JsonDecodeV03(b, raw)
+	case CloudEventsVersionV1:
+		err = e.JsonDecodeV1(b, raw)
+	default:
+		return fmt.Errorf("unnknown spec version: %q", version)
+	}
+
+	// Report the observable
+	if err != nil {
+		r.Error()
+		return err
+	} else {
+		r.OK()
+	}
+	return nil
+}
+
+func versionFromRawMessage(raw map[string]json.RawMessage) string {
+	// v0.2 and after
+	if v, ok := raw["specversion"]; ok {
+		var version string
+		if err := json.Unmarshal(v, &version); err != nil {
+			return ""
+		}
+		return version
+	}
+	return ""
+}
+
+// JsonEncode
+func JsonEncode(e Event) ([]byte, error) {
+	return jsonEncode(e.Context, e.DataEncoded, e.DataBinary)
+}
+
+// JsonEncodeLegacy
+func JsonEncodeLegacy(e Event) ([]byte, error) {
+	isBase64 := e.Context.DeprecatedGetDataContentEncoding() == Base64
+	return jsonEncode(e.Context, e.Data(), isBase64)
+}
+
+func jsonEncode(ctx EventContextReader, data []byte, isBase64 bool) ([]byte, error) {
+	var b map[string]json.RawMessage
+	var err error
+
+	b, err = marshalEvent(ctx, ctx.GetExtensions())
+	if err != nil {
+		return nil, err
+	}
+
+	if data != nil {
+		// data is passed in as an encoded []byte. That slice might be any
+		// number of things but for json encoding of the envelope all we care
+		// is if the payload is either a string or a json object. If it is a
+		// json object, it can be inserted into the body without modification.
+		// Otherwise we need to quote it if not already quoted.
+		mediaType, err := ctx.GetDataMediaType()
+		if err != nil {
+			return nil, err
+		}
+		isJson := mediaType == "" || mediaType == ApplicationJSON || mediaType == TextJSON
+		// TODO(#60): we do not support json values at the moment, only objects and lists.
+		if isJson && !isBase64 {
+			b["data"] = data
+		} else {
+			var dataKey string
+			if ctx.GetSpecVersion() == CloudEventsVersionV1 {
+				dataKey = "data_base64"
+				buf := make([]byte, base64.StdEncoding.EncodedLen(len(data)))
+				base64.StdEncoding.Encode(buf, data)
+				data = buf
+			} else {
+				dataKey = "data"
+			}
+			if data[0] != byte('"') {
+				b[dataKey] = []byte(strconv.QuoteToASCII(string(data)))
+			} else {
+				// already quoted
+				b[dataKey] = data
+			}
+		}
+	}
+
+	body, err := json.Marshal(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+// JsonDecodeV03 takes in the byte representation of a version 0.3 structured json CloudEvent and returns a
+// cloudevent.Event or an error if there are parsing errors.
+func (e *Event) JsonDecodeV03(body []byte, raw map[string]json.RawMessage) error {
+	ec := EventContextV03{}
+	if err := json.Unmarshal(body, &ec); err != nil {
+		return err
+	}
+
+	// TODO: could use reflection to get these.
+	delete(raw, "specversion")
+	delete(raw, "type")
+	delete(raw, "source")
+	delete(raw, "subject")
+	delete(raw, "id")
+	delete(raw, "time")
+	delete(raw, "schemaurl")
+	delete(raw, "datacontenttype")
+	delete(raw, "datacontentencoding")
+
+	var data []byte
+	if d, ok := raw["data"]; ok {
+		data = d
+	}
+	delete(raw, "data")
+
+	if len(raw) > 0 {
+		extensions := make(map[string]interface{}, len(raw))
+		ec.Extensions = extensions
+		for k, v := range raw {
+			k = strings.ToLower(k)
+			var tmp interface{}
+			if err := json.Unmarshal(v, &tmp); err != nil {
+				return err
+			}
+			if err := ec.SetExtension(k, tmp); err != nil {
+				return errors2.Wrap(err, "Cannot set extension with key "+k)
+			}
+		}
+	}
+
+	e.Context = &ec
+	e.DataEncoded = data
+
+	return nil
+}
+
+// JsonDecodeV1 takes in the byte representation of a version 1.0 structured json CloudEvent and returns a
+// cloudevent.Event or an error if there are parsing errors.
+func (e *Event) JsonDecodeV1(body []byte, raw map[string]json.RawMessage) error {
+	ec := EventContextV1{}
+	if err := json.Unmarshal(body, &ec); err != nil {
+		return err
+	}
+
+	delete(raw, "specversion")
+	delete(raw, "type")
+	delete(raw, "source")
+	delete(raw, "subject")
+	delete(raw, "id")
+	delete(raw, "time")
+	delete(raw, "dataschema")
+	delete(raw, "datacontenttype")
+
+	var data []byte
+	if d, ok := raw["data"]; ok {
+		data = d
+	}
+	delete(raw, "data")
+
+	var dataBase64 []byte
+	if d, ok := raw["data_base64"]; ok {
+		var tmp []byte
+		if err := json.Unmarshal(d, &tmp); err != nil {
+			return err
+		}
+		dataBase64 = tmp
+	}
+	delete(raw, "data_base64")
+
+	if len(raw) > 0 {
+		extensions := make(map[string]interface{}, len(raw))
+		ec.Extensions = extensions
+		for k, v := range raw {
+			k = strings.ToLower(k)
+			var tmp interface{}
+			if err := json.Unmarshal(v, &tmp); err != nil {
+				return err
+			}
+			if err := ec.SetExtension(k, tmp); err != nil {
+				return errors2.Wrap(err, "Cannot set extension with key "+k)
+			}
+		}
+	}
+
+	e.Context = &ec
+	if data != nil && dataBase64 != nil {
+		return errors.New("parsing error: JSON decoder found both 'data', and 'data_base64' in JSON payload")
+	}
+	if data != nil {
+		e.DataEncoded = data
+		e.DataBinary = false
+	} else if dataBase64 != nil {
+		e.DataEncoded = dataBase64
+		e.DataBinary = true
+	}
+
+	return nil
+}
+
+func marshalEvent(event interface{}, extensions map[string]interface{}) (map[string]json.RawMessage, error) {
+	b, err := json.Marshal(event)
+	if err != nil {
+		return nil, err
+	}
+
+	brm := map[string]json.RawMessage{}
+	if err := json.Unmarshal(b, &brm); err != nil {
+		return nil, err
+	}
+
+	for k, v := range extensions {
+		k = strings.ToLower(k)
+		vb, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		// Don't overwrite spec keys.
+		if _, ok := brm[k]; !ok {
+			brm[k] = vb
+		}
+	}
+
+	return brm, nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/event_observability.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/event_observability.go
@@ -1,0 +1,77 @@
+package event
+
+import (
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/pkg/observability"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+var (
+	// EventMarshalLatencyMs measures the latency in milliseconds for the
+	// CloudEvents.Event marshal/unmarshalJSON methods.
+	EventMarshalLatencyMs = stats.Float64(
+		"cloudevents.io/sdk-go/event/json/latency",
+		"The latency in milliseconds of (un)marshalJSON methods for CloudEvents.Event.",
+		"ms")
+)
+
+var (
+	// LatencyView is an OpenCensus view that shows CloudEvents.Event (un)marshalJSON method latency.
+	EventMarshalLatencyView = &view.View{
+		Name:        "event/json/latency",
+		Measure:     EventMarshalLatencyMs,
+		Description: "The distribution of latency inside of (un)marshalJSON methods for CloudEvents.Event.",
+		Aggregation: view.Distribution(0, .01, .1, 1, 10, 100, 1000, 10000),
+		TagKeys:     observability.LatencyTags(),
+	}
+)
+
+type observed int32
+
+// Adheres to Observable
+var _ observability.Observable = observed(0)
+
+const (
+	reportMarshal observed = iota
+	reportUnmarshal
+)
+
+// MethodName implements Observable.MethodName
+func (o observed) MethodName() string {
+	switch o {
+	case reportMarshal:
+		return "marshaljson"
+	case reportUnmarshal:
+		return "unmarshaljson"
+	default:
+		return "unknown"
+	}
+}
+
+// LatencyMs implements Observable.LatencyMs
+func (o observed) LatencyMs() *stats.Float64Measure {
+	return EventMarshalLatencyMs
+}
+
+// eventJSONObserved is a wrapper to append version to observed.
+type eventJSONObserved struct {
+	// Method
+	o observed
+	// Version
+	v string
+}
+
+// Adheres to Observable
+var _ observability.Observable = (*eventJSONObserved)(nil)
+
+// MethodName implements Observable.MethodName
+func (c eventJSONObserved) MethodName() string {
+	return fmt.Sprintf("%s/%s", c.o.MethodName(), c.v)
+}
+
+// LatencyMs implements Observable.LatencyMs
+func (c eventJSONObserved) LatencyMs() *stats.Float64Measure {
+	return c.o.LatencyMs()
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/event_reader.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/event_reader.go
@@ -1,0 +1,98 @@
+package event
+
+import (
+	"time"
+)
+
+var _ EventReader = (*Event)(nil)
+
+// SpecVersion implements EventReader.SpecVersion
+func (e Event) SpecVersion() string {
+	if e.Context != nil {
+		return e.Context.GetSpecVersion()
+	}
+	return ""
+}
+
+// Type implements EventReader.Type
+func (e Event) Type() string {
+	if e.Context != nil {
+		return e.Context.GetType()
+	}
+	return ""
+}
+
+// Source implements EventReader.Source
+func (e Event) Source() string {
+	if e.Context != nil {
+		return e.Context.GetSource()
+	}
+	return ""
+}
+
+// Subject implements EventReader.Subject
+func (e Event) Subject() string {
+	if e.Context != nil {
+		return e.Context.GetSubject()
+	}
+	return ""
+}
+
+// ID implements EventReader.ID
+func (e Event) ID() string {
+	if e.Context != nil {
+		return e.Context.GetID()
+	}
+	return ""
+}
+
+// Time implements EventReader.Time
+func (e Event) Time() time.Time {
+	if e.Context != nil {
+		return e.Context.GetTime()
+	}
+	return time.Time{}
+}
+
+// DataSchema implements EventReader.DataSchema
+func (e Event) DataSchema() string {
+	if e.Context != nil {
+		return e.Context.GetDataSchema()
+	}
+	return ""
+}
+
+// DataContentType implements EventReader.DataContentType
+func (e Event) DataContentType() string {
+	if e.Context != nil {
+		return e.Context.GetDataContentType()
+	}
+	return ""
+}
+
+// DataMediaType returns the parsed DataMediaType of the event. If parsing
+// fails, the empty string is returned. To retrieve the parsing error, use
+// `Context.GetDataMediaType` instead.
+func (e Event) DataMediaType() string {
+	if e.Context != nil {
+		mediaType, _ := e.Context.GetDataMediaType()
+		return mediaType
+	}
+	return ""
+}
+
+// DeprecatedDataContentEncoding implements EventReader.DeprecatedDataContentEncoding
+func (e Event) DeprecatedDataContentEncoding() string {
+	if e.Context != nil {
+		return e.Context.DeprecatedGetDataContentEncoding()
+	}
+	return ""
+}
+
+// Extensions implements EventReader.Extensions
+func (e Event) Extensions() map[string]interface{} {
+	if e.Context != nil {
+		return e.Context.GetExtensions()
+	}
+	return map[string]interface{}(nil)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/event_writer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/event_writer.go
@@ -1,0 +1,112 @@
+package event
+
+import (
+	"fmt"
+	"time"
+)
+
+var _ EventWriter = (*Event)(nil)
+
+// SetSpecVersion implements EventWriter.SetSpecVersion
+func (e *Event) SetSpecVersion(v string) {
+	if e.Context == nil {
+		switch v {
+		case CloudEventsVersionV03:
+			e.Context = EventContextV03{}.AsV03()
+		case CloudEventsVersionV1:
+			e.Context = EventContextV1{}.AsV1()
+		default:
+			e.fieldError("specversion", fmt.Errorf("a valid spec version is required: [%s, %s]",
+				CloudEventsVersionV03, CloudEventsVersionV1))
+			return
+		}
+		e.fieldOK("specversion")
+		return
+	}
+	if err := e.Context.SetSpecVersion(v); err != nil {
+		e.fieldError("specversion", err)
+	} else {
+		e.fieldOK("specversion")
+	}
+}
+
+// SetType implements EventWriter.SetType
+func (e *Event) SetType(t string) {
+	if err := e.Context.SetType(t); err != nil {
+		e.fieldError("type", err)
+	} else {
+		e.fieldOK("type")
+	}
+}
+
+// SetSource implements EventWriter.SetSource
+func (e *Event) SetSource(s string) {
+	if err := e.Context.SetSource(s); err != nil {
+		e.fieldError("source", err)
+	} else {
+		e.fieldOK("source")
+	}
+}
+
+// SetSubject implements EventWriter.SetSubject
+func (e *Event) SetSubject(s string) {
+	if err := e.Context.SetSubject(s); err != nil {
+		e.fieldError("subject", err)
+	} else {
+		e.fieldOK("subject")
+	}
+}
+
+// SetID implements EventWriter.SetID
+func (e *Event) SetID(id string) {
+	if err := e.Context.SetID(id); err != nil {
+		e.fieldError("id", err)
+	} else {
+		e.fieldOK("id")
+	}
+}
+
+// SetTime implements EventWriter.SetTime
+func (e *Event) SetTime(t time.Time) {
+	if err := e.Context.SetTime(t); err != nil {
+		e.fieldError("time", err)
+	} else {
+		e.fieldOK("time")
+	}
+}
+
+// SetDataSchema implements EventWriter.SetDataSchema
+func (e *Event) SetDataSchema(s string) {
+	if err := e.Context.SetDataSchema(s); err != nil {
+		e.fieldError("dataschema", err)
+	} else {
+		e.fieldOK("dataschema")
+	}
+}
+
+// SetDataContentType implements EventWriter.SetDataContentType
+func (e *Event) SetDataContentType(ct string) {
+	if err := e.Context.SetDataContentType(ct); err != nil {
+		e.fieldError("datacontenttype", err)
+	} else {
+		e.fieldOK("datacontenttype")
+	}
+}
+
+// DeprecatedSetDataContentEncoding implements EventWriter.DeprecatedSetDataContentEncoding
+func (e *Event) SetDataContentEncoding(enc string) {
+	if err := e.Context.DeprecatedSetDataContentEncoding(enc); err != nil {
+		e.fieldError("datacontentencoding", err)
+	} else {
+		e.fieldOK("datacontentencoding")
+	}
+}
+
+// SetExtension implements EventWriter.SetExtension
+func (e *Event) SetExtension(name string, obj interface{}) {
+	if err := e.Context.SetExtension(name, obj); err != nil {
+		e.fieldError("extension:"+name, err)
+	} else {
+		e.fieldOK("extension:" + name)
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext.go
@@ -1,0 +1,122 @@
+package event
+
+import "time"
+
+// EventContextReader are the methods required to be a reader of context
+// attributes.
+type EventContextReader interface {
+	// GetSpecVersion returns the native CloudEvents Spec version of the event
+	// context.
+	GetSpecVersion() string
+	// GetType returns the CloudEvents type from the context.
+	GetType() string
+	// GetSource returns the CloudEvents source from the context.
+	GetSource() string
+	// GetSubject returns the CloudEvents subject from the context.
+	GetSubject() string
+	// GetID returns the CloudEvents ID from the context.
+	GetID() string
+	// GetTime returns the CloudEvents creation time from the context.
+	GetTime() time.Time
+	// GetDataSchema returns the CloudEvents schema URL (if any) from the
+	// context.
+	GetDataSchema() string
+	// GetDataContentType returns content type on the context.
+	GetDataContentType() string
+	// DeprecatedGetDataContentEncoding returns content encoding on the context.
+	DeprecatedGetDataContentEncoding() string
+
+	// GetDataMediaType returns the MIME media type for encoded data, which is
+	// needed by both encoding and decoding. This is a processed form of
+	// GetDataContentType and it may return an error.
+	GetDataMediaType() (string, error)
+
+	// DEPRECATED: Access extensions directly via the GetExtensions()
+	// For example replace this:
+	//
+	//     var i int
+	//     err := ec.ExtensionAs("foo", &i)
+	//
+	// With this:
+	//
+	//     i, err := types.ToInteger(ec.GetExtensions["foo"])
+	//
+	ExtensionAs(string, interface{}) error
+
+	// GetExtensions returns the full extensions map.
+	//
+	// Extensions use the CloudEvents type system, details in package cloudevents/types.
+	GetExtensions() map[string]interface{}
+
+	// GetExtension returns the extension associated with with the given key.
+	// The given key is case insensitive. If the extension can not be found,
+	// an error will be returned.
+	GetExtension(string) (interface{}, error)
+}
+
+// EventContextWriter are the methods required to be a writer of context
+// attributes.
+type EventContextWriter interface {
+	// SetSpecVersion sets the spec version of the context.
+	SetSpecVersion(string) error
+	// SetType sets the type of the context.
+	SetType(string) error
+	// SetSource sets the source of the context.
+	SetSource(string) error
+	// SetSubject sets the subject of the context.
+	SetSubject(string) error
+	// SetID sets the ID of the context.
+	SetID(string) error
+	// SetTime sets the time of the context.
+	SetTime(time time.Time) error
+	// SetDataSchema sets the schema url of the context.
+	SetDataSchema(string) error
+	// SetDataContentType sets the data content type of the context.
+	SetDataContentType(string) error
+	// DeprecatedSetDataContentEncoding sets the data context encoding of the context.
+	DeprecatedSetDataContentEncoding(string) error
+
+	// SetExtension sets the given interface onto the extension attributes
+	// determined by the provided name.
+	//
+	// This function fails in V1 if the name doesn't respect the regex ^[a-zA-Z0-9]+$
+	//
+	// Package ./types documents the types that are allowed as extension values.
+	SetExtension(string, interface{}) error
+}
+
+// EventContextConverter are the methods that allow for event version
+// conversion.
+type EventContextConverter interface {
+	// AsV03 provides a translation from whatever the "native" encoding of the
+	// CloudEvent was to the equivalent in v0.3 field names, moving fields to or
+	// from extensions as necessary.
+	AsV03() *EventContextV03
+
+	// AsV1 provides a translation from whatever the "native" encoding of the
+	// CloudEvent was to the equivalent in v1.0 field names, moving fields to or
+	// from extensions as necessary.
+	AsV1() *EventContextV1
+}
+
+// EventContext is conical interface for a CloudEvents Context.
+type EventContext interface {
+	// EventContextConverter allows for conversion between versions.
+	EventContextConverter
+
+	// EventContextReader adds methods for reading context.
+	EventContextReader
+
+	// EventContextWriter adds methods for writing to context.
+	EventContextWriter
+
+	// Validate the event based on the specifics of the CloudEvents spec version
+	// represented by this event context.
+	Validate() error
+
+	// Clone clones the event context.
+	Clone() EventContext
+
+	// String returns a pretty-printed representation of the EventContext.
+	String() string
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v03.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v03.go
@@ -1,0 +1,318 @@
+package event
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+const (
+	// CloudEventsVersionV03 represents the version 0.3 of the CloudEvents spec.
+	CloudEventsVersionV03 = "0.3"
+)
+
+// EventContextV03 represents the non-data attributes of a CloudEvents v0.3
+// event.
+type EventContextV03 struct {
+	// SpecVersion - The version of the CloudEvents specification used by the event.
+	SpecVersion string `json:"specversion"`
+	// Type - The type of the occurrence which has happened.
+	Type string `json:"type"`
+	// Source - A URI describing the event producer.
+	Source types.URIRef `json:"source"`
+	// Subject - The subject of the event in the context of the event producer
+	// (identified by `source`).
+	Subject *string `json:"subject,omitempty"`
+	// ID of the event; must be non-empty and unique within the scope of the producer.
+	ID string `json:"id"`
+	// Time - A Timestamp when the event happened.
+	Time *types.Timestamp `json:"time,omitempty"`
+	// DataSchema - A link to the schema that the `data` attribute adheres to.
+	SchemaURL *types.URIRef `json:"schemaurl,omitempty"`
+	// GetDataMediaType - A MIME (RFC2046) string describing the media type of `data`.
+	// TODO: Should an empty string assume `application/json`, `application/octet-stream`, or auto-detect the content?
+	DataContentType *string `json:"datacontenttype,omitempty"`
+	// DeprecatedDataContentEncoding describes the content encoding for the `data` attribute. Valid: nil, `Base64`.
+	DataContentEncoding *string `json:"datacontentencoding,omitempty"`
+	// Extensions - Additional extension metadata beyond the base spec.
+	Extensions map[string]interface{} `json:"-"`
+}
+
+// Adhere to EventContext
+var _ EventContext = (*EventContextV03)(nil)
+
+// ExtensionAs implements EventContext.ExtensionAs
+func (ec EventContextV03) ExtensionAs(name string, obj interface{}) error {
+	value, ok := ec.Extensions[name]
+	if !ok {
+		return fmt.Errorf("extension %q does not exist", name)
+	}
+
+	// Try to unmarshal extension if we find it as a RawMessage.
+	switch v := value.(type) {
+	case json.RawMessage:
+		if err := json.Unmarshal(v, obj); err == nil {
+			// if that worked, return with obj set.
+			return nil
+		}
+	}
+	// else try as a string ptr.
+
+	// Only support *string for now.
+	switch v := obj.(type) {
+	case *string:
+		if valueAsString, ok := value.(string); ok {
+			*v = valueAsString
+			return nil
+		} else {
+			return fmt.Errorf("invalid type for extension %q", name)
+		}
+	default:
+		return fmt.Errorf("unknown extension type %T", obj)
+	}
+}
+
+// SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
+func (ec *EventContextV03) SetExtension(name string, value interface{}) error {
+	if ec.Extensions == nil {
+		ec.Extensions = make(map[string]interface{})
+	}
+	if value == nil {
+		delete(ec.Extensions, name)
+		if len(ec.Extensions) == 0 {
+			ec.Extensions = nil
+		}
+		return nil
+	} else {
+		v, err := types.Validate(value)
+		if err == nil {
+			ec.Extensions[name] = v
+		}
+		return err
+	}
+}
+
+// Clone implements EventContextConverter.Clone
+func (ec EventContextV03) Clone() EventContext {
+	ec03 := ec.AsV03()
+	ec03.Source = types.Clone(ec.Source).(types.URIRef)
+	if ec.Time != nil {
+		ec03.Time = types.Clone(ec.Time).(*types.Timestamp)
+	}
+	if ec.SchemaURL != nil {
+		ec03.SchemaURL = types.Clone(ec.SchemaURL).(*types.URIRef)
+	}
+	ec03.Extensions = ec.cloneExtensions()
+	return ec03
+}
+
+func (ec *EventContextV03) cloneExtensions() map[string]interface{} {
+	old := ec.Extensions
+	if old == nil {
+		return nil
+	}
+	new := make(map[string]interface{}, len(ec.Extensions))
+	for k, v := range old {
+		new[k] = types.Clone(v)
+	}
+	return new
+}
+
+// AsV03 implements EventContextConverter.AsV03
+func (ec EventContextV03) AsV03() *EventContextV03 {
+	ec.SpecVersion = CloudEventsVersionV03
+	return &ec
+}
+
+// AsV04 implements EventContextConverter.AsV04
+func (ec EventContextV03) AsV1() *EventContextV1 {
+	ret := EventContextV1{
+		SpecVersion:     CloudEventsVersionV1,
+		ID:              ec.ID,
+		Time:            ec.Time,
+		Type:            ec.Type,
+		DataContentType: ec.DataContentType,
+		Source:          types.URIRef{URL: ec.Source.URL},
+		Subject:         ec.Subject,
+		Extensions:      make(map[string]interface{}),
+	}
+	if ec.SchemaURL != nil {
+		ret.DataSchema = &types.URI{URL: ec.SchemaURL.URL}
+	}
+
+	// DataContentEncoding was removed in 1.0, so put it in an extension for 1.0.
+	if ec.DataContentEncoding != nil {
+		_ = ret.SetExtension(DataContentEncodingKey, *ec.DataContentEncoding)
+	}
+
+	if ec.Extensions != nil {
+		for k, v := range ec.Extensions {
+			k = strings.ToLower(k)
+			ret.Extensions[k] = v
+		}
+	}
+	if len(ret.Extensions) == 0 {
+		ret.Extensions = nil
+	}
+	return &ret
+}
+
+// Validate returns errors based on requirements from the CloudEvents spec.
+// For more details, see https://github.com/cloudevents/spec/blob/master/spec.md
+// As of Feb 26, 2019, commit 17c32ea26baf7714ad027d9917d03d2fff79fc7e
+// + https://github.com/cloudevents/spec/pull/387 -> datacontentencoding
+// + https://github.com/cloudevents/spec/pull/406 -> subject
+func (ec EventContextV03) Validate() error {
+	errors := []string(nil)
+
+	// type
+	// Type: String
+	// Constraints:
+	//  REQUIRED
+	//  MUST be a non-empty string
+	//  SHOULD be prefixed with a reverse-DNS name. The prefixed domain dictates the organization which defines the semantics of this event type.
+	eventType := strings.TrimSpace(ec.Type)
+	if eventType == "" {
+		errors = append(errors, "type: MUST be a non-empty string")
+	}
+
+	// specversion
+	// Type: String
+	// Constraints:
+	//  REQUIRED
+	//  MUST be a non-empty string
+	specVersion := strings.TrimSpace(ec.SpecVersion)
+	if specVersion == "" {
+		errors = append(errors, "specversion: MUST be a non-empty string")
+	}
+
+	// source
+	// Type: URI-reference
+	// Constraints:
+	//  REQUIRED
+	source := strings.TrimSpace(ec.Source.String())
+	if source == "" {
+		errors = append(errors, "source: REQUIRED")
+	}
+
+	// subject
+	// Type: String
+	// Constraints:
+	//  OPTIONAL
+	//  MUST be a non-empty string
+	if ec.Subject != nil {
+		subject := strings.TrimSpace(*ec.Subject)
+		if subject == "" {
+			errors = append(errors, "subject: if present, MUST be a non-empty string")
+		}
+	}
+
+	// id
+	// Type: String
+	// Constraints:
+	//  REQUIRED
+	//  MUST be a non-empty string
+	//  MUST be unique within the scope of the producer
+	id := strings.TrimSpace(ec.ID)
+	if id == "" {
+		errors = append(errors, "id: MUST be a non-empty string")
+
+		// no way to test "MUST be unique within the scope of the producer"
+	}
+
+	// time
+	// Type: Timestamp
+	// Constraints:
+	//  OPTIONAL
+	//  If present, MUST adhere to the format specified in RFC 3339
+	// --> no need to test this, no way to set the time without it being valid.
+
+	// schemaurl
+	// Type: URI
+	// Constraints:
+	//  OPTIONAL
+	//  If present, MUST adhere to the format specified in RFC 3986
+	if ec.SchemaURL != nil {
+		schemaURL := strings.TrimSpace(ec.SchemaURL.String())
+		// empty string is not RFC 3986 compatible.
+		if schemaURL == "" {
+			errors = append(errors, "schemaurl: if present, MUST adhere to the format specified in RFC 3986")
+		}
+	}
+
+	// datacontenttype
+	// Type: String per RFC 2046
+	// Constraints:
+	//  OPTIONAL
+	//  If present, MUST adhere to the format specified in RFC 2046
+	if ec.DataContentType != nil {
+		dataContentType := strings.TrimSpace(*ec.DataContentType)
+		if dataContentType == "" {
+			// TODO: need to test for RFC 2046
+			errors = append(errors, "datacontenttype: if present, MUST adhere to the format specified in RFC 2046")
+		}
+	}
+
+	// datacontentencoding
+	// Type: String per RFC 2045 Section 6.1
+	// Constraints:
+	//  The attribute MUST be set if the data attribute contains string-encoded binary data.
+	//    Otherwise the attribute MUST NOT be set.
+	//  If present, MUST adhere to RFC 2045 Section 6.1
+	if ec.DataContentEncoding != nil {
+		dataContentEncoding := strings.ToLower(strings.TrimSpace(*ec.DataContentEncoding))
+		if dataContentEncoding != Base64 {
+			// TODO: need to test for RFC 2046
+			errors = append(errors, "datacontentencoding: if present, MUST adhere to RFC 2045 Section 6.1")
+		}
+	}
+
+	if len(errors) > 0 {
+		return fmt.Errorf(strings.Join(errors, "\n"))
+	}
+	return nil
+}
+
+// String returns a pretty-printed representation of the EventContext.
+func (ec EventContextV03) String() string {
+	b := strings.Builder{}
+
+	b.WriteString("Context Attributes,\n")
+
+	b.WriteString("  specversion: " + ec.SpecVersion + "\n")
+	b.WriteString("  type: " + ec.Type + "\n")
+	b.WriteString("  source: " + ec.Source.String() + "\n")
+	if ec.Subject != nil {
+		b.WriteString("  subject: " + *ec.Subject + "\n")
+	}
+	b.WriteString("  id: " + ec.ID + "\n")
+	if ec.Time != nil {
+		b.WriteString("  time: " + ec.Time.String() + "\n")
+	}
+	if ec.SchemaURL != nil {
+		b.WriteString("  schemaurl: " + ec.SchemaURL.String() + "\n")
+	}
+	if ec.DataContentType != nil {
+		b.WriteString("  datacontenttype: " + *ec.DataContentType + "\n")
+	}
+	if ec.DataContentEncoding != nil {
+		b.WriteString("  datacontentencoding: " + *ec.DataContentEncoding + "\n")
+	}
+
+	if ec.Extensions != nil && len(ec.Extensions) > 0 {
+		b.WriteString("Extensions,\n")
+		keys := make([]string, 0, len(ec.Extensions))
+		for k := range ec.Extensions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			b.WriteString(fmt.Sprintf("  %s: %v\n", key, ec.Extensions[key]))
+		}
+	}
+
+	return b.String()
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v03_reader.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v03_reader.go
@@ -1,0 +1,96 @@
+package event
+
+import (
+	"fmt"
+	"mime"
+	"time"
+)
+
+// GetSpecVersion implements EventContextReader.GetSpecVersion
+func (ec EventContextV03) GetSpecVersion() string {
+	if ec.SpecVersion != "" {
+		return ec.SpecVersion
+	}
+	return CloudEventsVersionV03
+}
+
+// GetDataContentType implements EventContextReader.GetDataContentType
+func (ec EventContextV03) GetDataContentType() string {
+	if ec.DataContentType != nil {
+		return *ec.DataContentType
+	}
+	return ""
+}
+
+// GetDataMediaType implements EventContextReader.GetDataMediaType
+func (ec EventContextV03) GetDataMediaType() (string, error) {
+	if ec.DataContentType != nil {
+		mediaType, _, err := mime.ParseMediaType(*ec.DataContentType)
+		if err != nil {
+			return "", err
+		}
+		return mediaType, nil
+	}
+	return "", nil
+}
+
+// GetType implements EventContextReader.GetType
+func (ec EventContextV03) GetType() string {
+	return ec.Type
+}
+
+// GetSource implements EventContextReader.GetSource
+func (ec EventContextV03) GetSource() string {
+	return ec.Source.String()
+}
+
+// GetSubject implements EventContextReader.GetSubject
+func (ec EventContextV03) GetSubject() string {
+	if ec.Subject != nil {
+		return *ec.Subject
+	}
+	return ""
+}
+
+// GetTime implements EventContextReader.GetTime
+func (ec EventContextV03) GetTime() time.Time {
+	if ec.Time != nil {
+		return ec.Time.Time
+	}
+	return time.Time{}
+}
+
+// GetID implements EventContextReader.GetID
+func (ec EventContextV03) GetID() string {
+	return ec.ID
+}
+
+// GetDataSchema implements EventContextReader.GetDataSchema
+func (ec EventContextV03) GetDataSchema() string {
+	if ec.SchemaURL != nil {
+		return ec.SchemaURL.String()
+	}
+	return ""
+}
+
+// DeprecatedGetDataContentEncoding implements EventContextReader.DeprecatedGetDataContentEncoding
+func (ec EventContextV03) DeprecatedGetDataContentEncoding() string {
+	if ec.DataContentEncoding != nil {
+		return *ec.DataContentEncoding
+	}
+	return ""
+}
+
+// GetExtensions implements EventContextReader.GetExtensions
+func (ec EventContextV03) GetExtensions() map[string]interface{} {
+	return ec.Extensions
+}
+
+// GetExtension implements EventContextReader.GetExtension
+func (ec EventContextV03) GetExtension(key string) (interface{}, error) {
+	v, ok := caseInsensitiveSearch(key, ec.Extensions)
+	if !ok {
+		return "", fmt.Errorf("%q not found", key)
+	}
+	return v, nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v03_writer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v03_writer.go
@@ -1,0 +1,108 @@
+package event
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+// Adhere to EventContextWriter
+var _ EventContextWriter = (*EventContextV03)(nil)
+
+// SetSpecVersion implements EventContextWriter.SetSpecVersion
+func (ec *EventContextV03) SetSpecVersion(v string) error {
+	if v != CloudEventsVersionV03 {
+		return fmt.Errorf("invalid version %q, expecting %q", v, CloudEventsVersionV03)
+	}
+	ec.SpecVersion = CloudEventsVersionV03
+	return nil
+}
+
+// SetDataContentType implements EventContextWriter.SetDataContentType
+func (ec *EventContextV03) SetDataContentType(ct string) error {
+	ct = strings.TrimSpace(ct)
+	if ct == "" {
+		ec.DataContentType = nil
+	} else {
+		ec.DataContentType = &ct
+	}
+	return nil
+}
+
+// SetType implements EventContextWriter.SetType
+func (ec *EventContextV03) SetType(t string) error {
+	t = strings.TrimSpace(t)
+	ec.Type = t
+	return nil
+}
+
+// SetSource implements EventContextWriter.SetSource
+func (ec *EventContextV03) SetSource(u string) error {
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.Source = types.URIRef{URL: *pu}
+	return nil
+}
+
+// SetSubject implements EventContextWriter.SetSubject
+func (ec *EventContextV03) SetSubject(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		ec.Subject = nil
+	} else {
+		ec.Subject = &s
+	}
+	return nil
+}
+
+// SetID implements EventContextWriter.SetID
+func (ec *EventContextV03) SetID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("id is required to be a non-empty string")
+	}
+	ec.ID = id
+	return nil
+}
+
+// SetTime implements EventContextWriter.SetTime
+func (ec *EventContextV03) SetTime(t time.Time) error {
+	if t.IsZero() {
+		ec.Time = nil
+	} else {
+		ec.Time = &types.Timestamp{Time: t}
+	}
+	return nil
+}
+
+// SetDataSchema implements EventContextWriter.SetDataSchema
+func (ec *EventContextV03) SetDataSchema(u string) error {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		ec.SchemaURL = nil
+		return nil
+	}
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.SchemaURL = &types.URIRef{URL: *pu}
+	return nil
+}
+
+// DeprecatedSetDataContentEncoding implements EventContextWriter.DeprecatedSetDataContentEncoding
+func (ec *EventContextV03) DeprecatedSetDataContentEncoding(e string) error {
+	e = strings.ToLower(strings.TrimSpace(e))
+	if e == "" {
+		ec.DataContentEncoding = nil
+	} else {
+		ec.DataContentEncoding = &e
+	}
+	return nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v1.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v1.go
@@ -1,0 +1,313 @@
+package event
+
+import (
+	"errors"
+	"fmt"
+	"mime"
+	"sort"
+	"strings"
+
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+// WIP: AS OF SEP 20, 2019
+
+const (
+	// CloudEventsVersionV1 represents the version 1.0 of the CloudEvents spec.
+	CloudEventsVersionV1 = "1.0"
+)
+
+// EventContextV1 represents the non-data attributes of a CloudEvents v1.0
+// event.
+type EventContextV1 struct {
+	// ID of the event; must be non-empty and unique within the scope of the producer.
+	// +required
+	ID string `json:"id"`
+	// Source - A URI describing the event producer.
+	// +required
+	Source types.URIRef `json:"source"`
+	// SpecVersion - The version of the CloudEvents specification used by the event.
+	// +required
+	SpecVersion string `json:"specversion"`
+	// Type - The type of the occurrence which has happened.
+	// +required
+	Type string `json:"type"`
+
+	// DataContentType - A MIME (RFC2046) string describing the media type of `data`.
+	// +optional
+	DataContentType *string `json:"datacontenttype,omitempty"`
+	// Subject - The subject of the event in the context of the event producer
+	// (identified by `source`).
+	// +optional
+	Subject *string `json:"subject,omitempty"`
+	// Time - A Timestamp when the event happened.
+	// +optional
+	Time *types.Timestamp `json:"time,omitempty"`
+	// DataSchema - A link to the schema that the `data` attribute adheres to.
+	// +optional
+	DataSchema *types.URI `json:"dataschema,omitempty"`
+
+	// Extensions - Additional extension metadata beyond the base spec.
+	// +optional
+	Extensions map[string]interface{} `json:"-"`
+}
+
+// Adhere to EventContext
+var _ EventContext = (*EventContextV1)(nil)
+
+// ExtensionAs implements EventContext.ExtensionAs
+func (ec EventContextV1) ExtensionAs(name string, obj interface{}) error {
+	name = strings.ToLower(name)
+	value, ok := ec.Extensions[name]
+	if !ok {
+		return fmt.Errorf("extension %q does not exist", name)
+	}
+
+	// Only support *string for now.
+	if v, ok := obj.(*string); ok {
+		if *v, ok = value.(string); ok {
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown extension type %T", obj)
+}
+
+// SetExtension adds the extension 'name' with value 'value' to the CloudEvents context.
+// This function fails if the name doesn't respect the regex ^[a-zA-Z0-9]+$
+func (ec *EventContextV1) SetExtension(name string, value interface{}) error {
+	if !IsAlphaNumeric(name) {
+		return errors.New("bad key, CloudEvents attribute names MUST consist of lower-case letters ('a' to 'z') or digits ('0' to '9') from the ASCII character set")
+	}
+
+	name = strings.ToLower(name)
+	if ec.Extensions == nil {
+		ec.Extensions = make(map[string]interface{})
+	}
+	if value == nil {
+		delete(ec.Extensions, name)
+		if len(ec.Extensions) == 0 {
+			ec.Extensions = nil
+		}
+		return nil
+	} else {
+		v, err := types.Validate(value) // Ensure it's a legal CE attribute value
+		if err == nil {
+			ec.Extensions[name] = v
+		}
+		return err
+	}
+}
+
+// Clone implements EventContextConverter.Clone
+func (ec EventContextV1) Clone() EventContext {
+	ec1 := ec.AsV1()
+	ec1.Source = types.Clone(ec.Source).(types.URIRef)
+	if ec.Time != nil {
+		ec1.Time = types.Clone(ec.Time).(*types.Timestamp)
+	}
+	if ec.DataSchema != nil {
+		ec1.DataSchema = types.Clone(ec.DataSchema).(*types.URI)
+	}
+	ec1.Extensions = ec.cloneExtensions()
+	return ec1
+}
+
+func (ec *EventContextV1) cloneExtensions() map[string]interface{} {
+	old := ec.Extensions
+	if old == nil {
+		return nil
+	}
+	new := make(map[string]interface{}, len(ec.Extensions))
+	for k, v := range old {
+		new[k] = types.Clone(v)
+	}
+	return new
+}
+
+// AsV03 implements EventContextConverter.AsV03
+func (ec EventContextV1) AsV03() *EventContextV03 {
+	ret := EventContextV03{
+		SpecVersion:     CloudEventsVersionV03,
+		ID:              ec.ID,
+		Time:            ec.Time,
+		Type:            ec.Type,
+		DataContentType: ec.DataContentType,
+		Source:          types.URIRef{URL: ec.Source.URL},
+		Subject:         ec.Subject,
+		Extensions:      make(map[string]interface{}),
+	}
+
+	if ec.DataSchema != nil {
+		ret.SchemaURL = &types.URIRef{URL: ec.DataSchema.URL}
+	}
+
+	// TODO: DeprecatedDataContentEncoding needs to be moved to extensions.
+	if ec.Extensions != nil {
+		for k, v := range ec.Extensions {
+			k = strings.ToLower(k)
+			// DeprecatedDataContentEncoding was introduced in 0.3, removed in 1.0
+			if strings.EqualFold(k, DataContentEncodingKey) {
+				etv, ok := v.(string)
+				if ok && etv != "" {
+					ret.DataContentEncoding = &etv
+				}
+				continue
+			}
+			ret.Extensions[k] = v
+		}
+	}
+	if len(ret.Extensions) == 0 {
+		ret.Extensions = nil
+	}
+	return &ret
+}
+
+// AsV04 implements EventContextConverter.AsV04
+func (ec EventContextV1) AsV1() *EventContextV1 {
+	ec.SpecVersion = CloudEventsVersionV1
+	return &ec
+}
+
+// Validate returns errors based on requirements from the CloudEvents spec.
+// For more details, see https://github.com/cloudevents/spec/blob/v1.0-rc1/spec.md.
+func (ec EventContextV1) Validate() error {
+	errors := []string(nil)
+
+	// id
+	// Type: String
+	// Constraints:
+	//  REQUIRED
+	//  MUST be a non-empty string
+	//  MUST be unique within the scope of the producer
+	id := strings.TrimSpace(ec.ID)
+	if id == "" {
+		errors = append(errors, "id: MUST be a non-empty string")
+		// no way to test "MUST be unique within the scope of the producer"
+	}
+
+	// source
+	// Type: URI-reference
+	// Constraints:
+	//  REQUIRED
+	//  MUST be a non-empty URI-reference
+	//	An absolute URI is RECOMMENDED
+	source := strings.TrimSpace(ec.Source.String())
+	if source == "" {
+		errors = append(errors, "source: REQUIRED")
+	}
+
+	// specversion
+	// Type: String
+	// Constraints:
+	//  REQUIRED
+	//  MUST be a non-empty string
+	specVersion := strings.TrimSpace(ec.SpecVersion)
+	if specVersion == "" {
+		errors = append(errors, "specversion: MUST be a non-empty string")
+	}
+
+	// type
+	// Type: String
+	// Constraints:
+	//  REQUIRED
+	//  MUST be a non-empty string
+	//  SHOULD be prefixed with a reverse-DNS name. The prefixed domain dictates the organization which defines the semantics of this event type.
+	eventType := strings.TrimSpace(ec.Type)
+	if eventType == "" {
+		errors = append(errors, "type: MUST be a non-empty string")
+	}
+
+	// The following attributes are optional but still have validation.
+
+	// datacontenttype
+	// Type: String per RFC 2046
+	// Constraints:
+	//  OPTIONAL
+	//  If present, MUST adhere to the format specified in RFC 2046
+	if ec.DataContentType != nil {
+		dataContentType := strings.TrimSpace(*ec.DataContentType)
+		if dataContentType == "" {
+			errors = append(errors, "datacontenttype: if present, MUST adhere to the format specified in RFC 2046")
+		} else {
+			_, _, err := mime.ParseMediaType(dataContentType)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("datacontenttype: failed to parse media type, %s", err.Error()))
+			}
+		}
+	}
+
+	// dataschema
+	// Type: URI
+	// Constraints:
+	//  OPTIONAL
+	//  If present, MUST adhere to the format specified in RFC 3986
+	if ec.DataSchema != nil {
+		dataSchema := strings.TrimSpace(ec.DataSchema.String())
+		// empty string is not RFC 3986 compatible.
+		if dataSchema == "" {
+			errors = append(errors, "dataschema: if present, MUST adhere to the format specified in RFC 3986")
+		}
+	}
+
+	// subject
+	// Type: String
+	// Constraints:
+	//  OPTIONAL
+	//  MUST be a non-empty string
+	if ec.Subject != nil {
+		subject := strings.TrimSpace(*ec.Subject)
+		if subject == "" {
+			errors = append(errors, "subject: if present, MUST be a non-empty string")
+		}
+	}
+
+	// time
+	// Type: Timestamp
+	// Constraints:
+	//  OPTIONAL
+	//  If present, MUST adhere to the format specified in RFC 3339
+	// --> no need to test this, no way to set the time without it being valid.
+
+	if len(errors) > 0 {
+		return fmt.Errorf(strings.Join(errors, "\n"))
+	}
+	return nil
+}
+
+// String returns a pretty-printed representation of the EventContext.
+func (ec EventContextV1) String() string {
+	b := strings.Builder{}
+
+	b.WriteString("Context Attributes,\n")
+
+	b.WriteString("  specversion: " + ec.SpecVersion + "\n")
+	b.WriteString("  type: " + ec.Type + "\n")
+	b.WriteString("  source: " + ec.Source.String() + "\n")
+	if ec.Subject != nil {
+		b.WriteString("  subject: " + *ec.Subject + "\n")
+	}
+	b.WriteString("  id: " + ec.ID + "\n")
+	if ec.Time != nil {
+		b.WriteString("  time: " + ec.Time.String() + "\n")
+	}
+	if ec.DataSchema != nil {
+		b.WriteString("  dataschema: " + ec.DataSchema.String() + "\n")
+	}
+	if ec.DataContentType != nil {
+		b.WriteString("  datacontenttype: " + *ec.DataContentType + "\n")
+	}
+
+	if ec.Extensions != nil && len(ec.Extensions) > 0 {
+		b.WriteString("Extensions,\n")
+		keys := make([]string, 0, len(ec.Extensions))
+		for k := range ec.Extensions {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			b.WriteString(fmt.Sprintf("  %s: %v\n", key, ec.Extensions[key]))
+		}
+	}
+
+	return b.String()
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v1_reader.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v1_reader.go
@@ -1,0 +1,101 @@
+package event
+
+import (
+	"fmt"
+	"mime"
+	"time"
+)
+
+// GetSpecVersion implements EventContextReader.GetSpecVersion
+func (ec EventContextV1) GetSpecVersion() string {
+	if ec.SpecVersion != "" {
+		return ec.SpecVersion
+	}
+	return CloudEventsVersionV03
+}
+
+// GetDataContentType implements EventContextReader.GetDataContentType
+func (ec EventContextV1) GetDataContentType() string {
+	if ec.DataContentType != nil {
+		return *ec.DataContentType
+	}
+	return ""
+}
+
+// GetDataMediaType implements EventContextReader.GetDataMediaType
+func (ec EventContextV1) GetDataMediaType() (string, error) {
+	if ec.DataContentType != nil {
+		mediaType, _, err := mime.ParseMediaType(*ec.DataContentType)
+		if err != nil {
+			return "", err
+		}
+		return mediaType, nil
+	}
+	return "", nil
+}
+
+// GetType implements EventContextReader.GetType
+func (ec EventContextV1) GetType() string {
+	return ec.Type
+}
+
+// GetSource implements EventContextReader.GetSource
+func (ec EventContextV1) GetSource() string {
+	return ec.Source.String()
+}
+
+// GetSubject implements EventContextReader.GetSubject
+func (ec EventContextV1) GetSubject() string {
+	if ec.Subject != nil {
+		return *ec.Subject
+	}
+	return ""
+}
+
+// GetTime implements EventContextReader.GetTime
+func (ec EventContextV1) GetTime() time.Time {
+	if ec.Time != nil {
+		return ec.Time.Time
+	}
+	return time.Time{}
+}
+
+// GetID implements EventContextReader.GetID
+func (ec EventContextV1) GetID() string {
+	return ec.ID
+}
+
+// GetDataSchema implements EventContextReader.GetDataSchema
+func (ec EventContextV1) GetDataSchema() string {
+	if ec.DataSchema != nil {
+		return ec.DataSchema.String()
+	}
+	return ""
+}
+
+// DeprecatedGetDataContentEncoding implements EventContextReader.DeprecatedGetDataContentEncoding
+func (ec EventContextV1) DeprecatedGetDataContentEncoding() string {
+	return ""
+}
+
+// GetExtensions implements EventContextReader.GetExtensions
+func (ec EventContextV1) GetExtensions() map[string]interface{} {
+	if len(ec.Extensions) == 0 {
+		return nil
+	}
+	// For now, convert the extensions of v1.0 to the pre-v1.0 style.
+	ext := make(map[string]interface{}, len(ec.Extensions))
+	for k, v := range ec.Extensions {
+		ext[k] = v
+	}
+	return ext
+}
+
+// GetExtension implements EventContextReader.GetExtension
+func (ec EventContextV1) GetExtension(key string) (interface{}, error) {
+	v, ok := caseInsensitiveSearch(key, ec.Extensions)
+	if !ok {
+		return "", fmt.Errorf("%q not found", key)
+	}
+	return v, nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v1_writer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/eventcontext_v1_writer.go
@@ -1,0 +1,102 @@
+package event
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+// Adhere to EventContextWriter
+var _ EventContextWriter = (*EventContextV1)(nil)
+
+// SetSpecVersion implements EventContextWriter.SetSpecVersion
+func (ec *EventContextV1) SetSpecVersion(v string) error {
+	if v != CloudEventsVersionV1 {
+		return fmt.Errorf("invalid version %q, expecting %q", v, CloudEventsVersionV1)
+	}
+	ec.SpecVersion = CloudEventsVersionV1
+	return nil
+}
+
+// SetDataContentType implements EventContextWriter.SetDataContentType
+func (ec *EventContextV1) SetDataContentType(ct string) error {
+	ct = strings.TrimSpace(ct)
+	if ct == "" {
+		ec.DataContentType = nil
+	} else {
+		ec.DataContentType = &ct
+	}
+	return nil
+}
+
+// SetType implements EventContextWriter.SetType
+func (ec *EventContextV1) SetType(t string) error {
+	t = strings.TrimSpace(t)
+	ec.Type = t
+	return nil
+}
+
+// SetSource implements EventContextWriter.SetSource
+func (ec *EventContextV1) SetSource(u string) error {
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.Source = types.URIRef{URL: *pu}
+	return nil
+}
+
+// SetSubject implements EventContextWriter.SetSubject
+func (ec *EventContextV1) SetSubject(s string) error {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		ec.Subject = nil
+	} else {
+		ec.Subject = &s
+	}
+	return nil
+}
+
+// SetID implements EventContextWriter.SetID
+func (ec *EventContextV1) SetID(id string) error {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return errors.New("id is required to be a non-empty string")
+	}
+	ec.ID = id
+	return nil
+}
+
+// SetTime implements EventContextWriter.SetTime
+func (ec *EventContextV1) SetTime(t time.Time) error {
+	if t.IsZero() {
+		ec.Time = nil
+	} else {
+		ec.Time = &types.Timestamp{Time: t}
+	}
+	return nil
+}
+
+// SetDataSchema implements EventContextWriter.SetDataSchema
+func (ec *EventContextV1) SetDataSchema(u string) error {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		ec.DataSchema = nil
+		return nil
+	}
+	pu, err := url.Parse(u)
+	if err != nil {
+		return err
+	}
+	ec.DataSchema = &types.URI{URL: *pu}
+	return nil
+}
+
+// DeprecatedSetDataContentEncoding implements EventContextWriter.DeprecatedSetDataContentEncoding
+func (ec *EventContextV1) DeprecatedSetDataContentEncoding(e string) error {
+	return errors.New("deprecated: SetDataContentEncoding is not supported in v1.0 of CloudEvents")
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/event/extensions.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/event/extensions.go
@@ -1,0 +1,30 @@
+package event
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	// DataContentEncodingKey is the key to DeprecatedDataContentEncoding for versions that do not support data content encoding
+	// directly.
+	DataContentEncodingKey = "datacontentencoding"
+
+	// EventTypeVersionKey is the key to EventTypeVersion for versions that do not support event type version directly.
+	EventTypeVersionKey = "eventtypeversion"
+
+	// SubjectKey is the key to Subject for versions that do not support subject directly.
+	SubjectKey = "subject"
+)
+
+func caseInsensitiveSearch(key string, space map[string]interface{}) (interface{}, bool) {
+	lkey := strings.ToLower(key)
+	for k, v := range space {
+		if strings.EqualFold(lkey, strings.ToLower(k)) {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+var IsAlphaNumeric = regexp.MustCompile(`^[a-zA-Z0-9]+$`).MatchString

--- a/vendor/github.com/cloudevents/sdk-go/pkg/extensions/distributed_tracing_extension.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/extensions/distributed_tracing_extension.go
@@ -1,0 +1,126 @@
+package extensions
+
+import (
+	"context"
+	"reflect"
+	"strings"
+
+	"github.com/cloudevents/sdk-go/pkg/event"
+
+	"github.com/cloudevents/sdk-go/pkg/types"
+	"github.com/lightstep/tracecontext.go/traceparent"
+	"github.com/lightstep/tracecontext.go/tracestate"
+	"go.opencensus.io/trace"
+	octs "go.opencensus.io/trace/tracestate"
+)
+
+const (
+	TraceParentExtension = "traceparent"
+	TraceStateExtension  = "tracestate"
+)
+
+// DistributedTracingExtension represents the extension for cloudevents context
+type DistributedTracingExtension struct {
+	TraceParent string `json:"traceparent"`
+	TraceState  string `json:"tracestate"`
+}
+
+// AddTracingAttributes adds the tracing attributes traceparent and tracestate to the cloudevents context
+func (d DistributedTracingExtension) AddTracingAttributes(e event.EventWriter) {
+	if d.TraceParent != "" {
+		value := reflect.ValueOf(d)
+		typeOf := value.Type()
+
+		for i := 0; i < value.NumField(); i++ {
+			k := strings.ToLower(typeOf.Field(i).Name)
+			v := value.Field(i).Interface()
+			if k == TraceStateExtension && v == "" {
+				continue
+			}
+			e.SetExtension(k, v)
+		}
+	}
+}
+
+func GetDistributedTracingExtension(event event.Event) (DistributedTracingExtension, bool) {
+	if tp, ok := event.Extensions()[TraceParentExtension]; ok {
+		if tpStr, err := types.ToString(tp); err == nil {
+			var tsStr string
+			if ts, ok := event.Extensions()[TraceStateExtension]; ok {
+				tsStr, _ = types.ToString(ts)
+			}
+			return DistributedTracingExtension{TraceParent: tpStr, TraceState: tsStr}, true
+		}
+	}
+	return DistributedTracingExtension{}, false
+}
+
+// FromSpanContext populates DistributedTracingExtension from a SpanContext.
+func FromSpanContext(sc trace.SpanContext) DistributedTracingExtension {
+	tp := traceparent.TraceParent{
+		TraceID: sc.TraceID,
+		SpanID:  sc.SpanID,
+		Flags: traceparent.Flags{
+			Recorded: sc.IsSampled(),
+		},
+	}
+
+	entries := make([]string, 0, len(sc.Tracestate.Entries()))
+	for _, entry := range sc.Tracestate.Entries() {
+		entries = append(entries, strings.Join([]string{entry.Key, entry.Value}, "="))
+	}
+
+	return DistributedTracingExtension{
+		TraceParent: tp.String(),
+		TraceState:  strings.Join(entries, ","),
+	}
+}
+
+// ToSpanContext creates a SpanContext from a DistributedTracingExtension instance.
+func (d DistributedTracingExtension) ToSpanContext() (trace.SpanContext, error) {
+	tp, err := traceparent.ParseString(d.TraceParent)
+	if err != nil {
+		return trace.SpanContext{}, err
+	}
+	sc := trace.SpanContext{
+		TraceID: tp.TraceID,
+		SpanID:  tp.SpanID,
+	}
+	if tp.Flags.Recorded {
+		sc.TraceOptions &= 1
+	}
+
+	if ts, err := tracestate.ParseString(d.TraceState); err == nil {
+		entries := make([]octs.Entry, 0, len(ts))
+		for _, member := range ts {
+			var key string
+			if member.Vendor != "" {
+				key = member.Tenant + "@" + member.Vendor
+			} else {
+				key = member.Tenant
+			}
+			entries = append(entries, octs.Entry{Key: key, Value: member.Value})
+		}
+		sc.Tracestate, _ = octs.New(nil, entries...)
+	}
+
+	return sc, nil
+}
+
+func (d DistributedTracingExtension) StartChildSpan(ctx context.Context, name string, opts ...trace.StartOption) (context.Context, *trace.Span) {
+	if sc, err := d.ToSpanContext(); err == nil {
+		tSpan := trace.FromContext(ctx)
+		ctx, span := trace.StartSpanWithRemoteParent(ctx, name, sc, opts...)
+		if tSpan != nil {
+			// Add link to the previous in-process trace.
+			tsc := tSpan.SpanContext()
+			span.AddLink(trace.Link{
+				TraceID: tsc.TraceID,
+				SpanID:  tsc.SpanID,
+				Type:    trace.LinkTypeParent,
+			})
+		}
+		return ctx, span
+	}
+	return ctx, nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/observability/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/observability/doc.go
@@ -1,0 +1,4 @@
+/*
+Package observability holds metrics and tracing recording implementations.
+*/
+package observability

--- a/vendor/github.com/cloudevents/sdk-go/pkg/observability/keys.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/observability/keys.go
@@ -1,0 +1,22 @@
+package observability
+
+import (
+	"go.opencensus.io/tag"
+)
+
+var (
+	// KeyMethod is the tag used for marking method on a metric.
+	KeyMethod, _ = tag.NewKey("method")
+	// KeyResult is the tag used for marking result on a metric.
+	KeyResult, _ = tag.NewKey("result")
+)
+
+const (
+	// ClientSpanName is the key used to start spans from the client.
+	ClientSpanName = "cloudevents.client"
+
+	// ResultError is a shared result tag value for error.
+	ResultError = "error"
+	// ResultOK is a shared result tag value for success.
+	ResultOK = "success"
+)

--- a/vendor/github.com/cloudevents/sdk-go/pkg/observability/observer.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/observability/observer.go
@@ -1,0 +1,87 @@
+package observability
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+// Observable represents the the customization used by the Reporter for a given
+// measurement and trace for a single method.
+type Observable interface {
+	MethodName() string
+	LatencyMs() *stats.Float64Measure
+}
+
+// Reporter represents a running latency counter. When Error or OK are
+// called, the latency is calculated. Error or OK are only allowed to
+// be called once.
+type Reporter interface {
+	Error()
+	OK()
+}
+
+type reporter struct {
+	ctx   context.Context
+	on    Observable
+	start time.Time
+	once  sync.Once
+}
+
+// All tags used for Latency measurements.
+func LatencyTags() []tag.Key {
+	return []tag.Key{KeyMethod, KeyResult}
+}
+
+// Deprecated. Tracing is always enabled.
+func EnableTracing(enabled bool) {}
+
+// NewReporter creates and returns a reporter wrapping the provided Observable.
+func NewReporter(ctx context.Context, on Observable) (context.Context, Reporter) {
+	r := &reporter{
+		ctx:   ctx,
+		on:    on,
+		start: time.Now(),
+	}
+	r.tagMethod()
+	return ctx, r
+}
+
+func (r *reporter) tagMethod() {
+	var err error
+	r.ctx, err = tag.New(r.ctx, tag.Insert(KeyMethod, r.on.MethodName()))
+	if err != nil {
+		panic(err) // or ignore?
+	}
+}
+
+func (r *reporter) record() {
+	ms := float64(time.Since(r.start) / time.Millisecond)
+	stats.Record(r.ctx, r.on.LatencyMs().M(ms))
+}
+
+// Error records the result as an error.
+func (r *reporter) Error() {
+	r.once.Do(func() {
+		r.result(ResultError)
+	})
+}
+
+// OK records the result as a success.
+func (r *reporter) OK() {
+	r.once.Do(func() {
+		r.result(ResultOK)
+	})
+}
+
+func (r *reporter) result(v string) {
+	var err error
+	r.ctx, err = tag.New(r.ctx, tag.Insert(KeyResult, v))
+	if err != nil {
+		panic(err) // or ignore?
+	}
+	r.record()
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/doc.go
@@ -1,0 +1,26 @@
+/*
+
+Package transport defines interfaces to decouple the client package
+from transport implementations.
+
+Most event sender and receiver applications should not use this
+package, they should use the client package. This package is for
+infrastructure developers implementing new transports, or intermediary
+components like importers, channels or brokers.
+
+*/
+// TODO: merge these two things ^^ vv
+/*
+Package bindings contains packages that implement different protocol bindings.
+
+Package binding provides interfaces and helper functions for implementing and using protocol bindings in a uniform way.
+
+Available bindings:
+
+* HTTP (using net/http)
+* Kafka (using github.com/Shopify/sarama)
+* AMQP (using pack.ag/amqp)
+
+*/
+
+package protocol

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/error.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/error.go
@@ -1,0 +1,37 @@
+package protocol
+
+import "fmt"
+
+// ErrTransportMessageConversion is an error produced when the transport
+// message can not be converted.
+type ErrTransportMessageConversion struct {
+	fatal     bool
+	handled   bool
+	transport string
+	message   string
+}
+
+// NewErrMessageEncodingUnknown makes a new ErrMessageEncodingUnknown.
+func NewErrTransportMessageConversion(transport, message string, handled, fatal bool) *ErrTransportMessageConversion {
+	return &ErrTransportMessageConversion{
+		transport: transport,
+		message:   message,
+		handled:   handled,
+		fatal:     fatal,
+	}
+}
+
+// IsFatal reports if this error should be considered fatal.
+func (e *ErrTransportMessageConversion) IsFatal() bool {
+	return e.fatal
+}
+
+// Handled reports if this error should be considered accepted and no further action.
+func (e *ErrTransportMessageConversion) Handled() bool {
+	return e.handled
+}
+
+// Error implements error.Error
+func (e *ErrTransportMessageConversion) Error() string {
+	return fmt.Sprintf("transport %s failed to convert message: %s", e.transport, e.message)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/doc.go
@@ -1,0 +1,5 @@
+package http
+
+/*
+Module http implements an HTTP binding using net/http module
+*/

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/engine.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/engine.go
@@ -1,0 +1,138 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/cloudevents/sdk-go/pkg/protocol"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
+)
+
+var _ protocol.Opener = (*Protocol)(nil)
+
+func (e *Protocol) OpenInbound(ctx context.Context) error {
+	e.reMu.Lock()
+	defer e.reMu.Unlock()
+
+	if e.Handler == nil {
+		e.Handler = http.NewServeMux()
+	}
+
+	if !e.handlerRegistered {
+		// handler.Handle might panic if the user tries to use the same path as the sdk.
+		e.Handler.Handle(e.GetPath(), e)
+		e.handlerRegistered = true
+	}
+
+	addr, err := e.listen()
+	if err != nil {
+		return err
+	}
+
+	e.server = &http.Server{
+		Addr: addr.String(),
+		Handler: &ochttp.Handler{
+			Propagation:    &tracecontext.HTTPFormat{},
+			Handler:        attachMiddleware(e.Handler, e.middleware),
+			FormatSpanName: formatSpanName,
+		},
+	}
+
+	// Shutdown
+	defer func() {
+		_ = e.server.Close()
+		e.server = nil
+	}()
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- e.server.Serve(e.listener)
+	}()
+
+	// wait for the server to return or ctx.Done().
+	select {
+	case <-ctx.Done():
+		// Try a gracefully shutdown.
+		timeout := *e.ShutdownTimeout
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		err := e.server.Shutdown(ctx)
+		<-errChan // Wait for server goroutine to exit
+		return err
+	case err := <-errChan:
+		return err
+	}
+}
+
+// HasTracePropagation implements Protocol.HasTracePropagation
+func (e *Protocol) HasTracePropagation() bool { // TODO: clean this all up.
+	return false
+}
+
+// GetPort returns the listening port.
+// Returns -1 if there is a listening error.
+// Note this will call net.Listen() if  the listener is not already started.
+func (e *Protocol) GetPort() int {
+	// Ensure we have a listener and therefore a port.
+	if _, err := e.listen(); err == nil || e.Port != nil {
+		return *e.Port
+	}
+	return -1
+}
+
+func formatSpanName(r *http.Request) string {
+	return "cloudevents.http." + r.URL.Path
+}
+
+func (e *Protocol) setPort(port int) {
+	if e.Port == nil {
+		e.Port = new(int)
+	}
+	*e.Port = port
+}
+
+// listen if not already listening, update t.Port
+func (e *Protocol) listen() (net.Addr, error) {
+	if e.listener == nil {
+		port := 8080
+		if e.Port != nil {
+			port = *e.Port
+			if port < 0 || port > 65535 {
+				return nil, fmt.Errorf("invalid port %d", port)
+			}
+		}
+		var err error
+		if e.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", port)); err != nil {
+			return nil, err
+		}
+	}
+	addr := e.listener.Addr()
+	if tcpAddr, ok := addr.(*net.TCPAddr); ok {
+		e.setPort(tcpAddr.Port)
+	}
+	return addr, nil
+}
+
+// GetPath returns the path the transport is hosted on. If the path is '/',
+// the transport will handle requests on any URI. To discover the true path
+// a request was received on, inspect the context from Receive(cxt, ...) with
+// TransportContextFrom(ctx).
+func (e *Protocol) GetPath() string {
+	path := strings.TrimSpace(e.Path)
+	if len(path) > 0 {
+		return path
+	}
+	return "/" // default
+}
+
+// attachMiddleware attaches the HTTP middleware to the specified handler.
+func attachMiddleware(h http.Handler, middleware []Middleware) http.Handler {
+	for _, m := range middleware {
+		h = m(h)
+	}
+	return h
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/message.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/message.go
@@ -1,0 +1,125 @@
+package http
+
+import (
+	"context"
+	"io"
+	nethttp "net/http"
+	"strings"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+)
+
+const prefix = "Ce-"
+
+var specs = spec.WithPrefix(prefix)
+
+const ContentType = "Content-Type"
+const ContentLength = "Content-Length"
+
+// Message holds the Header and Body of a HTTP Request or Response.
+// The Message instance *must* be constructed from NewMessage function.
+// This message *cannot* be read several times. In order to read it more times, buffer it using binding/buffering methods
+type Message struct {
+	Header     nethttp.Header
+	BodyReader io.ReadCloser
+	OnFinish   func(error) error
+
+	format  format.Format
+	version spec.Version
+}
+
+// Check if http.Message implements binding.Message
+var _ binding.Message = (*Message)(nil)
+
+// NewMessage returns a binding.Message with header and data.
+// The returned binding.Message *cannot* be read several times. In order to read it more times, buffer it using binding/buffering methods
+func NewMessage(header nethttp.Header, body io.ReadCloser) *Message {
+	m := Message{Header: header}
+	if body != nil {
+		m.BodyReader = body
+	}
+	if m.format = format.Lookup(header.Get(ContentType)); m.format == nil {
+		m.version = specs.Version(m.Header.Get(specs.PrefixedSpecVersionName()))
+	}
+	return &m
+}
+
+// NewMessageFromHttpRequest returns a binding.Message with header and data.
+// The returned binding.Message *cannot* be read several times. In order to read it more times, buffer it using binding/buffering methods
+func NewMessageFromHttpRequest(req *nethttp.Request) *Message {
+	return NewMessage(req.Header, req.Body)
+}
+
+// NewMessageFromHttpResponse returns a binding.Message with header and data.
+// The returned binding.Message *cannot* be read several times. In order to read it more times, buffer it using binding/buffering methods
+func NewMessageFromHttpResponse(req *nethttp.Response) *Message {
+	return NewMessage(req.Header, req.Body)
+}
+
+func (m *Message) ReadEncoding() binding.Encoding {
+	if m.version != nil {
+		return binding.EncodingBinary
+	}
+	if m.format != nil {
+		return binding.EncodingStructured
+	}
+	return binding.EncodingUnknown
+}
+
+func (m *Message) ReadStructured(ctx context.Context, encoder binding.StructuredWriter) error {
+	if m.format == nil {
+		return binding.ErrNotStructured
+	} else {
+		return encoder.SetStructuredEvent(ctx, m.format, m.BodyReader)
+	}
+}
+
+func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) error {
+	if m.version == nil {
+		return binding.ErrNotBinary
+	}
+
+	err := encoder.Start(ctx)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range m.Header {
+		if strings.HasPrefix(k, prefix) {
+			attr := m.version.Attribute(k)
+			if attr != nil {
+				err = encoder.SetAttribute(attr, v[0])
+			} else {
+				err = encoder.SetExtension(strings.ToLower(strings.TrimPrefix(k, prefix)), v[0])
+			}
+		} else if k == ContentType {
+			err = encoder.SetAttribute(m.version.AttributeFromKind(spec.DataContentType), v[0])
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	if m.BodyReader != nil {
+		err = encoder.SetData(m.BodyReader)
+		if err != nil {
+			return err
+		}
+	}
+
+	return encoder.End(ctx)
+}
+
+func (m *Message) Finish(err error) error {
+	if m.BodyReader != nil {
+		_ = m.BodyReader.Close()
+	}
+	if m.OnFinish != nil {
+		return m.OnFinish(err)
+	}
+	// TODO: if in binary mode, there could be nothing in this request or
+	// response. Meaning Message is not nil but never going to be a valid event.
+	return nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/options.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/options.go
@@ -1,0 +1,164 @@
+package http
+
+import (
+	"fmt"
+	"net"
+	nethttp "net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Option is the function signature required to be considered an http.Option.
+type Option func(*Protocol) error
+
+// WithTarget sets the outbound recipient of cloudevents when using an HTTP
+// request.
+func WithTarget(targetUrl string) Option {
+	return func(p *Protocol) error {
+		if p == nil {
+			return fmt.Errorf("http protocol option can not set nil protocol")
+		}
+		targetUrl = strings.TrimSpace(targetUrl)
+		if targetUrl != "" {
+			var err error
+			var target *url.URL
+			target, err = url.Parse(targetUrl)
+			if err != nil {
+				return fmt.Errorf("http target option failed to parse target url: %s", err.Error())
+			}
+
+			p.Target = target
+
+			if p.RequestTemplate == nil {
+				p.RequestTemplate = &nethttp.Request{
+					Method: nethttp.MethodPost,
+				}
+			}
+			p.RequestTemplate.URL = target
+
+			return nil
+		}
+		return fmt.Errorf("http target option was empty string")
+	}
+}
+
+// WithHeader sets an additional default outbound header for all cloudevents
+// when using an HTTP request.
+func WithHeader(key, value string) Option {
+	return func(p *Protocol) error {
+		if p == nil {
+			return fmt.Errorf("http header option can not set nil transport")
+		}
+		key = strings.TrimSpace(key)
+		if key != "" {
+			if p.RequestTemplate == nil {
+				p.RequestTemplate = &nethttp.Request{
+					Method: nethttp.MethodPost,
+				}
+			}
+			if p.RequestTemplate.Header == nil {
+				p.RequestTemplate.Header = nethttp.Header{}
+			}
+			p.RequestTemplate.Header.Add(key, value)
+			return nil
+		}
+		return fmt.Errorf("http header option was empty string")
+	}
+}
+
+// WithShutdownTimeout sets the shutdown timeout when the http server is being shutdown.
+func WithShutdownTimeout(timeout time.Duration) Option {
+	return func(t *Protocol) error {
+		if t == nil {
+			return fmt.Errorf("http shutdown timeout option can not set nil transport")
+		}
+		t.ShutdownTimeout = &timeout
+		return nil
+	}
+}
+
+func checkListen(t *Protocol, prefix string) error {
+	switch {
+	case t.Port != nil:
+		return fmt.Errorf("%v port already set", prefix)
+	case t.listener != nil:
+		return fmt.Errorf("%v listener already set", prefix)
+	}
+	return nil
+}
+
+// WithPort sets the listening port for StartReceiver.
+// Only one of WithListener  or WithPort is allowed.
+func WithPort(port int) Option {
+	return func(t *Protocol) error {
+		if t == nil {
+			return fmt.Errorf("http port option can not set nil transport")
+		}
+		if port < 0 || port > 65535 {
+			return fmt.Errorf("http port option was given an invalid port: %d", port)
+		}
+		if err := checkListen(t, "http port option"); err != nil {
+			return err
+		}
+		t.setPort(port)
+		return nil
+	}
+}
+
+// WithListener sets the listener for StartReceiver.
+// Only one of WithListener or WithPort is allowed.
+func WithListener(l net.Listener) Option {
+	return func(t *Protocol) error {
+		if t == nil {
+			return fmt.Errorf("http listener option can not set nil transport")
+		}
+		if err := checkListen(t, "http port option"); err != nil {
+			return err
+		}
+		t.listener = l
+		_, err := t.listen()
+		return err
+	}
+}
+
+// WithPath sets the path to receive cloudevents on for HTTP transports.
+func WithPath(path string) Option {
+	return func(t *Protocol) error {
+		if t == nil {
+			return fmt.Errorf("http path option can not set nil transport")
+		}
+		path = strings.TrimSpace(path)
+		if len(path) == 0 {
+			return fmt.Errorf("http path option was given an invalid path: %q", path)
+		}
+		t.Path = path
+		return nil
+	}
+}
+
+//
+// Middleware is a function that takes an existing http.Handler and wraps it in middleware,
+// returning the wrapped http.Handler.
+type Middleware func(next nethttp.Handler) nethttp.Handler
+
+// WithMiddleware adds an HTTP middleware to the transport. It may be specified multiple times.
+// Middleware is applied to everything before it. For example
+// `NewClient(WithMiddleware(foo), WithMiddleware(bar))` would result in `bar(foo(original))`.
+func WithMiddleware(middleware Middleware) Option {
+	return func(t *Protocol) error {
+		if t == nil {
+			return fmt.Errorf("http middleware option can not set nil transport")
+		}
+		t.middleware = append(t.middleware, middleware)
+		return nil
+	}
+}
+
+// WithHTTPTransport sets the HTTP client transport.
+func WithHTTPTransport(httpTransport nethttp.RoundTripper) Option {
+	return func(t *Protocol) error {
+		t.transport = httpTransport
+		return nil
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/protocol.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/protocol.go
@@ -1,0 +1,234 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/cloudevents/sdk-go/pkg/protocol"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	cecontext "github.com/cloudevents/sdk-go/pkg/context"
+)
+
+const (
+	// DefaultShutdownTimeout defines the default timeout given to the http.Server when calling Shutdown.
+	DefaultShutdownTimeout = time.Minute * 1
+)
+
+// Protocol acts as both a http client and a http handler.
+type Protocol struct {
+	Target          *url.URL
+	RequestTemplate *http.Request
+	transformers    binding.TransformerFactories
+	Client          *http.Client
+	incoming        chan msgErr
+
+	// To support Opener:
+
+	// ShutdownTimeout defines the timeout given to the http.Server when calling Shutdown.
+	// If nil, DefaultShutdownTimeout is used.
+	ShutdownTimeout *time.Duration
+
+	// Port is the port to bind the receiver to. Defaults to 8080.
+	Port *int
+	// Path is the path to bind the receiver to. Defaults to "/".
+	Path string
+
+	// Receive Mutex
+	reMu sync.Mutex
+	// Handler is the handler the http Server will use. Use this to reuse the
+	// http server. If nil, the Protocol will create a one.
+	Handler           *http.ServeMux
+	listener          net.Listener
+	transport         http.RoundTripper // TODO: use this.
+	server            *http.Server
+	handlerRegistered bool
+	middleware        []Middleware
+}
+
+func New(opts ...Option) (*Protocol, error) {
+	p := &Protocol{
+		transformers: make(binding.TransformerFactories, 0),
+		incoming:     make(chan msgErr),
+	}
+	if err := p.applyOptions(opts...); err != nil {
+		return nil, err
+	}
+
+	if p.Client == nil {
+		p.Client = http.DefaultClient
+	}
+
+	if p.ShutdownTimeout == nil {
+		timeout := DefaultShutdownTimeout
+		p.ShutdownTimeout = &timeout
+	}
+
+	return p, nil
+}
+
+func (p *Protocol) applyOptions(opts ...Option) error {
+	for _, fn := range opts {
+		if err := fn(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Send implements binding.Sender
+func (p *Protocol) Send(ctx context.Context, m binding.Message) error {
+	_, err := p.Request(ctx, m)
+	return err
+}
+
+// Request implements binding.Requester
+func (p *Protocol) Request(ctx context.Context, m binding.Message) (binding.Message, error) {
+	var err error
+	defer func() { _ = m.Finish(err) }()
+
+	req := p.makeRequest(ctx)
+
+	if p.Client == nil || req == nil || req.URL == nil {
+		return nil, fmt.Errorf("not initialized: %#v", p)
+	}
+
+	if err = WriteRequest(ctx, m, req, p.transformers); err != nil {
+		return nil, err
+	}
+	resp, err := p.Client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("%d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+	}
+
+	return NewMessage(resp.Header, resp.Body), nil
+}
+
+func (p *Protocol) makeRequest(ctx context.Context) *http.Request {
+	// TODO: support custom headers from context?
+	req := &http.Request{
+		Header: make(http.Header),
+		// TODO: HeaderFrom(ctx),
+	}
+
+	if p.RequestTemplate != nil {
+		req.Method = p.RequestTemplate.Method
+		req.URL = p.RequestTemplate.URL
+		req.Close = p.RequestTemplate.Close
+		req.Host = p.RequestTemplate.Host
+		copyHeadersEnsure(p.RequestTemplate.Header, &req.Header)
+	}
+
+	if p.Target != nil {
+		req.URL = p.Target
+	}
+
+	// Override the default request with target from context.
+	if target := cecontext.TargetFrom(ctx); target != nil {
+		req.URL = target
+	}
+	return req.WithContext(ctx)
+}
+
+// Ensure to is a non-nil map before copying
+func copyHeadersEnsure(from http.Header, to *http.Header) {
+	if len(from) > 0 {
+		if *to == nil {
+			*to = http.Header{}
+		}
+		copyHeaders(from, *to)
+	}
+}
+
+func copyHeaders(from, to http.Header) {
+	if from == nil || to == nil {
+		return
+	}
+	for header, values := range from {
+		for _, value := range values {
+			to.Add(header, value)
+		}
+	}
+}
+
+// Receive the next incoming HTTP request as a CloudEvent.
+// Returns non-nil error if the incoming HTTP request fails to parse as a CloudEvent
+// Returns io.EOF if the receiver is closed.
+func (p *Protocol) Receive(ctx context.Context) (binding.Message, error) {
+	msg, fn, err := p.Respond(ctx)
+	// No-op the response.
+	defer func() {
+		if fn != nil {
+			_ = fn(ctx, nil, nil)
+		}
+	}()
+	return msg, err
+}
+
+// Respond receives the next incoming HTTP request as a CloudEvent and waits
+// for the response callback to invoked before continuing.
+// Returns non-nil error if the incoming HTTP request fails to parse as a CloudEvent
+// Returns io.EOF if the receiver is closed.
+func (p *Protocol) Respond(ctx context.Context) (binding.Message, protocol.ResponseFn, error) {
+	in, ok := <-p.incoming
+	if !ok {
+		return nil, nil, io.EOF
+	}
+	return in.msg, in.respFn, in.err
+}
+
+type msgErr struct {
+	msg    *Message
+	respFn protocol.ResponseFn
+	err    error
+}
+
+// ServeHTTP implements http.Handler.
+// Blocks until Message.Finish is called.
+func (p *Protocol) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	var err error
+	m := NewMessageFromHttpRequest(req)
+	if m.ReadEncoding() == binding.EncodingUnknown {
+		p.incoming <- msgErr{msg: nil, err: binding.ErrUnknownEncoding}
+	}
+	done := make(chan error)
+
+	m.OnFinish = func(err error) error {
+		done <- err
+		return nil
+	}
+
+	var fn protocol.ResponseFn = func(ctx context.Context, resp binding.Message, er protocol.Result) error {
+		if resp != nil {
+			status := http.StatusOK
+			if er != nil {
+				var result *Result
+				if protocol.ResultAs(er, &result) {
+					if result.Status > 100 && result.Status < 600 {
+						status = result.Status
+					}
+				}
+			}
+
+			err := WriteResponseWriter(ctx, resp, status, rw, p.transformers)
+			return resp.Finish(err)
+		}
+
+		return nil
+	}
+
+	p.incoming <- msgErr{msg: m, respFn: fn, err: err} // Send to Respond()
+	if err = <-done; err != nil {
+		fmt.Println("attempting to write an error out on response writer:", err)
+		http.Error(rw, fmt.Sprintf("cannot forward CloudEvent: %v", err), http.StatusInternalServerError)
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/response.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/response.go
@@ -1,0 +1,44 @@
+package http
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/cloudevents/sdk-go/pkg/protocol"
+)
+
+// NewResult returns a fully populated http Result that should be used as
+// a transport.Result.
+func NewResult(status int, messageFmt string, args ...interface{}) protocol.Result {
+	return &Result{
+		Status: status,
+		Format: messageFmt,
+		Args:   args,
+	}
+}
+
+// Result wraps the fields required to make adjustments for http Responses.
+type Result struct {
+	Status int
+	Format string
+	Args   []interface{}
+}
+
+// make sure Result implements error.
+var _ error = (*Result)(nil)
+
+// Is returns if the target error is a Result type checking target.
+func (e *Result) Is(target error) bool {
+	if _, ok := target.(*Result); ok {
+		return true
+	}
+	// Allow for wrapped errors.
+	err := fmt.Errorf(e.Format, e.Args...)
+	return errors.Is(err, target)
+}
+
+// Error returns the string that is formed by using the format string with the
+// provided args.
+func (e *Result) Error() string {
+	return fmt.Sprintf(e.Format, e.Args...)
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/write_request.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/write_request.go
@@ -1,0 +1,78 @@
+package http
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+// Fill the provided httpRequest with the message m.
+// Using context you can tweak the encoding processing (more details on binding.Write documentation).
+func WriteRequest(ctx context.Context, m binding.Message, httpRequest *http.Request, transformers ...binding.TransformerFactory) error {
+	structuredWriter := (*httpRequestWriter)(httpRequest)
+	binaryWriter := (*httpRequestWriter)(httpRequest)
+
+	_, err := binding.Write(
+		ctx,
+		m,
+		structuredWriter,
+		binaryWriter,
+		transformers...,
+	)
+	return err
+}
+
+type httpRequestWriter http.Request
+
+func (b *httpRequestWriter) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error {
+	b.Header.Set(ContentType, format.MediaType())
+	b.Body = ioutil.NopCloser(event)
+	return nil
+}
+
+func (b *httpRequestWriter) Start(ctx context.Context) error {
+	return nil
+}
+
+func (b *httpRequestWriter) End(ctx context.Context) error {
+	return nil
+}
+
+func (b *httpRequestWriter) SetData(reader io.Reader) error {
+	b.Body = ioutil.NopCloser(reader)
+	return nil
+}
+
+func (b *httpRequestWriter) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	// Http headers, everything is a string!
+	s, err := types.Format(value)
+	if err != nil {
+		return err
+	}
+
+	if attribute.Kind() == spec.DataContentType {
+		b.Header.Add(ContentType, s)
+	} else {
+		b.Header.Add(prefix+attribute.Name(), s)
+	}
+	return nil
+}
+
+func (b *httpRequestWriter) SetExtension(name string, value interface{}) error {
+	// Http headers, everything is a string!
+	s, err := types.Format(value)
+	if err != nil {
+		return err
+	}
+	b.Header.Add(prefix+name, s)
+	return nil
+}
+
+var _ binding.StructuredWriter = (*httpRequestWriter)(nil) // Test it conforms to the interface
+var _ binding.BinaryWriter = (*httpRequestWriter)(nil)     // Test it conforms to the interface

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/write_responsewriter.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/http/write_responsewriter.go
@@ -1,0 +1,90 @@
+package http
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+// Write out to the the provided httpResponseWriter with the message m.
+// Using context you can tweak the encoding processing (more details on binding.Write documentation).
+func WriteResponseWriter(ctx context.Context, m binding.Message, status int, rw http.ResponseWriter, transformers ...binding.TransformerFactory) error {
+	if status < 200 || status >= 600 {
+		status = http.StatusOK
+	}
+	writer := &httpResponseWriter{rw: rw, status: status}
+
+	_, err := binding.Write(
+		ctx,
+		m,
+		writer,
+		writer,
+		transformers...,
+	)
+	return err
+}
+
+type httpResponseWriter struct {
+	rw     http.ResponseWriter
+	status int
+}
+
+func (b *httpResponseWriter) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error {
+	b.rw.Header().Set(ContentType, format.MediaType())
+	return b.SetData(event)
+}
+
+func (b *httpResponseWriter) Start(ctx context.Context) error {
+	return nil
+}
+
+func (b *httpResponseWriter) End(ctx context.Context) error {
+	return nil
+}
+
+func (b *httpResponseWriter) SetData(reader io.Reader) error {
+	// Finalize the headers.
+	b.rw.WriteHeader(b.status)
+
+	// Write body.
+	copied, err := io.Copy(b.rw, reader)
+	if err != nil {
+		return err
+	}
+	b.rw.Header().Set("Content-Length", strconv.FormatInt(copied, 10))
+	return nil
+}
+
+func (b *httpResponseWriter) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	// Http headers, everything is a string!
+	s, err := types.Format(value)
+	if err != nil {
+		return err
+	}
+
+	if attribute.Kind() == spec.DataContentType {
+		b.rw.Header().Add(ContentType, s)
+	} else {
+		b.rw.Header().Add(prefix+attribute.Name(), s)
+	}
+	return nil
+}
+
+func (b *httpResponseWriter) SetExtension(name string, value interface{}) error {
+	// Http headers, everything is a string!
+	s, err := types.Format(value)
+	if err != nil {
+		return err
+	}
+	b.rw.Header().Add(prefix+name, s)
+	return nil
+}
+
+var _ binding.StructuredWriter = (*httpResponseWriter)(nil) // Test it conforms to the interface
+var _ binding.BinaryWriter = (*httpResponseWriter)(nil)     // Test it conforms to the interface

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/inbound.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/inbound.go
@@ -1,0 +1,41 @@
+package protocol
+
+import (
+	"context"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+)
+
+// Receiver receives messages.
+type Receiver interface {
+	// Receive blocks till a message is received or ctx expires.
+	//
+	// A non-nil error means the receiver is closed.
+	// io.EOF means it closed cleanly, any other value indicates an error.
+	Receive(ctx context.Context) (binding.Message, error)
+}
+
+// ReceiveCloser is a Receiver that can be closed.
+type ReceiveCloser interface {
+	Receiver
+	Closer
+}
+
+// ResponseFn is the function callback provided from Responder.Respond to allow
+// for a receiver to "reply" to a message it receives.
+type ResponseFn func(ctx context.Context, m binding.Message, r Result) error
+
+// Responder receives messages and is given a callback to respond.
+type Responder interface {
+	// Receive blocks till a message is received or ctx expires.
+	//
+	// A non-nil error means the receiver is closed.
+	// io.EOF means it closed cleanly, any other value indicates an error.
+	Respond(ctx context.Context) (binding.Message, ResponseFn, error)
+}
+
+// ResponderCloser is a Responder that can be closed.
+type ResponderCloser interface {
+	Responder
+	Closer
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/doc.go
@@ -1,0 +1,5 @@
+package kafka_sarama
+
+/*
+Module kafka_sarama implements a Kafka binding using github.com/Shopify/sarama module
+*/

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/message.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/message.go
@@ -1,0 +1,143 @@
+package kafka_sarama
+
+import (
+	"bytes"
+	"context"
+	"strings"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+
+	"github.com/Shopify/sarama"
+)
+
+const (
+	prefix            = "ce_"
+	contentTypeHeader = "content-type"
+)
+
+var specs = spec.WithPrefix(prefix)
+
+// Message holds a Kafka Message.
+// This message *can* be read several times safely
+type Message struct {
+	Key, Value  []byte
+	Headers     map[string][]byte
+	ContentType string
+	format      format.Format
+	version     spec.Version
+}
+
+// Check if http.Message implements binding.Message
+var _ binding.Message = (*Message)(nil)
+
+// Returns a binding.Message that holds the provided ConsumerMessage.
+// The returned binding.Message *can* be read several times safely
+// This function *doesn't* guarantee that the returned binding.Message is always a kafka_sarama.Message instance
+func NewMessageFromConsumerMessage(cm *sarama.ConsumerMessage) *Message {
+	var contentType string
+	headers := make(map[string][]byte, len(cm.Headers))
+	for _, r := range cm.Headers {
+		k := strings.ToLower(string(r.Key))
+		if k == contentTypeHeader {
+			contentType = string(r.Value)
+		}
+		headers[k] = r.Value
+	}
+	return NewMessage(cm.Key, cm.Value, contentType, headers)
+}
+
+// Returns a binding.Message that holds the provided kafka message components.
+// The returned binding.Message *can* be read several times safely
+// This function *doesn't* guarantee that the returned binding.Message is always a kafka_sarama.Message instance
+func NewMessage(key []byte, value []byte, contentType string, headers map[string][]byte) *Message {
+	if ft := format.Lookup(contentType); ft != nil {
+		return &Message{
+			Key:         key,
+			Value:       value,
+			ContentType: contentType,
+			Headers:     headers,
+			format:      ft,
+		}
+	} else if v := specs.Version(string(headers[specs.PrefixedSpecVersionName()])); v != nil {
+		return &Message{
+			Key:         key,
+			Value:       value,
+			ContentType: contentType,
+			Headers:     headers,
+			version:     v,
+		}
+	}
+
+	return &Message{
+		Key:         key,
+		Value:       value,
+		ContentType: contentType,
+		Headers:     headers,
+	}
+}
+
+func (m *Message) ReadEncoding() binding.Encoding {
+	if m.version != nil {
+		return binding.EncodingBinary
+	}
+	if m.format != nil {
+		return binding.EncodingStructured
+	}
+	return binding.EncodingUnknown
+}
+
+func (m *Message) ReadStructured(ctx context.Context, encoder binding.StructuredWriter) error {
+	if m.format != nil {
+		return encoder.SetStructuredEvent(ctx, m.format, bytes.NewReader(m.Value))
+	}
+	return binding.ErrNotStructured
+}
+
+func (m *Message) ReadBinary(ctx context.Context, encoder binding.BinaryWriter) error {
+	if m.version == nil {
+		return binding.ErrNotBinary
+	}
+
+	err := encoder.Start(ctx)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range m.Headers {
+		if strings.HasPrefix(k, prefix) {
+			attr := m.version.Attribute(k)
+			if attr != nil {
+				err = encoder.SetAttribute(attr, string(v))
+			} else {
+				err = encoder.SetExtension(strings.TrimPrefix(k, prefix), string(v))
+			}
+		} else if k == contentTypeHeader {
+			err = encoder.SetAttribute(m.version.AttributeFromKind(spec.DataContentType), string(v))
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	if m.Key != nil {
+		err = encoder.SetExtension("key", string(m.Key))
+		if err != nil {
+			return err
+		}
+	}
+
+	if m.Value != nil {
+		err = encoder.SetData(bytes.NewReader(m.Value))
+		if err != nil {
+			return err
+		}
+	}
+
+	return encoder.End(ctx)
+}
+
+func (m *Message) Finish(error) error {
+	return nil
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/option.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/option.go
@@ -1,0 +1,32 @@
+package kafka_sarama
+
+import (
+	"context"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+)
+
+// kafka_sarama.Sender options
+type SenderOptionFunc func(sender *Sender)
+
+// Add a transformer, which Sender uses while encoding a binding.Message to a sarama.ProducerMessage
+func WithTransformer(transformer binding.TransformerFactory) SenderOptionFunc {
+	return func(sender *Sender) {
+		sender.transformers = append(sender.transformers, transformer)
+	}
+}
+
+// kafka_sarama.Protocol options
+type ProtocolOptionFunc func(protocol *Protocol)
+
+func WithReceiverGroupId(groupId string) ProtocolOptionFunc {
+	return func(protocol *Protocol) {
+		protocol.receiverGroupId = groupId
+	}
+}
+
+func WithSenderContextDecorators(decorator func(context.Context) context.Context) ProtocolOptionFunc {
+	return func(protocol *Protocol) {
+		protocol.SenderContextDecorators = append(protocol.SenderContextDecorators, decorator)
+	}
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/protocol.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/protocol.go
@@ -1,0 +1,126 @@
+package kafka_sarama
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/Shopify/sarama"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	cecontext "github.com/cloudevents/sdk-go/pkg/context"
+	"github.com/cloudevents/sdk-go/pkg/protocol"
+)
+
+const (
+	defaultGroupId = "cloudevents-sdk-go"
+)
+
+type Protocol struct {
+	// Kafka
+	Client sarama.Client
+
+	// Sender
+	Sender *Sender
+
+	// Sender options
+	SenderContextDecorators []func(context.Context) context.Context
+	senderTransformers      binding.TransformerFactories
+	senderTopic             string
+
+	// Consumer
+	Consumer    *Consumer
+	consumerMux sync.Mutex
+
+	// Consumer options
+	receiverTopic   string
+	receiverGroupId string
+}
+
+// NewProtocol creates a new kafka transport.
+func NewProtocol(brokers []string, saramaConfig *sarama.Config, sendToTopic string, receiveFromTopic string, opts ...ProtocolOptionFunc) (*Protocol, error) {
+	client, err := sarama.NewClient(brokers, saramaConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewProtocolFromClient(client, sendToTopic, receiveFromTopic, opts...)
+}
+
+// NewProtocolFromClient creates a new kafka transport starting from a sarama.Client
+func NewProtocolFromClient(client sarama.Client, sendToTopic string, receiveFromTopic string, opts ...ProtocolOptionFunc) (*Protocol, error) {
+	p := &Protocol{
+		Client:                  client,
+		SenderContextDecorators: make([]func(context.Context) context.Context, 0),
+		receiverGroupId:         defaultGroupId,
+		senderTopic:             sendToTopic,
+		receiverTopic:           receiveFromTopic,
+	}
+
+	var err error
+	if err = p.applyOptions(opts...); err != nil {
+		return nil, err
+	}
+
+	if p.senderTopic == "" {
+		return nil, errors.New("you didn't specify the topic to send to")
+	}
+	p.Sender, err = NewSenderFromClient(p.Client, p.senderTopic)
+	if err != nil {
+		return nil, err
+	}
+
+	if p.receiverTopic == "" {
+		return nil, errors.New("you didn't specify the topic to receive from")
+	}
+	p.Consumer = NewConsumerFromClient(p.Client, p.receiverGroupId, p.receiverTopic)
+
+	return p, nil
+}
+
+func (p *Protocol) applyOptions(opts ...ProtocolOptionFunc) error {
+	for _, fn := range opts {
+		fn(p)
+	}
+	return nil
+}
+
+// StartReceiver implements Protocol.StartReceiver
+// NOTE: This is a blocking call.
+func (p *Protocol) OpenInbound(ctx context.Context) error {
+	p.consumerMux.Lock()
+	defer p.consumerMux.Unlock()
+
+	logger := cecontext.LoggerFrom(ctx)
+	logger.Infof("Starting consumer group to topic {} and group id {}", p.receiverTopic, p.receiverGroupId)
+
+	return p.Consumer.OpenInbound(ctx)
+}
+
+// HasTracePropagation implements Protocol.HasTracePropagation
+func (p *Protocol) HasTracePropagation() bool {
+	return false
+}
+
+func (p *Protocol) Send(ctx context.Context, in binding.Message) error {
+	for _, f := range p.SenderContextDecorators {
+		ctx = f(ctx)
+	}
+	return p.Sender.Send(ctx, in)
+}
+
+func (p *Protocol) Receive(ctx context.Context) (binding.Message, error) {
+	return p.Consumer.Receive(ctx)
+}
+
+func (p *Protocol) Close(ctx context.Context) error {
+	if err := p.Consumer.Close(ctx); err != nil {
+		return err
+	}
+	return p.Sender.Close(ctx)
+}
+
+// Kafka protocol implements Sender, Receiver
+var _ protocol.Sender = (*Protocol)(nil)
+var _ protocol.Receiver = (*Protocol)(nil)
+var _ protocol.Closer = (*Protocol)(nil)

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/receiver.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/receiver.go
@@ -1,0 +1,129 @@
+package kafka_sarama
+
+import (
+	"context"
+	"io"
+	"sync"
+
+	"github.com/Shopify/sarama"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/protocol"
+)
+
+type msgErr struct {
+	msg binding.Message
+	err error
+}
+
+// Receiver which implements sarama.ConsumerGroupHandler
+// After the first invocation of Receiver.Receive(), the sarama.ConsumerGroup is created and started.
+type Receiver struct {
+	once     sync.Once
+	incoming chan msgErr
+}
+
+// NewReceiver creates a Receiver which implements sarama.ConsumerGroupHandler
+// The sarama.ConsumerGroup must be started invoking. If you need a Receiver which also manage the ConsumerGroup, use NewConsumer
+// After the first invocation of Receiver.Receive(), the sarama.ConsumerGroup is created and started.
+func NewReceiver() *Receiver {
+	return &Receiver{
+		incoming: make(chan msgErr),
+	}
+}
+
+func (r *Receiver) Setup(sess sarama.ConsumerGroupSession) error {
+	return nil
+}
+
+func (r *Receiver) Cleanup(sarama.ConsumerGroupSession) error {
+	r.once.Do(func() {
+		close(r.incoming)
+	})
+	return nil
+}
+
+func (r *Receiver) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+	for message := range claim.Messages() {
+		m := NewMessageFromConsumerMessage(message)
+
+		r.incoming <- msgErr{
+			msg: binding.WithFinish(m, func(err error) { session.MarkMessage(message, "") }),
+		}
+	}
+	return nil
+}
+
+func (r *Receiver) Receive(ctx context.Context) (binding.Message, error) {
+	msgErr, ok := <-r.incoming
+	if !ok {
+		return nil, io.EOF
+	}
+	return msgErr.msg, msgErr.err
+}
+
+var _ protocol.Receiver = (*Receiver)(nil)
+
+type Consumer struct {
+	Receiver
+
+	client              sarama.Client
+	topic               string
+	groupId             string
+	saramaConsumerGroup sarama.ConsumerGroup
+}
+
+func NewConsumer(brokers []string, saramaConfig *sarama.Config, groupId string, topic string) (*Consumer, error) {
+	client, err := sarama.NewClient(brokers, saramaConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewConsumerFromClient(client, groupId, topic), nil
+}
+
+func NewConsumerFromClient(client sarama.Client, groupId string, topic string) *Consumer {
+	return &Consumer{
+		Receiver: Receiver{
+			incoming: make(chan msgErr),
+		},
+		client:  client,
+		topic:   topic,
+		groupId: groupId,
+	}
+}
+
+func (c *Consumer) OpenInbound(ctx context.Context) (err error) {
+	cg, err := sarama.NewConsumerGroupFromClient(c.groupId, c.client)
+	if err != nil {
+		return
+	}
+	c.saramaConsumerGroup = cg
+
+	errCh := make(chan error)
+
+	go func(errs chan error) {
+		errs <- cg.Consume(context.Background(), []string{c.topic}, c)
+	}(errCh)
+
+	for {
+		select {
+		case <-ctx.Done():
+			err = c.Close(context.TODO())
+			return
+		case err = <-errCh:
+			return
+		}
+	}
+}
+
+func (c *Consumer) Close(ctx context.Context) error {
+	if c.saramaConsumerGroup != nil {
+		if err := c.saramaConsumerGroup.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+var _ protocol.Opener = (*Consumer)(nil)

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/sender.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/sender.go
@@ -1,0 +1,60 @@
+package kafka_sarama
+
+import (
+	"context"
+
+	"github.com/Shopify/sarama"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+)
+
+// Sender implements binding.Sender that sends messages to a specific receiverTopic using sarama.SyncProducer
+type Sender struct {
+	topic        string
+	syncProducer sarama.SyncProducer
+
+	transformers binding.TransformerFactories
+}
+
+// Returns a binding.Sender that sends messages to a specific receiverTopic using sarama.SyncProducer
+func NewSender(brokers []string, saramaConfig *sarama.Config, topic string, options ...SenderOptionFunc) (*Sender, error) {
+	client, err := sarama.NewClient(brokers, saramaConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewSenderFromClient(client, topic, options...)
+}
+
+// Returns a binding.Sender that sends messages to a specific receiverTopic using sarama.SyncProducer
+func NewSenderFromClient(client sarama.Client, topic string, options ...SenderOptionFunc) (*Sender, error) {
+	producer, err := sarama.NewSyncProducerFromClient(client)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Sender{
+		topic:        topic,
+		syncProducer: producer,
+		transformers: make(binding.TransformerFactories, 0),
+	}
+	for _, o := range options {
+		o(s)
+	}
+	return s, nil
+}
+
+func (s *Sender) Send(ctx context.Context, m binding.Message) error {
+	kafkaMessage := sarama.ProducerMessage{Topic: s.topic}
+
+	if err := WriteProducerMessage(ctx, m, &kafkaMessage, s.transformers); err != nil {
+		return err
+	}
+
+	_, _, err := s.syncProducer.SendMessage(&kafkaMessage)
+	return err
+}
+
+func (s *Sender) Close(ctx context.Context) error {
+	return s.syncProducer.Close()
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/write_producer_message.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/kafka_sarama/write_producer_message.go
@@ -1,0 +1,95 @@
+package kafka_sarama
+
+import (
+	"bytes"
+	"context"
+	"io"
+
+	"github.com/Shopify/sarama"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/format"
+	"github.com/cloudevents/sdk-go/pkg/binding/spec"
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+// Fill the provided producerMessage with the message m.
+// Using context you can tweak the encoding processing (more details on binding.Write documentation).
+func WriteProducerMessage(ctx context.Context, m binding.Message, producerMessage *sarama.ProducerMessage, transformerFactories ...binding.TransformerFactory) error {
+	enc := (*kafkaProducerMessageWriter)(producerMessage)
+
+	_, err := binding.Write(
+		ctx,
+		m,
+		enc,
+		enc,
+		transformerFactories...,
+	)
+	return err
+}
+
+type kafkaProducerMessageWriter sarama.ProducerMessage
+
+func (b *kafkaProducerMessageWriter) SetStructuredEvent(ctx context.Context, format format.Format, event io.Reader) error {
+	b.Headers = []sarama.RecordHeader{{
+		Key:   []byte(contentTypeHeader),
+		Value: []byte(format.MediaType()),
+	}}
+
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, event)
+	if err != nil {
+		return err
+	}
+
+	b.Value = sarama.ByteEncoder(buf.Bytes())
+	return nil
+}
+
+func (b *kafkaProducerMessageWriter) Start(ctx context.Context) error {
+	b.Headers = []sarama.RecordHeader{}
+	return nil
+}
+
+func (b *kafkaProducerMessageWriter) End(ctx context.Context) error {
+	return nil
+}
+
+func (b *kafkaProducerMessageWriter) SetData(reader io.Reader) error {
+	var buf bytes.Buffer
+	_, err := io.Copy(&buf, reader)
+	if err != nil {
+		return err
+	}
+
+	b.Value = sarama.ByteEncoder(buf.Bytes())
+	return nil
+}
+
+func (b *kafkaProducerMessageWriter) SetAttribute(attribute spec.Attribute, value interface{}) error {
+	// Everything is a string here
+	s, err := types.Format(value)
+	if err != nil {
+		return err
+	}
+
+	if attribute.Kind() == spec.DataContentType {
+		b.Headers = append(b.Headers, sarama.RecordHeader{Key: []byte(contentTypeHeader), Value: []byte(s)})
+	} else {
+		b.Headers = append(b.Headers, sarama.RecordHeader{Key: []byte(prefix + attribute.Name()), Value: []byte(s)})
+	}
+	return nil
+}
+
+func (b *kafkaProducerMessageWriter) SetExtension(name string, value interface{}) error {
+	// Kafka headers, everything is a string!
+	s, err := types.Format(value)
+	if err != nil {
+		return err
+	}
+	b.Headers = append(b.Headers, sarama.RecordHeader{Key: []byte(prefix + name), Value: []byte(s)})
+	return nil
+}
+
+var _ binding.StructuredWriter = (*kafkaProducerMessageWriter)(nil) // Test it conforms to the interface
+var _ binding.BinaryWriter = (*kafkaProducerMessageWriter)(nil)     // Test it conforms to the interface

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/lifecycle.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/lifecycle.go
@@ -1,0 +1,16 @@
+package protocol
+
+import (
+	"context"
+)
+
+// Opener is the common interface for things that need to be opened.
+type Opener interface {
+	// Blocking call. Context is used to cancel.
+	OpenInbound(ctx context.Context) error
+}
+
+// Closer is the common interface for things that can be closed.
+type Closer interface {
+	Close(ctx context.Context) error
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/outbound.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/outbound.go
@@ -1,0 +1,41 @@
+package protocol
+
+import (
+	"context"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+)
+
+// Sender sends messages.
+type Sender interface {
+	// Send a message.
+	//
+	// Send returns when the "outbound" message has been sent. The Sender may
+	// still be expecting acknowledgment or holding other state for the message.
+	//
+	// m.Finish() is called when sending is finished: expected acknowledgments (or
+	// errors) have been received, the Sender is no longer holding any state for
+	// the message. m.Finish() may be called during or after Send().
+	Send(ctx context.Context, m binding.Message) error
+}
+
+// SendCloser is a Sender that can be closed.
+type SendCloser interface {
+	Sender
+	Closer
+}
+
+// Requester sends a message and receives a response
+//
+// Optional interface that may be implemented by protocols that support
+// request/response correlation.
+type Requester interface {
+	// Request sends m like Sender.Send() but also arranges to receive a response.
+	Request(ctx context.Context, m binding.Message) (binding.Message, error)
+}
+
+// RequesterCloser is a Requester that can be closed.
+type RequesterCloser interface {
+	Requester
+	Closer
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/protocol/result.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/protocol/result.go
@@ -1,0 +1,39 @@
+package protocol
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Result leverages go's 1.13 error wrapping.
+type Result error
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+// (text from errors/wrap.go)
+var ResultIs = errors.Is
+
+// As finds the first error in err's chain that matches target, and if so, sets
+// target to that error value and returns true.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// As will panic if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type. As returns false if err is nil.
+// (text from errors/wrap.go)
+var ResultAs = errors.As
+
+func NewResult(messageFmt string, args ...interface{}) Result {
+	return fmt.Errorf(messageFmt, args...) // TODO: look at adding Ack/Nak support.
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/types/allocate.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/types/allocate.go
@@ -1,0 +1,36 @@
+package types
+
+import "reflect"
+
+// Allocate allocates a new instance of type t and returns:
+// asPtr is of type t if t is a pointer type and of type &t otherwise
+// asValue is a Value of type t pointing to the same data as asPtr
+func Allocate(obj interface{}) (asPtr interface{}, asValue reflect.Value) {
+	if obj == nil {
+		return nil, reflect.Value{}
+	}
+
+	switch t := reflect.TypeOf(obj); t.Kind() {
+	case reflect.Ptr:
+		reflectPtr := reflect.New(t.Elem())
+		asPtr = reflectPtr.Interface()
+		asValue = reflectPtr
+	case reflect.Map:
+		reflectPtr := reflect.MakeMap(t)
+		asPtr = reflectPtr.Interface()
+		asValue = reflectPtr
+	case reflect.String:
+		reflectPtr := reflect.New(t)
+		asPtr = ""
+		asValue = reflectPtr.Elem()
+	case reflect.Slice:
+		reflectPtr := reflect.MakeSlice(t, 0, 0)
+		asPtr = reflectPtr.Interface()
+		asValue = reflectPtr
+	default:
+		reflectPtr := reflect.New(t)
+		asPtr = reflectPtr.Interface()
+		asValue = reflectPtr.Elem()
+	}
+	return
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/types/doc.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/types/doc.go
@@ -1,0 +1,41 @@
+/*
+Package types implements the CloudEvents type system.
+
+CloudEvents defines a set of abstract types for event context attributes. Each
+type has a corresponding native Go type and a canonical string encoding.  The
+native Go types used to represent the CloudEvents types are:
+bool, int32, string, []byte, *url.URL, time.Time
+
+ +----------------+----------------+-----------------------------------+
+ |CloudEvents Type|Native Type     |Convertible From                   |
+ +================+================+===================================+
+ |Bool            |bool            |bool                               |
+ +----------------+----------------+-----------------------------------+
+ |Integer         |int32           |Any numeric type with value in     |
+ |                |                |range of int32                     |
+ +----------------+----------------+-----------------------------------+
+ |String          |string          |string                             |
+ +----------------+----------------+-----------------------------------+
+ |Binary          |[]byte          |[]byte                             |
+ +----------------+----------------+-----------------------------------+
+ |URI-Reference   |*url.URL        |url.URL, types.URIRef, types.URI   |
+ +----------------+----------------+-----------------------------------+
+ |URI             |*url.URL        |url.URL, types.URIRef, types.URI   |
+ |                |                |Must be an absolute URI.           |
+ +----------------+----------------+-----------------------------------+
+ |Timestamp       |time.Time       |time.Time, types.Timestamp         |
+ +----------------+----------------+-----------------------------------+
+
+Extension attributes may be stored as a native type or a canonical string.  The
+To<Type> functions will convert to the desired <Type> from any convertible type
+or from the canonical string form.
+
+The Parse<Type> and Format<Type> functions convert native types to/from
+canonical strings.
+
+Note are no Parse or Format functions for URL or string. For URL use the
+standard url.Parse() and url.URL.String(). The canonical string format of a
+string is the string itself.
+
+*/
+package types

--- a/vendor/github.com/cloudevents/sdk-go/pkg/types/timestamp.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/types/timestamp.go
@@ -1,0 +1,70 @@
+package types
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"time"
+)
+
+// Timestamp wraps time.Time to normalize the time layout to RFC3339. It is
+// intended to enforce compliance with the CloudEvents spec for their
+// definition of Timestamp. Custom marshal methods are implemented to ensure
+// the outbound Timestamp is a string in the RFC3339 layout.
+type Timestamp struct {
+	time.Time
+}
+
+// ParseTimestamp attempts to parse the given time assuming RFC3339 layout
+func ParseTimestamp(s string) (*Timestamp, error) {
+	if s == "" {
+		return nil, nil
+	}
+	tt, err := ParseTime(s)
+	return &Timestamp{Time: tt}, err
+}
+
+// MarshalJSON implements a custom json marshal method used when this type is
+// marshaled using json.Marshal.
+func (t *Timestamp) MarshalJSON() ([]byte, error) {
+	if t == nil || t.IsZero() {
+		return []byte(`""`), nil
+	}
+	return []byte(fmt.Sprintf("%q", t)), nil
+}
+
+// UnmarshalJSON implements the json unmarshal method used when this type is
+// unmarshaled using json.Unmarshal.
+func (t *Timestamp) UnmarshalJSON(b []byte) error {
+	var timestamp string
+	if err := json.Unmarshal(b, &timestamp); err != nil {
+		return err
+	}
+	var err error
+	t.Time, err = ParseTime(timestamp)
+	return err
+}
+
+// MarshalXML implements a custom xml marshal method used when this type is
+// marshaled using xml.Marshal.
+func (t *Timestamp) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if t == nil || t.IsZero() {
+		return e.EncodeElement(nil, start)
+	}
+	return e.EncodeElement(t.String(), start)
+}
+
+// UnmarshalXML implements the xml unmarshal method used when this type is
+// unmarshaled using xml.Unmarshal.
+func (t *Timestamp) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var timestamp string
+	if err := d.DecodeElement(&timestamp, &start); err != nil {
+		return err
+	}
+	var err error
+	t.Time, err = ParseTime(timestamp)
+	return err
+}
+
+// String outputs the time using RFC3339 format.
+func (t Timestamp) String() string { return FormatTime(t.Time) }

--- a/vendor/github.com/cloudevents/sdk-go/pkg/types/uri.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/types/uri.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/url"
+)
+
+// URI is a wrapper to url.URL. It is intended to enforce compliance with
+// the CloudEvents spec for their definition of URI. Custom
+// marshal methods are implemented to ensure the outbound URI object
+// is a flat string.
+type URI struct {
+	url.URL
+}
+
+// ParseURI attempts to parse the given string as a URI.
+func ParseURI(u string) *URI {
+	if u == "" {
+		return nil
+	}
+	pu, err := url.Parse(u)
+	if err != nil {
+		return nil
+	}
+	return &URI{URL: *pu}
+}
+
+// MarshalJSON implements a custom json marshal method used when this type is
+// marshaled using json.Marshal.
+func (u URI) MarshalJSON() ([]byte, error) {
+	b := fmt.Sprintf("%q", u.String())
+	return []byte(b), nil
+}
+
+// UnmarshalJSON implements the json unmarshal method used when this type is
+// unmarshaled using json.Unmarshal.
+func (u *URI) UnmarshalJSON(b []byte) error {
+	var ref string
+	if err := json.Unmarshal(b, &ref); err != nil {
+		return err
+	}
+	r := ParseURI(ref)
+	if r != nil {
+		*u = *r
+	}
+	return nil
+}
+
+// MarshalXML implements a custom xml marshal method used when this type is
+// marshaled using xml.Marshal.
+func (u URI) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(u.String(), start)
+}
+
+// UnmarshalXML implements the xml unmarshal method used when this type is
+// unmarshaled using xml.Unmarshal.
+func (u *URI) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var ref string
+	if err := d.DecodeElement(&ref, &start); err != nil {
+		return err
+	}
+	r := ParseURI(ref)
+	if r != nil {
+		*u = *r
+	}
+	return nil
+}
+
+// String returns the full string representation of the URI-Reference.
+func (u *URI) String() string {
+	if u == nil {
+		return ""
+	}
+	return u.URL.String()
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/types/uriref.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/types/uriref.go
@@ -1,0 +1,77 @@
+package types
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"net/url"
+)
+
+// URIRef is a wrapper to url.URL. It is intended to enforce compliance with
+// the CloudEvents spec for their definition of URI-Reference. Custom
+// marshal methods are implemented to ensure the outbound URIRef object is
+// is a flat string.
+type URIRef struct {
+	url.URL
+}
+
+// ParseURIRef attempts to parse the given string as a URI-Reference.
+func ParseURIRef(u string) *URIRef {
+	if u == "" {
+		return nil
+	}
+	pu, err := url.Parse(u)
+	if err != nil {
+		return nil
+	}
+	return &URIRef{URL: *pu}
+}
+
+// MarshalJSON implements a custom json marshal method used when this type is
+// marshaled using json.Marshal.
+func (u URIRef) MarshalJSON() ([]byte, error) {
+	b := fmt.Sprintf("%q", u.String())
+	return []byte(b), nil
+}
+
+// UnmarshalJSON implements the json unmarshal method used when this type is
+// unmarshaled using json.Unmarshal.
+func (u *URIRef) UnmarshalJSON(b []byte) error {
+	var ref string
+	if err := json.Unmarshal(b, &ref); err != nil {
+		return err
+	}
+	r := ParseURIRef(ref)
+	if r != nil {
+		*u = *r
+	}
+	return nil
+}
+
+// MarshalXML implements a custom xml marshal method used when this type is
+// marshaled using xml.Marshal.
+func (u URIRef) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(u.String(), start)
+}
+
+// UnmarshalXML implements the xml unmarshal method used when this type is
+// unmarshaled using xml.Unmarshal.
+func (u *URIRef) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	var ref string
+	if err := d.DecodeElement(&ref, &start); err != nil {
+		return err
+	}
+	r := ParseURIRef(ref)
+	if r != nil {
+		*u = *r
+	}
+	return nil
+}
+
+// String returns the full string representation of the URI-Reference.
+func (u *URIRef) String() string {
+	if u == nil {
+		return ""
+	}
+	return u.URL.String()
+}

--- a/vendor/github.com/cloudevents/sdk-go/pkg/types/value.go
+++ b/vendor/github.com/cloudevents/sdk-go/pkg/types/value.go
@@ -1,0 +1,305 @@
+package types
+
+import (
+	"encoding/base64"
+	"fmt"
+	"math"
+	"net/url"
+	"reflect"
+	"strconv"
+	"time"
+)
+
+// FormatBool returns canonical string format: "true" or "false"
+func FormatBool(v bool) string { return strconv.FormatBool(v) }
+
+// FormatInteger returns canonical string format: decimal notation.
+func FormatInteger(v int32) string { return strconv.Itoa(int(v)) }
+
+// FormatBinary returns canonical string format: standard base64 encoding
+func FormatBinary(v []byte) string { return base64.StdEncoding.EncodeToString(v) }
+
+// FormatTime returns canonical string format: RFC3339 with nanoseconds
+func FormatTime(v time.Time) string { return v.UTC().Format(time.RFC3339Nano) }
+
+// ParseBool parse canonical string format: "true" or "false"
+func ParseBool(v string) (bool, error) { return strconv.ParseBool(v) }
+
+// ParseInteger parse canonical string format: decimal notation.
+func ParseInteger(v string) (int32, error) {
+	// Accept floating-point but truncate to int32 as per CE spec.
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return 0, err
+	}
+	if f > math.MaxInt32 || f < math.MinInt32 {
+		return 0, rangeErr(v)
+	}
+	return int32(f), nil
+}
+
+// ParseBinary parse canonical string format: standard base64 encoding
+func ParseBinary(v string) ([]byte, error) { return base64.StdEncoding.DecodeString(v) }
+
+// ParseTime parse canonical string format: RFC3339 with nanoseconds
+func ParseTime(v string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339Nano, v)
+	if err != nil {
+		err := convertErr(time.Time{}, v)
+		err.extra = ": not in RFC3339 format"
+		return time.Time{}, err
+	}
+	return t, nil
+}
+
+// Format returns the canonical string format of v, where v can be
+// any type that is convertible to a CloudEvents type.
+func Format(v interface{}) (string, error) {
+	v, err := Validate(v)
+	if err != nil {
+		return "", err
+	}
+	switch v := v.(type) {
+	case bool:
+		return FormatBool(v), nil
+	case int32:
+		return FormatInteger(v), nil
+	case string:
+		return v, nil
+	case []byte:
+		return FormatBinary(v), nil
+	case URI:
+		return v.String(), nil
+	case URIRef:
+		// url.URL is often passed by pointer so allow both
+		return v.String(), nil
+	case Timestamp:
+		return FormatTime(v.Time), nil
+	default:
+		return "", fmt.Errorf("%T is not a CloudEvents type", v)
+	}
+}
+
+// Validate v is a valid CloudEvents attribute value, convert it to one of:
+//     bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+func Validate(v interface{}) (interface{}, error) {
+	switch v := v.(type) {
+	case bool, int32, string, []byte:
+		return v, nil // Already a CloudEvents type, no validation needed.
+
+	case uint, uintptr, uint8, uint16, uint32, uint64:
+		u := reflect.ValueOf(v).Uint()
+		if u > math.MaxInt32 {
+			return nil, rangeErr(v)
+		}
+		return int32(u), nil
+	case int, int8, int16, int64:
+		i := reflect.ValueOf(v).Int()
+		if i > math.MaxInt32 || i < math.MinInt32 {
+			return nil, rangeErr(v)
+		}
+		return int32(i), nil
+	case float32, float64:
+		f := reflect.ValueOf(v).Float()
+		if f > math.MaxInt32 || f < math.MinInt32 {
+			return nil, rangeErr(v)
+		}
+		return int32(f), nil
+
+	case *url.URL:
+		if v == nil {
+			break
+		}
+		return URI{*v}, nil
+	case url.URL:
+		return URI{v}, nil
+	case URIRef:
+		return v, nil
+	case URI:
+		return v, nil
+	case time.Time:
+		return Timestamp{v}, nil
+	case *time.Time:
+		if v == nil {
+			break
+		}
+		return Timestamp{*v}, nil
+	case Timestamp:
+		return v, nil
+	}
+	rx := reflect.ValueOf(v)
+	if rx.Kind() == reflect.Ptr && !rx.IsNil() {
+		// Allow pointers-to convertible types
+		return Validate(rx.Elem().Interface())
+	}
+	return nil, fmt.Errorf("invalid CloudEvents value: %#v", v)
+}
+
+// Clone v clones a CloudEvents attribute value, which is one of the valid types:
+//     bool, int32, string, []byte, types.URI, types.URIRef, types.Timestamp
+// Returns the same type
+// Panics if the type is not valid
+func Clone(v interface{}) interface{} {
+	if v == nil {
+		return nil
+	}
+	switch v := v.(type) {
+	case bool, int32, string, nil:
+		return v // Already a CloudEvents type, no validation needed.
+	case []byte:
+		clone := make([]byte, len(v))
+		copy(clone, v)
+		return v
+	case url.URL:
+		return URI{v}
+	case *url.URL:
+		return &URI{*v}
+	case URIRef:
+		return v
+	case *URIRef:
+		return &URIRef{v.URL}
+	case URI:
+		return v
+	case *URI:
+		return &URI{v.URL}
+	case time.Time:
+		return Timestamp{v}
+	case *time.Time:
+		return &Timestamp{*v}
+	case Timestamp:
+		return v
+	case *Timestamp:
+		return &Timestamp{v.Time}
+	}
+	panic(fmt.Errorf("invalid CloudEvents value: %#v", v))
+}
+
+// ToBool accepts a bool value or canonical "true"/"false" string.
+func ToBool(v interface{}) (bool, error) {
+	v, err := Validate(v)
+	if err != nil {
+		return false, err
+	}
+	switch v := v.(type) {
+	case bool:
+		return v, nil
+	case string:
+		return ParseBool(v)
+	default:
+		return false, convertErr(true, v)
+	}
+}
+
+// ToInteger accepts any numeric value in int32 range, or canonical string.
+func ToInteger(v interface{}) (int32, error) {
+	v, err := Validate(v)
+	if err != nil {
+		return 0, err
+	}
+	switch v := v.(type) {
+	case int32:
+		return v, nil
+	case string:
+		return ParseInteger(v)
+	default:
+		return 0, convertErr(int32(0), v)
+	}
+}
+
+// ToString returns a string value unaltered.
+//
+// This function does not perform canonical string encoding, use one of the
+// Format functions for that.
+func ToString(v interface{}) (string, error) {
+	v, err := Validate(v)
+	if err != nil {
+		return "", err
+	}
+	switch v := v.(type) {
+	case string:
+		return v, nil
+	default:
+		return "", convertErr("", v)
+	}
+}
+
+// ToBinary returns a []byte value, decoding from base64 string if necessary.
+func ToBinary(v interface{}) ([]byte, error) {
+	v, err := Validate(v)
+	if err != nil {
+		return nil, err
+	}
+	switch v := v.(type) {
+	case []byte:
+		return v, nil
+	case string:
+		return base64.StdEncoding.DecodeString(v)
+	default:
+		return nil, convertErr([]byte(nil), v)
+	}
+}
+
+// ToURL returns a *url.URL value, parsing from string if necessary.
+func ToURL(v interface{}) (*url.URL, error) {
+	v, err := Validate(v)
+	if err != nil {
+		return nil, err
+	}
+	switch v := v.(type) {
+	case URI:
+		return &v.URL, nil
+	case URIRef:
+		return &v.URL, nil
+	case string:
+		u, err := url.Parse(v)
+		if err != nil {
+			return nil, err
+		}
+		return u, nil
+	default:
+		return nil, convertErr((*url.URL)(nil), v)
+	}
+}
+
+// ToTime returns a time.Time value, parsing from RFC3339 string if necessary.
+func ToTime(v interface{}) (time.Time, error) {
+	v, err := Validate(v)
+	if err != nil {
+		return time.Time{}, err
+	}
+	switch v := v.(type) {
+	case Timestamp:
+		return v.Time, nil
+	case string:
+		ts, err := time.Parse(time.RFC3339Nano, v)
+		if err != nil {
+			return time.Time{}, err
+		}
+		return ts, nil
+	default:
+		return time.Time{}, convertErr(time.Time{}, v)
+	}
+}
+
+type ConvertErr struct {
+	// Value being converted
+	Value interface{}
+	// Type of attempted conversion
+	Type reflect.Type
+
+	extra string
+}
+
+func (e *ConvertErr) Error() string {
+	return fmt.Sprintf("cannot convert %#v to %s%s", e.Value, e.Type, e.extra)
+}
+
+func convertErr(target, v interface{}) *ConvertErr {
+	return &ConvertErr{Value: v, Type: reflect.TypeOf(target)}
+}
+
+func rangeErr(v interface{}) error {
+	e := convertErr(int32(0), v)
+	e.extra = ": out of range"
+	return e
+}

--- a/vendor/github.com/valyala/bytebufferpool/LICENSE
+++ b/vendor/github.com/valyala/bytebufferpool/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Aliaksandr Valialkin, VertaMedia
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/vendor/github.com/valyala/bytebufferpool/bytebuffer.go
+++ b/vendor/github.com/valyala/bytebufferpool/bytebuffer.go
@@ -1,0 +1,111 @@
+package bytebufferpool
+
+import "io"
+
+// ByteBuffer provides byte buffer, which can be used for minimizing
+// memory allocations.
+//
+// ByteBuffer may be used with functions appending data to the given []byte
+// slice. See example code for details.
+//
+// Use Get for obtaining an empty byte buffer.
+type ByteBuffer struct {
+
+	// B is a byte buffer to use in append-like workloads.
+	// See example code for details.
+	B []byte
+}
+
+// Len returns the size of the byte buffer.
+func (b *ByteBuffer) Len() int {
+	return len(b.B)
+}
+
+// ReadFrom implements io.ReaderFrom.
+//
+// The function appends all the data read from r to b.
+func (b *ByteBuffer) ReadFrom(r io.Reader) (int64, error) {
+	p := b.B
+	nStart := int64(len(p))
+	nMax := int64(cap(p))
+	n := nStart
+	if nMax == 0 {
+		nMax = 64
+		p = make([]byte, nMax)
+	} else {
+		p = p[:nMax]
+	}
+	for {
+		if n == nMax {
+			nMax *= 2
+			bNew := make([]byte, nMax)
+			copy(bNew, p)
+			p = bNew
+		}
+		nn, err := r.Read(p[n:])
+		n += int64(nn)
+		if err != nil {
+			b.B = p[:n]
+			n -= nStart
+			if err == io.EOF {
+				return n, nil
+			}
+			return n, err
+		}
+	}
+}
+
+// WriteTo implements io.WriterTo.
+func (b *ByteBuffer) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(b.B)
+	return int64(n), err
+}
+
+// Bytes returns b.B, i.e. all the bytes accumulated in the buffer.
+//
+// The purpose of this function is bytes.Buffer compatibility.
+func (b *ByteBuffer) Bytes() []byte {
+	return b.B
+}
+
+// Write implements io.Writer - it appends p to ByteBuffer.B
+func (b *ByteBuffer) Write(p []byte) (int, error) {
+	b.B = append(b.B, p...)
+	return len(p), nil
+}
+
+// WriteByte appends the byte c to the buffer.
+//
+// The purpose of this function is bytes.Buffer compatibility.
+//
+// The function always returns nil.
+func (b *ByteBuffer) WriteByte(c byte) error {
+	b.B = append(b.B, c)
+	return nil
+}
+
+// WriteString appends s to ByteBuffer.B.
+func (b *ByteBuffer) WriteString(s string) (int, error) {
+	b.B = append(b.B, s...)
+	return len(s), nil
+}
+
+// Set sets ByteBuffer.B to p.
+func (b *ByteBuffer) Set(p []byte) {
+	b.B = append(b.B[:0], p...)
+}
+
+// SetString sets ByteBuffer.B to s.
+func (b *ByteBuffer) SetString(s string) {
+	b.B = append(b.B[:0], s...)
+}
+
+// String returns string representation of ByteBuffer.B.
+func (b *ByteBuffer) String() string {
+	return string(b.B)
+}
+
+// Reset makes ByteBuffer.B empty.
+func (b *ByteBuffer) Reset() {
+	b.B = b.B[:0]
+}

--- a/vendor/github.com/valyala/bytebufferpool/doc.go
+++ b/vendor/github.com/valyala/bytebufferpool/doc.go
@@ -1,0 +1,7 @@
+// Package bytebufferpool implements a pool of byte buffers
+// with anti-fragmentation protection.
+//
+// The pool may waste limited amount of memory due to fragmentation.
+// This amount equals to the maximum total size of the byte buffers
+// in concurrent use.
+package bytebufferpool

--- a/vendor/github.com/valyala/bytebufferpool/pool.go
+++ b/vendor/github.com/valyala/bytebufferpool/pool.go
@@ -1,0 +1,151 @@
+package bytebufferpool
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+)
+
+const (
+	minBitSize = 6 // 2**6=64 is a CPU cache line size
+	steps      = 20
+
+	minSize = 1 << minBitSize
+	maxSize = 1 << (minBitSize + steps - 1)
+
+	calibrateCallsThreshold = 42000
+	maxPercentile           = 0.95
+)
+
+// Pool represents byte buffer pool.
+//
+// Distinct pools may be used for distinct types of byte buffers.
+// Properly determined byte buffer types with their own pools may help reducing
+// memory waste.
+type Pool struct {
+	calls       [steps]uint64
+	calibrating uint64
+
+	defaultSize uint64
+	maxSize     uint64
+
+	pool sync.Pool
+}
+
+var defaultPool Pool
+
+// Get returns an empty byte buffer from the pool.
+//
+// Got byte buffer may be returned to the pool via Put call.
+// This reduces the number of memory allocations required for byte buffer
+// management.
+func Get() *ByteBuffer { return defaultPool.Get() }
+
+// Get returns new byte buffer with zero length.
+//
+// The byte buffer may be returned to the pool via Put after the use
+// in order to minimize GC overhead.
+func (p *Pool) Get() *ByteBuffer {
+	v := p.pool.Get()
+	if v != nil {
+		return v.(*ByteBuffer)
+	}
+	return &ByteBuffer{
+		B: make([]byte, 0, atomic.LoadUint64(&p.defaultSize)),
+	}
+}
+
+// Put returns byte buffer to the pool.
+//
+// ByteBuffer.B mustn't be touched after returning it to the pool.
+// Otherwise data races will occur.
+func Put(b *ByteBuffer) { defaultPool.Put(b) }
+
+// Put releases byte buffer obtained via Get to the pool.
+//
+// The buffer mustn't be accessed after returning to the pool.
+func (p *Pool) Put(b *ByteBuffer) {
+	idx := index(len(b.B))
+
+	if atomic.AddUint64(&p.calls[idx], 1) > calibrateCallsThreshold {
+		p.calibrate()
+	}
+
+	maxSize := int(atomic.LoadUint64(&p.maxSize))
+	if maxSize == 0 || cap(b.B) <= maxSize {
+		b.Reset()
+		p.pool.Put(b)
+	}
+}
+
+func (p *Pool) calibrate() {
+	if !atomic.CompareAndSwapUint64(&p.calibrating, 0, 1) {
+		return
+	}
+
+	a := make(callSizes, 0, steps)
+	var callsSum uint64
+	for i := uint64(0); i < steps; i++ {
+		calls := atomic.SwapUint64(&p.calls[i], 0)
+		callsSum += calls
+		a = append(a, callSize{
+			calls: calls,
+			size:  minSize << i,
+		})
+	}
+	sort.Sort(a)
+
+	defaultSize := a[0].size
+	maxSize := defaultSize
+
+	maxSum := uint64(float64(callsSum) * maxPercentile)
+	callsSum = 0
+	for i := 0; i < steps; i++ {
+		if callsSum > maxSum {
+			break
+		}
+		callsSum += a[i].calls
+		size := a[i].size
+		if size > maxSize {
+			maxSize = size
+		}
+	}
+
+	atomic.StoreUint64(&p.defaultSize, defaultSize)
+	atomic.StoreUint64(&p.maxSize, maxSize)
+
+	atomic.StoreUint64(&p.calibrating, 0)
+}
+
+type callSize struct {
+	calls uint64
+	size  uint64
+}
+
+type callSizes []callSize
+
+func (ci callSizes) Len() int {
+	return len(ci)
+}
+
+func (ci callSizes) Less(i, j int) bool {
+	return ci[i].calls > ci[j].calls
+}
+
+func (ci callSizes) Swap(i, j int) {
+	ci[i], ci[j] = ci[j], ci[i]
+}
+
+func index(n int) int {
+	n--
+	n >>= minBitSize
+	idx := 0
+	for n > 0 {
+		n >>= 1
+		idx++
+	}
+	if idx >= steps {
+		idx = steps - 1
+	}
+	return idx
+}

--- a/vendor/knative.dev/eventing/pkg/adapter/main.go
+++ b/vendor/knative.dev/eventing/pkg/adapter/main.go
@@ -24,8 +24,6 @@ import (
 	"net/http"
 	"time"
 
-	"knative.dev/pkg/profiling"
-
 	// Uncomment the following line to load the gcp plugin
 	// (only required to authenticate against GKE clusters).
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -35,6 +33,7 @@ import (
 	"go.uber.org/zap"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/metrics"
+	"knative.dev/pkg/profiling"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/source"
 
@@ -49,9 +48,11 @@ type Adapter interface {
 type AdapterConstructor func(ctx context.Context, env EnvConfigAccessor, client cloudevents.Client, reporter source.StatsReporter) Adapter
 
 func Main(component string, ector EnvConfigConstructor, ctor AdapterConstructor) {
-	flag.Parse()
+	MainWithContext(signals.NewContext(), component, ector, ctor)
+}
 
-	ctx := signals.NewContext()
+func MainWithContext(ctx context.Context, component string, ector EnvConfigConstructor, ctor AdapterConstructor) {
+	flag.Parse()
 
 	env := ector()
 	if err := envconfig.Process("", env); err != nil {

--- a/vendor/knative.dev/eventing/pkg/adapter/main_message_adapter.go
+++ b/vendor/knative.dev/eventing/pkg/adapter/main_message_adapter.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"knative.dev/pkg/profiling"
+	"knative.dev/pkg/signals"
+
+	"github.com/kelseyhightower/envconfig"
+	"go.opencensus.io/stats/view"
+	"go.uber.org/zap"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
+	"knative.dev/pkg/source"
+
+	"knative.dev/eventing/pkg/kncloudevents"
+	"knative.dev/eventing/pkg/tracing"
+)
+
+type MessageAdapter interface {
+	Start(stopCh <-chan struct{}) error
+}
+
+type MessageAdapterConstructor func(ctx context.Context, env EnvConfigAccessor, adapter *kncloudevents.HttpMessageSender, reporter source.StatsReporter) MessageAdapter
+
+func MainMessageAdapter(component string, ector EnvConfigConstructor, ctor MessageAdapterConstructor) {
+	MainMessageAdapterWithContext(signals.NewContext(), component, ector, ctor)
+}
+
+func MainMessageAdapterWithContext(ctx context.Context, component string, ector EnvConfigConstructor, ctor MessageAdapterConstructor) {
+	flag.Parse()
+
+	env := ector()
+	if err := envconfig.Process("", env); err != nil {
+		log.Fatalf("Error processing env var: %s", err)
+	}
+
+	// Convert json logging.Config to logging.Config.
+	loggingConfig, err := logging.JsonToLoggingConfig(env.GetLoggingConfigJson())
+	if err != nil {
+		fmt.Printf("[ERROR] failed to process logging config: %s", err.Error())
+		// Use default logging config.
+		if loggingConfig, err = logging.NewConfigFromMap(map[string]string{}); err != nil {
+			// If this fails, there is no recovering.
+			panic(err)
+		}
+	}
+
+	logger, _ := logging.NewLoggerFromConfig(loggingConfig, component)
+	defer flush(logger)
+	ctx = logging.WithLogger(ctx, logger)
+
+	// Report stats on Go memory usage every 30 seconds.
+	msp := metrics.NewMemStatsAll()
+	msp.Start(ctx, 30*time.Second)
+	if err := view.Register(msp.DefaultViews()...); err != nil {
+		logger.Fatal("Error exporting go memstats view: %v", zap.Error(err))
+	}
+
+	// Convert json metrics.ExporterOptions to metrics.ExporterOptions.
+	metricsConfig, err := metrics.JsonToMetricsOptions(env.GetMetricsConfigJson())
+	if err != nil {
+		logger.Error("failed to process metrics options", zap.Error(err))
+	} else {
+		if err := metrics.UpdateExporter(*metricsConfig, logger); err != nil {
+			logger.Error("failed to create the metrics exporter", zap.Error(err))
+		}
+	}
+
+	// Check if metrics config contains profiling flag
+	if metricsConfig != nil && metricsConfig.ConfigMap != nil {
+		if enabled, err := profiling.ReadProfilingFlag(metricsConfig.ConfigMap); err == nil {
+			if enabled {
+				// Start a goroutine to server profiling metrics
+				logger.Info("Profiling enabled")
+				go func() {
+					server := profiling.NewServer(profiling.NewHandler(logger, true))
+					// Don't forward ErrServerClosed as that indicates we're already shutting down.
+					if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+						logger.Error("profiling server failed", zap.Error(err))
+					}
+				}()
+			}
+		} else {
+			logger.Error("error while reading profiling flag", zap.Error(err))
+		}
+	}
+
+	reporter, err := source.NewStatsReporter()
+	if err != nil {
+		logger.Error("error building statsreporter", zap.Error(err))
+	}
+
+	if err = tracing.SetupStaticPublishing(logger, "", tracing.OnePercentSampling); err != nil {
+		// If tracing doesn't work, we will log an error, but allow the adapter
+		// to continue to start.
+		logger.Error("Error setting up trace publishing", zap.Error(err))
+	}
+
+	httpBindingsSender, err := kncloudevents.NewHttpMessageSender(nil, env.GetSinkURI())
+	if err != nil {
+		logger.Fatal("error building cloud event client", zap.Error(err))
+	}
+
+	// Configuring the adapter
+	adapter := ctor(ctx, env, httpBindingsSender, reporter)
+
+	logger.Info("Starting Receive MessageAdapter", zap.Any("adapter", adapter))
+
+	if err := adapter.Start(ctx.Done()); err != nil {
+		logger.Warn("start returned an error", zap.Error(err))
+	}
+}

--- a/vendor/knative.dev/eventing/pkg/channel/event_dispatcher.go
+++ b/vendor/knative.dev/eventing/pkg/channel/event_dispatcher.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Knative Authors
+ * Copyright 2020 The Knative Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vendor/knative.dev/eventing/pkg/channel/event_receiver.go
+++ b/vendor/knative.dev/eventing/pkg/channel/event_receiver.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The Knative Authors
+ * Copyright 2020 The Knative Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/vendor/knative.dev/eventing/pkg/channel/history_transformer.go
+++ b/vendor/knative.dev/eventing/pkg/channel/history_transformer.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package channel
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/transformer"
+	"github.com/cloudevents/sdk-go/pkg/types"
+)
+
+func AddHistory(host string) []binding.TransformerFactory {
+	return transformer.SetExtension(EventHistory, host, func(i interface{}) (interface{}, error) {
+		str, err := types.Format(i)
+		if err != nil {
+			return nil, err
+		}
+		h := decodeEventHistory(str)
+		h = append(h, host)
+		return encodeEventHistory(h), nil
+	})
+}

--- a/vendor/knative.dev/eventing/pkg/channel/message_dispatcher.go
+++ b/vendor/knative.dev/eventing/pkg/channel/message_dispatcher.go
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package channel
+
+import (
+	"context"
+	"fmt"
+	nethttp "net/http"
+	"net/url"
+
+	cloudevents "github.com/cloudevents/sdk-go"
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/protocol/http"
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"knative.dev/eventing/pkg/kncloudevents"
+	"knative.dev/eventing/pkg/utils"
+)
+
+type MessageDispatcher interface {
+	// DispatchMessage dispatches an event to a destination over HTTP.
+	//
+	// The destination and reply are URLs.
+	DispatchMessage(ctx context.Context, message cloudevents.Message, additionalHeaders nethttp.Header, destination, reply string) error
+
+	// DispatchMessageWithDelivery dispatches an event to a destination over HTTP with delivery options
+	//
+	// The destination and reply are URLs.
+	DispatchMessageWithDelivery(ctx context.Context, message cloudevents.Message, additionalHeaders nethttp.Header, destination, reply string, delivery *DeliveryOptions) error
+}
+
+// MessageDispatcherImpl is the 'real' MessageDispatcher used everywhere except unit tests.
+var _ MessageDispatcher = &MessageDispatcherImpl{}
+
+// MessageDispatcherImpl dispatches events to a destination over HTTP.
+type MessageDispatcherImpl struct {
+	sender           *kncloudevents.HttpMessageSender
+	supportedSchemes sets.String
+
+	logger *zap.Logger
+}
+
+// NewMessageDispatcher creates a new event dispatcher that can dispatch
+// events to HTTP destinations.
+func NewMessageDispatcher(logger *zap.Logger) *MessageDispatcherImpl {
+	return NewMessageDispatcherFromConfig(logger, defaultEventDispatcherConfig)
+}
+
+// NewMessageDispatcherFromConfig creates a new event dispatcher based on config.
+func NewMessageDispatcherFromConfig(logger *zap.Logger, config EventDispatcherConfig) *MessageDispatcherImpl {
+	sender, err := kncloudevents.NewHttpMessageSender(&config.ConnectionArgs, "")
+	if err != nil {
+		logger.Fatal("Unable to create cloudevents binding sender", zap.Error(err))
+		return nil
+	}
+	return &MessageDispatcherImpl{
+		sender:           sender,
+		supportedSchemes: sets.NewString("http", "https"),
+		logger:           logger,
+	}
+}
+
+// DispatchMessage dispatches an event to a destination over HTTP.
+//
+// The destination and reply are URLs.
+func (d *MessageDispatcherImpl) DispatchMessage(ctx context.Context, message cloudevents.Message, additionalHeaders nethttp.Header, destination, reply string) error {
+	return d.DispatchMessageWithDelivery(ctx, message, additionalHeaders, destination, reply, nil)
+}
+
+// DispatchMessageWithDelivery dispatches an event to a destination over HTTP with delivery options
+//
+// The destination and reply are URLs.
+func (d *MessageDispatcherImpl) DispatchMessageWithDelivery(ctx context.Context, message cloudevents.Message, initialAdditionalHeaders nethttp.Header, destination, reply string, delivery *DeliveryOptions) error {
+	var err error
+
+	// Default to replying with the original event. If there is a destination, then replace it
+	// with the response from the call to the destination instead.
+	response := message
+	additionalHeaders := initialAdditionalHeaders
+	if destination != "" {
+		defer message.Finish(nil)
+
+		destinationURL := d.resolveURL(destination)
+		response, additionalHeaders, err = d.executeRequest(ctx, destinationURL, message, initialAdditionalHeaders)
+		if err != nil {
+			if delivery != nil && delivery.DeadLetterSink != "" {
+				deadLetterURL := d.resolveURL(delivery.DeadLetterSink)
+
+				// TODO: decorate event with deadletter attributes
+				_, _, err2 := d.executeRequest(ctx, deadLetterURL, message, initialAdditionalHeaders)
+				if err2 != nil {
+					return fmt.Errorf("unable to complete request to either %s (%v) or %s (%v)", destinationURL, err, deadLetterURL, err2)
+				}
+
+				// Do not send event to reply
+				return nil
+			}
+			return fmt.Errorf("unable to complete request to %s: %v", destinationURL, err)
+		}
+	}
+
+	defer func() {
+		if response != nil {
+			_ = response.Finish(nil)
+		}
+	}()
+
+	if reply == "" && response != nil {
+		d.logger.Debug("cannot forward response as reply is empty", zap.Any("response", response))
+		return nil
+	}
+
+	if reply != "" && response != nil {
+		replyURL := d.resolveURL(reply)
+		_, _, err = d.executeRequest(ctx, replyURL, response, additionalHeaders)
+		if err != nil {
+			if delivery != nil && delivery.DeadLetterSink != "" {
+				deadLetterURL := d.resolveURL(delivery.DeadLetterSink)
+
+				// TODO: decorate event with deadletter attributes
+				_, _, err2 := d.executeRequest(ctx, deadLetterURL, message, additionalHeaders)
+				if err2 != nil {
+					return fmt.Errorf("failed to forward reply to %s (%v) and failed to send it to the dead letter sink %s (%v)", replyURL, err, deadLetterURL, err2)
+				}
+			} else {
+				return fmt.Errorf("failed to forward reply to %s: %v", replyURL, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (d *MessageDispatcherImpl) executeRequest(ctx context.Context, url *url.URL, message cloudevents.Message, additionalHeaders nethttp.Header) (cloudevents.Message, nethttp.Header, error) {
+	d.logger.Debug("Dispatching event", zap.String("url", url.String()))
+
+	req, err := d.sender.NewCloudEventRequestWithTarget(ctx, url.String())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = kncloudevents.WriteHttpRequestWithAdditionalHeaders(ctx, message, req, additionalHeaders, []binding.TransformerFactory{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	response, err := d.sender.Send(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	if isFailure(response.StatusCode) {
+		// Reject non-successful responses.
+		return nil, nil, fmt.Errorf("unexpected HTTP response, expected 2xx, got %d", response.StatusCode)
+	}
+	responseMessage := http.NewMessageFromHttpResponse(response)
+	if responseMessage.ReadEncoding() == binding.EncodingUnknown {
+		d.logger.Debug("Response is a non event, discarding it", zap.Int("status_code", response.StatusCode))
+		return nil, nil, nil
+	}
+	return responseMessage, utils.PassThroughHeaders(response.Header), nil
+}
+
+func (d *MessageDispatcherImpl) resolveURL(destination string) *url.URL {
+	if u, err := url.Parse(destination); err == nil && d.supportedSchemes.Has(u.Scheme) {
+		// Already a URL with a known scheme.
+		return u
+	}
+	return &url.URL{
+		Scheme: "http",
+		Host:   destination,
+		Path:   "/",
+	}
+}

--- a/vendor/knative.dev/eventing/pkg/kncloudevents/message_client.go
+++ b/vendor/knative.dev/eventing/pkg/kncloudevents/message_client.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kncloudevents
+
+import (
+	"context"
+	"fmt"
+	"net"
+	nethttp "net/http"
+	"time"
+
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+	"knative.dev/pkg/tracing"
+)
+
+const (
+	DefaultShutdownTimeout = time.Minute * 1
+)
+
+type HttpMessageSender struct {
+	Client *nethttp.Client
+	Target string
+}
+
+func NewHttpMessageSender(connectionArgs *ConnectionArgs, target string) (*HttpMessageSender, error) {
+	// Add connection options to the default transport.
+	var base = nethttp.DefaultTransport.(*nethttp.Transport).Clone()
+	connectionArgs.ConfigureTransport(base)
+	// Add output tracing.
+	client := &nethttp.Client{
+		Transport: &ochttp.Transport{
+			Base:        base,
+			Propagation: &b3.HTTPFormat{},
+		},
+	}
+
+	return &HttpMessageSender{Client: client, Target: target}, nil
+}
+
+func (s *HttpMessageSender) NewCloudEventRequest(ctx context.Context) (*nethttp.Request, error) {
+	return nethttp.NewRequestWithContext(ctx, "POST", s.Target, nil)
+}
+
+func (s *HttpMessageSender) NewCloudEventRequestWithTarget(ctx context.Context, target string) (*nethttp.Request, error) {
+	return nethttp.NewRequestWithContext(ctx, "POST", target, nil)
+}
+
+func (s *HttpMessageSender) Send(req *nethttp.Request) (*nethttp.Response, error) {
+	return s.Client.Do(req)
+}
+
+type HttpMessageReceiver struct {
+	port int
+
+	handler  *nethttp.ServeMux
+	server   *nethttp.Server
+	addr     net.Addr
+	listener net.Listener
+}
+
+func NewHttpMessageReceiver(port int) *HttpMessageReceiver {
+	return &HttpMessageReceiver{
+		port: port,
+	}
+}
+
+// Blocking
+func (recv *HttpMessageReceiver) StartListen(ctx context.Context, handler nethttp.Handler) error {
+	var err error
+	if recv.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", recv.port)); err != nil {
+		return err
+	}
+
+	recv.handler = nethttp.NewServeMux()
+
+	recv.server = &nethttp.Server{
+		Addr:    recv.listener.Addr().String(),
+		Handler: tracing.HTTPSpanMiddleware(handler),
+	}
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- recv.server.Serve(recv.listener)
+	}()
+
+	// wait for the server to return or ctx.Done().
+	select {
+	case <-ctx.Done():
+		ctx, cancel := context.WithTimeout(context.Background(), DefaultShutdownTimeout)
+		defer cancel()
+		err := recv.server.Shutdown(ctx)
+		<-errChan // Wait for server goroutine to exit
+		return err
+	case err := <-errChan:
+		return err
+	}
+}

--- a/vendor/knative.dev/eventing/pkg/kncloudevents/utils.go
+++ b/vendor/knative.dev/eventing/pkg/kncloudevents/utils.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 The Knative Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kncloudevents
+
+import (
+	"context"
+	nethttp "net/http"
+
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/protocol/http"
+)
+
+func WriteHttpRequestWithAdditionalHeaders(ctx context.Context, message binding.Message, req *nethttp.Request, additionalHeaders nethttp.Header, transformers binding.TransformerFactories) error {
+	err := http.WriteRequest(ctx, message, req, transformers)
+	if err != nil {
+		return err
+	}
+
+	if additionalHeaders != nil {
+		for k, v := range additionalHeaders {
+			req.Header[k] = v
+		}
+	}
+
+	return nil
+}

--- a/vendor/knative.dev/eventing/pkg/tracing/traceparent.go
+++ b/vendor/knative.dev/eventing/pkg/tracing/traceparent.go
@@ -57,10 +57,8 @@ func traceparentAttributeValue(span *trace.Span) string {
 	if span.SpanContext().IsSampled() {
 		flags = "01"
 	}
-	return fmt.Sprintf("00-%s-%s-%s",
-		span.SpanContext().TraceID.String(),
-		span.SpanContext().SpanID.String(),
-		flags)
+	return "00-" + span.SpanContext().TraceID.String() + "-" +
+		span.SpanContext().SpanID.String() + "-" + flags
 }
 
 // AddSpanFromTraceparentAttribute extracts the traceparent extension attribute from the CloudEvent

--- a/vendor/knative.dev/eventing/pkg/tracing/traceparent_transformer.go
+++ b/vendor/knative.dev/eventing/pkg/tracing/traceparent_transformer.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"github.com/cloudevents/sdk-go/pkg/binding"
+	"github.com/cloudevents/sdk-go/pkg/binding/transformer"
+	"go.opencensus.io/trace"
+)
+
+// AddTraceparent returns a CloudEvent that is identical to the input event,
+// with the traceparent CloudEvents extension attribute added.
+func AddTraceparent(span *trace.Span) []binding.TransformerFactory {
+	val := traceparentAttributeValue(span)
+	return transformer.SetExtension(traceparentAttribute, val, func(i2 interface{}) (i interface{}, err error) {
+		return val, nil
+	})
+}

--- a/vendor/knative.dev/pkg/Gopkg.lock
+++ b/vendor/knative.dev/pkg/Gopkg.lock
@@ -1350,14 +1350,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:e5bd21467544cbd14cb25553c5c78eb2e0e93baf9288a3c2ebaf1cf1fdb0c95f"
+  digest = "1:115d2f6e72ee06327259bdba21d26f28c359c62464afd73538fbab66ae2b7698"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "3f96c9e98f31595fe33eaa2d95f5e2170522acd7"
+  revision = "01c075fbeae4b089793fcca6fc855d31e1628cad"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"

--- a/vendor/knative.dev/serving/pkg/autoscaler/config/config.go
+++ b/vendor/knative.dev/serving/pkg/autoscaler/config/config.go
@@ -62,6 +62,11 @@ type Config struct {
 	// NB: most of our computations are in floats, so this is float to avoid casting.
 	TargetBurstCapacity float64
 
+	// ActivatorCapacity is the number of the concurrent requests an activator
+	// task can accept. This is used in activator subsetting algorithm, to determine
+	// the number of activators per revision.
+	ActivatorCapacity float64
+
 	// General autoscaler algorithm configuration.
 	MaxScaleUpRate           float64
 	MaxScaleDownRate         float64
@@ -140,6 +145,10 @@ func NewConfigFromMap(data map[string]string) (*Config, error) {
 		field:        &lc.PanicWindowPercentage,
 		defaultValue: 10.0,
 	}, {
+		key:          "activator-capacity",
+		field:        &lc.ActivatorCapacity,
+		defaultValue: 100.0,
+	}, {
 		key:          "panic-threshold-percentage",
 		field:        &lc.PanicThresholdPercentage,
 		defaultValue: 200.0,
@@ -214,6 +223,10 @@ func validate(lc *Config) (*Config, error) {
 
 	if lc.RPSTargetDefault < autoscaling.TargetMin {
 		return nil, fmt.Errorf("requests-per-second-target-default must be at least %v, got %v", autoscaling.TargetMin, lc.RPSTargetDefault)
+	}
+
+	if lc.ActivatorCapacity < 1 {
+		return nil, fmt.Errorf("activator-capacity = %v, must be at least 1", lc.ActivatorCapacity)
 	}
 
 	if lc.MaxScaleUpRate <= 1.0 {


### PR DESCRIPTION
Fixes https://github.com/knative/eventing-contrib/issues/975

<!-- Please include the 'why' behind your changes if no issue exists -->

## Performance improvements

Master:

```
BenchmarkHandle/Benchmark_Handle-8 	   51207	     46508 ns/op	   20200 B/op	     334 allocs/op
```

This PR:

```
BenchmarkHandle/Benchmark_Handle-8 	  225570	     10643 ns/op	    5675 B/op	     125 allocs/op
```

Around 3x less memory and 4.5x less CPU

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
Now KafkaSource implements the CloudEvents Kafka binding spec, so it can read both binary and structured events from kafka topics
```
