### PR TITLE
Reduce namespace verbs for {kafka,github}source webhooks

### DIFF
--- a/github/config/201-clusterrole.yaml
+++ b/github/config/201-clusterrole.yaml
@@ -81,8 +81,20 @@ rules:
   resources:
   - events
   - configmaps
-  - namespaces
   verbs: *everything
+
+# Namespace labelling for webhook
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+  - patch
 
 - apiGroups:
   - coordination.k8s.io

--- a/kafka/source/config/201-clusterrole.yaml
+++ b/kafka/source/config/201-clusterrole.yaml
@@ -84,8 +84,20 @@ rules:
   - events
   - configmaps
   - secrets
-  - namespaces
   verbs: *everything
+
+# let the webhook label the appropriate namespace
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+  - patch
 
 - apiGroups:
   - "coordination.k8s.io"


### PR DESCRIPTION
Don't need to allow deleting a namespace, this mirrors the evening webhook rbac