### PR TITLE
golang format tools

### DIFF
--- a/natss/pkg/dispatcher/types.go
+++ b/natss/pkg/dispatcher/types.go
@@ -18,6 +18,7 @@ package dispatcher
 
 import (
 	"fmt"
+
 	eventingchannels "knative.dev/eventing/pkg/channel"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
@@ -27,7 +28,7 @@ type subscriptionReference struct {
 	UID           string
 	SubscriberURI string
 	ReplyURI      string
-	Delivery eventingchannels.DeliveryOptions
+	Delivery      eventingchannels.DeliveryOptions
 }
 
 func newSubscriptionReference(spec eventingduck.SubscriberSpec) subscriptionReference {


### PR DESCRIPTION
<!--golang format tools-->
<!---->
Produced via:
  `gofmt -s -w $(find -path './vendor' -prune -o -path './third_party' -prune -o -type f -name '*.go' -print)`
  `goimports -w $(find -name '*.go' | grep -v vendor | grep -v third_party)`
/assign grantr n3wscott
/cc grantr n3wscott
