### PR TITLE
[github] add permission to read namespaces to the github-webhook (#1172)

### DIFF
--- a/github/config/201-clusterrole.yaml
+++ b/github/config/201-clusterrole.yaml
@@ -83,19 +83,6 @@ rules:
   - configmaps
   verbs: *everything
 
-# Namespace labelling for webhook
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - create
-  - update
-  - list
-  - watch
-  - patch
-
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/github/config/203-webhook-clusterrole.yaml
+++ b/github/config/203-webhook-clusterrole.yaml
@@ -75,6 +75,17 @@ rules:
   - list
   - watch
 
+# Namespace labelling for webhook
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+
 # Events admin
 - apiGroups:
   - ""


### PR DESCRIPTION
Fixes #1172
This PR grants the github-webhook service account permission to read namespaces

As this is my first contribution, I hope that I did not miss something. Looking forward to your feedback!