### PR TITLE
Fix parallelism of Kafka's consumer groups

### DIFF
--- a/kafka/common/pkg/kafka/consumer_factory_test.go
+++ b/kafka/common/pkg/kafka/consumer_factory_test.go
@@ -89,10 +89,11 @@ func mockedNewConsumerGroupFromClient(mockInputMessageCh chan *sarama.ConsumerMe
 
 func TestErrorPropagationCustomConsumerGroup(t *testing.T) {
 
+	newConsumerGroup = mockedNewConsumerGroupFromClient(nil, true, true, false, false)
+
 	factory := kafkaConsumerGroupFactoryImpl{
-		config:               sarama.NewConfig(),
-		addrs:                []string{"b1", "b2"},
-		newConsumerGroupFunc: mockedNewConsumerGroupFromClient(nil, true, true, false, false),
+		config: sarama.NewConfig(),
+		addrs:  []string{"b1", "b2"},
 	}
 
 	consumerGroup, err := factory.StartConsumerGroup("bla", []string{}, zap.NewNop(), nil)
@@ -124,10 +125,12 @@ func assertContainsError(t *testing.T, collection []error, errorStr string) {
 }
 
 func TestErrorWhileCreatingNewConsumerGroup(t *testing.T) {
+
+	newConsumerGroup = mockedNewConsumerGroupFromClient(nil, true, true, false, true)
+
 	factory := kafkaConsumerGroupFactoryImpl{
-		config:               sarama.NewConfig(),
-		addrs:                []string{"b1", "b2"},
-		newConsumerGroupFunc: mockedNewConsumerGroupFromClient(nil, true, true, false, true),
+		config: sarama.NewConfig(),
+		addrs:  []string{"b1", "b2"},
 	}
 	_, err := factory.StartConsumerGroup("bla", []string{}, zap.L(), nil)
 
@@ -137,10 +140,12 @@ func TestErrorWhileCreatingNewConsumerGroup(t *testing.T) {
 }
 
 func TestErrorWhileNewConsumerGroup(t *testing.T) {
+
+	newConsumerGroup = mockedNewConsumerGroupFromClient(nil, false, false, true, false)
+
 	factory := kafkaConsumerGroupFactoryImpl{
-		config:               sarama.NewConfig(),
-		addrs:                []string{"b1", "b2"},
-		newConsumerGroupFunc: mockedNewConsumerGroupFromClient(nil, false, false, true, false),
+		config: sarama.NewConfig(),
+		addrs:  []string{"b1", "b2"},
 	}
 	cg, _ := factory.StartConsumerGroup("bla", []string{}, zap.L(), nil)
 
@@ -150,75 +155,3 @@ func TestErrorWhileNewConsumerGroup(t *testing.T) {
 		t.Errorf("Should contain an error with message boom!. Got %v", err)
 	}
 }
-
-type saramaClientMock struct{}
-
-func (s saramaClientMock) Config() *sarama.Config {
-	return sarama.NewConfig()
-}
-
-func (s saramaClientMock) Controller() (*sarama.Broker, error) {
-	return sarama.NewBroker(""), nil
-}
-
-func (s saramaClientMock) Brokers() []*sarama.Broker {
-	return []*sarama.Broker{sarama.NewBroker("")}
-}
-
-func (s saramaClientMock) Topics() ([]string, error) {
-	panic("implement me")
-}
-
-func (s saramaClientMock) Partitions(_ string) ([]int32, error) {
-	panic("implement me")
-}
-
-func (s saramaClientMock) WritablePartitions(_ string) ([]int32, error) {
-	panic("implement me")
-}
-
-func (s saramaClientMock) Leader(_ string, _ int32) (*sarama.Broker, error) {
-	panic("implement me")
-}
-
-func (s saramaClientMock) Replicas(_ string, _ int32) ([]int32, error) {
-	panic("implement me")
-}
-
-func (s saramaClientMock) InSyncReplicas(_ string, _ int32) ([]int32, error) {
-	panic("implement me")
-}
-
-func (s saramaClientMock) OfflineReplicas(_ string, _ int32) ([]int32, error) {
-	panic("implement me")
-}
-
-func (s saramaClientMock) RefreshMetadata(_ ...string) error {
-	panic("implement me")
-}
-
-func (s saramaClientMock) GetOffset(_ string, _ int32, _ int64) (int64, error) {
-	panic("implement me")
-}
-
-func (s saramaClientMock) Coordinator(_ string) (*sarama.Broker, error) {
-	panic("implement me")
-}
-
-func (s saramaClientMock) RefreshCoordinator(_ string) error {
-	panic("implement me")
-}
-
-func (s saramaClientMock) InitProducerID() (*sarama.InitProducerIDResponse, error) {
-	panic("implement me")
-}
-
-func (s saramaClientMock) Close() error {
-	panic("implement me")
-}
-
-func (s saramaClientMock) Closed() bool {
-	panic("implement me")
-}
-
-var _ sarama.Client = saramaClientMock{}

--- a/kafka/source/pkg/adapter/adapter.go
+++ b/kafka/source/pkg/adapter/adapter.go
@@ -89,6 +89,9 @@ func (a *Adapter) Start(stopCh <-chan struct{}) error {
 
 	// init consumer group
 	addrs, config, err := kafkabinding.NewConfig(context.Background())
+	if err != nil {
+		return fmt.Errorf("failed to create the config: %w", err)
+	}
 	consumerGroupFactory := kafka.NewConsumerGroupFactory(addrs, config)
 	group, err := consumerGroupFactory.StartConsumerGroup(a.config.ConsumerGroup, a.config.Topics, a.logger, a)
 	if err != nil {

--- a/kafka/source/pkg/adapter/adapter.go
+++ b/kafka/source/pkg/adapter/adapter.go
@@ -106,12 +106,10 @@ func (a *Adapter) Start(stopCh <-chan struct{}) error {
 		}
 	}()
 
-	for {
-		select {
-		case <-stopCh:
-			a.logger.Info("Shutting down...")
-			return nil
-		}
+	select {
+	case <-stopCh:
+		a.logger.Info("Shutting down...")
+		return nil
 	}
 }
 

--- a/kafka/source/pkg/adapter/adapter_test.go
+++ b/kafka/source/pkg/adapter/adapter_test.go
@@ -401,3 +401,12 @@ func sinkAccepted(writer http.ResponseWriter, req *http.Request) {
 func sinkRejected(writer http.ResponseWriter, _ *http.Request) {
 	writer.WriteHeader(http.StatusRequestTimeout)
 }
+
+func TestAdapter_Start(t *testing.T) { // just increase code coverage
+	ctx, cancel := context.WithCancel(context.Background())
+
+	a := NewAdapter(ctx, NewEnvConfig(), nil, nil)
+	_ = a.Start(ctx.Done())
+
+	cancel()
+}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -241,9 +241,7 @@ function camel_teardown() {
 
 initialize $@ --skip-istio-addon
 
-# TODO: Figure out why kafka channels do not like parallel=12 (which it was)
-# https://github.com/knative/eventing-contrib/issues/917
-go_test_e2e -timeout=20m -parallel=1 ./test/e2e -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1alpha1:KafkaChannel  || fail_test
+go_test_e2e -timeout=20m -parallel=12 ./test/e2e -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1alpha1:KafkaChannel  || fail_test
 
 go_test_e2e -timeout=5m -parallel=2 ./test/conformance -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1alpha1:KafkaChannel  || fail_test
 


### PR DESCRIPTION
Fixes #917

## Proposed Changes

- Fix parallelism of Kafka's consumer groups
- Run e2e tests in parallel
