### PR TITLE
Add a webhook for KafkaSource that runs alongside the controller.

### DIFF
--- a/kafka/source/cmd/controller/main.go
+++ b/kafka/source/cmd/controller/main.go
@@ -17,14 +17,91 @@ limitations under the License.
 package main
 
 import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	sourcesv1alpha1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1"
 	kafka "knative.dev/eventing-contrib/kafka/source/pkg/reconciler"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/signals"
+	"knative.dev/pkg/webhook"
+	"knative.dev/pkg/webhook/certificates"
+	"knative.dev/pkg/webhook/resourcesemantics"
+	"knative.dev/pkg/webhook/resourcesemantics/defaulting"
+	"knative.dev/pkg/webhook/resourcesemantics/validation"
 )
 
 const (
 	component = "kafka-controller"
 )
 
+var types = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
+	// List the types to validate.
+	sourcesv1alpha1.SchemeGroupVersion.WithKind("KafkaSource"): &sourcesv1alpha1.KafkaSource{},
+}
+
+func NewDefaultingAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return defaulting.NewAdmissionController(ctx,
+
+		// Name of the resource webhook.
+		"defaulting.webhook.kafka.sources.knative.dev",
+
+		// The path on which to serve the webhook.
+		"/defaulting",
+
+		// The resources to validate and default.
+		types,
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		func(ctx context.Context) context.Context {
+			// Here is where you would infuse the context with state
+			// (e.g. attach a store with configmap data)
+			return ctx
+		},
+
+		// Whether to disallow unknown fields.
+		true,
+	)
+}
+
+func NewValidationAdmissionController(ctx context.Context, cmw configmap.Watcher) *controller.Impl {
+	return validation.NewAdmissionController(ctx,
+
+		// Name of the resource webhook.
+		"validation.webhook.kafka.sources.knative.dev",
+
+		// The path on which to serve the webhook.
+		"/resource-validation",
+
+		// The resources to validate and default.
+		types,
+
+		// A function that infuses the context passed to Validate/SetDefaults with custom metadata.
+		func(ctx context.Context) context.Context {
+			// Here is where you would infuse the context with state
+			// (e.g. attach a store with configmap data)
+			return ctx
+		},
+
+		// Whether to disallow unknown fields.
+		true,
+	)
+}
+
 func main() {
-	sharedmain.Main(component, kafka.NewController)
+	ctx := webhook.WithOptions(signals.NewContext(), webhook.Options{
+		ServiceName: "kafka-source-webhook",
+		Port:        8443,
+		SecretName:  "kafka-source-webhook-certs",
+	})
+
+	sharedmain.WebhookMainWithContext(ctx, component,
+		certificates.NewController,
+		NewDefaultingAdmissionController,
+		NewValidationAdmissionController,
+
+		kafka.NewController,
+	)
 }

--- a/kafka/source/config/201-clusterrole.yaml
+++ b/kafka/source/config/201-clusterrole.yaml
@@ -67,6 +67,21 @@ rules:
   - leases
   verbs: *everything
 
+# For actually registering our webhook.
+- apiGroups:
+    - "admissionregistration.k8s.io"
+  resources:
+    - "mutatingwebhookconfigurations"
+    - "validatingwebhookconfigurations"
+  verbs: &everything
+    - "get"
+    - "list"
+    - "create"
+    - "update"
+    - "delete"
+    - "patch"
+    - "watch"
+
 ---
 # The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
 # See https://github.com/knative/eventing/blob/master/config/200-source-observer-clusterrole.yaml.

--- a/kafka/source/config/500-controller.yaml
+++ b/kafka/source/config/500-controller.yaml
@@ -53,3 +53,19 @@ spec:
             memory: 20Mi
       serviceAccount: kafka-controller-manager
       terminationGracePeriodSeconds: 10
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    role: webhook
+    contrib.eventing.knative.dev/release: devel
+  name: kafka-source-webhook
+  namespace: knative-sources
+spec:
+  ports:
+    - port: 443
+      targetPort: 8443
+  selector:
+    control-plane: kafka-controller-manager

--- a/kafka/source/config/500-webhook-configuration.yaml
+++ b/kafka/source/config/500-webhook-configuration.yaml
@@ -1,0 +1,74 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: defaulting.webhook.kafka.sources.knative.dev
+  labels:
+    samples.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: kafka-source-webhook
+      namespace: knative-sources
+  failurePolicy: Fail
+  name: defaulting.webhook.kafka.sources.knative.dev
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.webhook.kafka.sources.knative.dev
+  labels:
+    samples.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: kafka-source-webhook
+      namespace: knative-sources
+  failurePolicy: Fail
+  name: validation.webhook.kafka.sources.knative.dev
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: config.webhook.kafka.sources.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+webhooks:
+- admissionReviewVersions:
+  - v1beta1
+  clientConfig:
+    service:
+      name: kafka-source-webhook
+      namespace: knative-sources
+  failurePolicy: Fail
+  name: config.webhook.kafka.sources.knative.dev
+  namespaceSelector:
+    matchExpressions:
+    - key: samples.knative.dev/release
+      operator: Exists
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kafka-source-webhook-certs
+  namespace: knative-sources
+  labels:
+    samples.knative.dev/release: devel
+# The data is populated at install time.

--- a/kafka/source/config/500-webhook-configuration.yaml
+++ b/kafka/source/config/500-webhook-configuration.yaml
@@ -17,7 +17,7 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.kafka.sources.knative.dev
   labels:
-    samples.knative.dev/release: devel
+    contrib.eventing.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -33,7 +33,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.kafka.sources.knative.dev
   labels:
-    samples.knative.dev/release: devel
+    contrib.eventing.knative.dev/release: devel
 webhooks:
 - admissionReviewVersions:
   - v1beta1
@@ -61,7 +61,7 @@ webhooks:
   name: config.webhook.kafka.sources.knative.dev
   namespaceSelector:
     matchExpressions:
-    - key: samples.knative.dev/release
+    - key: contrib.eventing.knative.dev/release
       operator: Exists
 ---
 apiVersion: v1
@@ -70,5 +70,5 @@ metadata:
   name: kafka-source-webhook-certs
   namespace: knative-sources
   labels:
-    samples.knative.dev/release: devel
+    contrib.eventing.knative.dev/release: devel
 # The data is populated at install time.


### PR DESCRIPTION
- 🐛 Fix bug

Previously KafkaSource implemented `apis.Defaultable` and `apis.Validatable`, but didn't run a webhook component.  This turns the controller itself into the webhook, which we can tease apart if needed later.  I am going to looks for other instances of this across contrib and try to get them fixed in a similar manner.