### PR TITLE
Gitlabsource example URL fixed

### DIFF
--- a/gitlab/config/300-gitlabsource.yaml
+++ b/gitlab/config/300-gitlabsource.yaml
@@ -113,7 +113,7 @@ spec:
               type: array
             projectUrl:
               description: 'ProjectUrl is the url of the GitLab project for which
-                we are interested to receive events from. Examples:   https://knative.dev/eventing-contrib/gitlab'
+                we are interested to receive events from. Examples:   https://gitlab.com/gitlab-org/gitlab-foss'
               minLength: 1
               type: string
             secretToken:

--- a/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types.go
+++ b/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types.go
@@ -46,7 +46,7 @@ type GitLabSourceSpec struct {
 	// ProjectUrl is the url of the GitLab project for which we are interested
 	// to receive events from.
 	// Examples:
-	//   https://knative.dev/eventing-contrib/gitlab
+	//   https://gitlab.com/gitlab-org/gitlab-foss
 	// +kubebuilder:validation:MinLength=1
 	ProjectUrl string `json:"projectUrl"`
 


### PR DESCRIPTION
Gitlabsource example URL set to real project to generate valid knative/docs eventing-contrib API references. Otherwise docs tests are failing:
https://storage.googleapis.com/knative-prow/pr-logs/pull/knative_docs/2353/pull-knative-docs-markdown-link-check/1251124790782070784/build-log.txt  