### PR TITLE
Use config from context in controller initialization.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1880,11 +1880,11 @@
     "test/test_images/transformevents",
   ]
   pruneopts = "UT"
-  revision = "40f0a540923eb858985e7c1df309e9d898dbbed1"
+  revision = "69f5d21b88b5582717cd121b7696af72252bafd3"
 
 [[projects]]
   branch = "master"
-  digest = "1:04f788ac12f571fa1ca01efc29cff6ae68de257287c7f3aa4485f768cceaf1b1"
+  digest = "1:da86dc44e4f58bae55f0800acbfb9f6e745645c71429909413deaaa5de2b0c5d"
   name = "knative.dev/pkg"
   packages = [
     "apis",
@@ -1967,7 +1967,7 @@
     "webhook/resourcesemantics/validation",
   ]
   pruneopts = "T"
-  revision = "7b6e21a57a3169cfe4acf71b2fa34ca0f6e3898e"
+  revision = "22b9613719340036137e8e666390d9bc17733c1f"
 
 [[projects]]
   branch = "master"
@@ -2011,18 +2011,18 @@
     "pkg/client/listers/serving/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "7ad5cc721f86524b52faafb849888a58a811b692"
+  revision = "cac3287054faf4bc657725674912f2d1a8e842e2"
 
 [[projects]]
   branch = "master"
-  digest = "1:4d8d06fc8e0f7dbfad243aa377651234d422d523c2a3297366343b9ff5165922"
+  digest = "1:31bd9c0a200618a3325145139d59d17726c7ffaa2ae4d88480de3ee5137714bb"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "e6e89d29e93a3f4dba44c4a694d704e3e8921c64"
+  revision = "bf3e6802597ac31776a8e3e62b32d51744b2ae77"
 
 [[projects]]
   digest = "1:c4e8f6509ee8cec911985a812ed3f9cc024404acc45ac613fa103f735cf3222a"

--- a/kafka/channel/cmd/channel_dispatcher/main.go
+++ b/kafka/channel/cmd/channel_dispatcher/main.go
@@ -17,11 +17,8 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"os"
 
-	"knative.dev/pkg/configmap"
-	pkgcontroller "knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/signals"
@@ -38,8 +35,5 @@ func main() {
 		ctx = injection.WithNamespaceScope(ctx, ns)
 	}
 
-	cfg := sharedmain.ParseAndGetConfigOrDie()
-	sharedmain.MainWithConfig(ctx, component, cfg, func(ctx context.Context, watcher configmap.Watcher) *pkgcontroller.Impl {
-		return controller.NewController(ctx, watcher, cfg)
-	})
+	sharedmain.MainWithContext(ctx, component, controller.NewController)
 }

--- a/kafka/channel/pkg/reconciler/dispatcher/kafkachannel.go
+++ b/kafka/channel/pkg/reconciler/dispatcher/kafkachannel.go
@@ -93,7 +93,7 @@ var _ controller.Reconciler = (*Reconciler)(nil)
 
 // NewController initializes the controller and is called by the generated code.
 // Registers event handlers to enqueue events.
-func NewController(ctx context.Context, _ configmap.Watcher, cfg *rest.Config) *controller.Impl {
+func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 
 	logger := logging.FromContext(ctx)
 
@@ -128,7 +128,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, cfg *rest.Config) *
 	logger.Info("Kafka broker configuration", zap.Strings(utils.BrokerConfigMapKey, kafkaConfig.Brokers))
 
 	r := &Reconciler{
-		recorder:             getRecorder(ctx, cfg),
+		recorder:             getRecorder(ctx, injection.GetConfig(ctx)),
 		kafkaDispatcher:      kafkaDispatcher,
 		kafkaClientSet:       kafkaclientsetinjection.Get(ctx),
 		kafkachannelLister:   kafkaChannelInformer.Lister(),

--- a/natss/cmd/channel_dispatcher/main.go
+++ b/natss/cmd/channel_dispatcher/main.go
@@ -17,17 +17,14 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"flag"
 	"os"
 
 	controller "knative.dev/eventing-contrib/natss/pkg/reconciler/dispatcher"
 
-	kncontroller "knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 
-	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/signals"
 )
 
@@ -41,8 +38,5 @@ func main() {
 		ctx = injection.WithNamespaceScope(ctx, ns)
 	}
 
-	cfg := sharedmain.ParseAndGetConfigOrDie()
-	sharedmain.MainWithConfig(ctx, component, cfg, func(ctx context.Context, watcher configmap.Watcher) *kncontroller.Impl {
-		return controller.NewController(ctx, watcher, cfg)
-	})
+	sharedmain.MainWithContext(ctx, component, controller.NewController)
 }

--- a/natss/pkg/reconciler/dispatcher/natsschannel.go
+++ b/natss/pkg/reconciler/dispatcher/natsschannel.go
@@ -23,6 +23,8 @@ import (
 	"reflect"
 	"strings"
 
+	"knative.dev/pkg/injection"
+
 	"go.uber.org/zap"
 
 	corev1 "k8s.io/api/core/v1"
@@ -31,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
 	eventingduck "knative.dev/eventing/pkg/apis/duck/v1alpha1"
@@ -75,7 +76,7 @@ var _ controller.Reconciler = (*Reconciler)(nil)
 
 // NewController initializes the controller and is called by the generated code.
 // Registers event handlers to enqueue events.
-func NewController(ctx context.Context, _ configmap.Watcher, config *rest.Config) *controller.Impl {
+func NewController(ctx context.Context, _ configmap.Watcher) *controller.Impl {
 
 	logger := logging.FromContext(ctx)
 
@@ -103,7 +104,7 @@ func NewController(ctx context.Context, _ configmap.Watcher, config *rest.Config
 	r := &Reconciler{
 		natssDispatcher:    natssDispatcher,
 		natsschannelLister: channelInformer.Lister(),
-		natssClientSet:     clientset.NewForConfigOrDie(config),
+		natssClientSet:     clientset.NewForConfigOrDie(injection.GetConfig(ctx)),
 	}
 	r.impl = controller.NewImpl(r, logger.Sugar(), ReconcilerName)
 

--- a/natss/pkg/reconciler/dispatcher/natsschannel_test.go
+++ b/natss/pkg/reconciler/dispatcher/natsschannel_test.go
@@ -143,9 +143,10 @@ func TestNewController(t *testing.T) {
 	ctx, _ = fakedynamicclient.With(ctx, runtime.NewScheme())
 	ctx, _ = fakeclientset.With(ctx)
 	cfg := &rest.Config{}
+	ctx = injection.WithConfig(ctx, cfg)
 	ctx, _ = injection.Fake.SetupInformers(ctx, cfg)
 
-	NewController(ctx, configmap.NewStaticWatcher(), cfg)
+	NewController(ctx, configmap.NewStaticWatcher())
 }
 
 func TestFailedNatssSubscription(t *testing.T) {

--- a/vendor/knative.dev/pkg/Gopkg.lock
+++ b/vendor/knative.dev/pkg/Gopkg.lock
@@ -55,6 +55,22 @@
   version = "v0.1.1"
 
 [[projects]]
+  digest = "1:0a111edd8693fd977f42a0c4f199a0efb13c20aec9da99ad8830c7bb6a87e8d6"
+  name = "github.com/PuerkitoBio/purell"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "44968752391892e1b0d0b821ee79e9a85fa13049"
+  version = "v1.1.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:8098cd40cd09879efbf12e33bcd51ead4a66006ac802cd563a66c4f3373b9727"
+  name = "github.com/PuerkitoBio/urlesc"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "de5bf2ad457846296e2031421a34e2568e304e35"
+
+[[projects]]
   digest = "1:acf5b7756eca7cd8133461c44771fd318ee2bef31d4cc013551165473a984ba8"
   name = "github.com/aws/aws-sdk-go"
   packages = [
@@ -133,6 +149,17 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:0d013fe54abe3c38b4da55925d95ab25dfce28c3e2ff71931b1d51b8f3aab042"
+  name = "github.com/emicklei/go-restful"
+  packages = [
+    ".",
+    "log",
+  ]
+  pruneopts = "NUT"
+  revision = "7c2556bbbff7dc38dc0673ce61902903671c0b55"
+  version = "v2.12.0"
+
+[[projects]]
   digest = "1:4304cca260ab815326ca42d9c28fb843342748267034c51963e13f5e54e727d1"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
@@ -163,6 +190,38 @@
   pruneopts = "NUT"
   revision = "03f06a783fbb7dfaf3f629c7825480e43a7105e6"
   version = "v0.1.1"
+
+[[projects]]
+  digest = "1:3758c86e787dfe5792a23430f34636106a16da914446724399c9c12f121a225d"
+  name = "github.com/go-openapi/jsonpointer"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "ed123515f087412cd7ef02e49b0b0a5e6a79a360"
+  version = "v0.19.3"
+
+[[projects]]
+  digest = "1:98abd61947ff5c7c6fcfec5473d02a4821ed3a2dd99a4fbfdb7925b0dd745546"
+  name = "github.com/go-openapi/jsonreference"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "82f31475a8f7a12bc26962f6e26ceade8ea6f66a"
+  version = "v0.19.3"
+
+[[projects]]
+  digest = "1:da2ad0356c603997317f60dfa8c571df6c60411b4359846b8b9ed735b62e913f"
+  name = "github.com/go-openapi/spec"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "1297e9a4ddf9325269fe013d7c1300aac3985f92"
+  version = "v0.19.7"
+
+[[projects]]
+  digest = "1:b8bae5ae3c3ccc79b8af1cf6658aa8255711b7eb4eabfb3a3ac785129a372b0c"
+  name = "github.com/go-openapi/swag"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "ab98f8e6456407f6afd63e441c5304d6ef60cb7f"
+  version = "v0.19.9"
 
 [[projects]]
   digest = "1:416b666cb79f02526f115d16aba8b318b854f3c964107081311e9df6a08b39a9"
@@ -716,7 +775,7 @@
   revision = "fae7ac547cb717d141c433a2a173315e216b64c4"
 
 [[projects]]
-  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
+  digest = "1:66a2f252a58b4fbbad0e4e180e1d85a83c222b6bce09c3dcdef3dc87c72eda7c"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -735,6 +794,7 @@
     "unicode/cldr",
     "unicode/norm",
     "unicode/rangetable",
+    "width",
   ]
   pruneopts = "NUT"
   revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
@@ -787,6 +847,39 @@
   pruneopts = "NUT"
   revision = "e8422f09d27ee2c8cfb2c7f8089eb9eeb0764849"
   version = "v2.0.1"
+
+[[projects]]
+  digest = "1:671efe894b8ea8faeda2df5dd18a26b6994065398e816b6577537f141cb2f3ea"
+  name = "gonum.org/v1/gonum"
+  packages = [
+    "blas",
+    "blas/blas64",
+    "blas/cblas128",
+    "blas/gonum",
+    "floats",
+    "graph",
+    "graph/internal/linear",
+    "graph/internal/ordered",
+    "graph/internal/set",
+    "graph/internal/uid",
+    "graph/iterator",
+    "graph/simple",
+    "graph/topo",
+    "graph/traverse",
+    "internal/asm/c128",
+    "internal/asm/c64",
+    "internal/asm/f32",
+    "internal/asm/f64",
+    "internal/cmplx64",
+    "internal/math32",
+    "lapack",
+    "lapack/gonum",
+    "lapack/lapack64",
+    "mat",
+  ]
+  pruneopts = "NUT"
+  revision = "960a37950cca5ec8d1efe76ed4eec9dfe3065bd6"
+  version = "v0.7.0"
 
 [[projects]]
   digest = "1:74ee58de746e67a8d7d44b8b71ca3b980f6b1f62211075832d2f427205ea18cd"
@@ -1282,6 +1375,7 @@
   digest = "1:a6aa236db5d07dff9ea1160ef316b17e131d2b1b2ad7d177431206bf389d241e"
   name = "k8s.io/code-generator"
   packages = [
+    ".",
     "cmd/client-gen",
     "cmd/client-gen/args",
     "cmd/client-gen/generators",
@@ -1290,18 +1384,30 @@
     "cmd/client-gen/generators/util",
     "cmd/client-gen/path",
     "cmd/client-gen/types",
+    "cmd/conversion-gen",
+    "cmd/conversion-gen/args",
+    "cmd/conversion-gen/generators",
     "cmd/deepcopy-gen",
     "cmd/deepcopy-gen/args",
     "cmd/defaulter-gen",
     "cmd/defaulter-gen/args",
+    "cmd/go-to-protobuf",
+    "cmd/go-to-protobuf/protobuf",
+    "cmd/import-boss",
     "cmd/informer-gen",
     "cmd/informer-gen/args",
     "cmd/informer-gen/generators",
     "cmd/lister-gen",
     "cmd/lister-gen/args",
     "cmd/lister-gen/generators",
+    "cmd/openapi-gen",
+    "cmd/register-gen",
+    "cmd/register-gen/args",
+    "cmd/register-gen/generators",
+    "cmd/set-gen",
     "pkg/namer",
     "pkg/util",
+    "third_party/forked/golang/reflect",
   ]
   pruneopts = "T"
   revision = "8e001e5d18949be7e823ccb9cfe9b60026e7bda0"
@@ -1309,12 +1415,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:39912eb5f8eaf46486faae0839586c27c93423e552f76875defa048f52c15c15"
+  digest = "1:042764790129d530ed2db8ab2d593beb7ecd7dee51136122912101e55b601211"
   name = "k8s.io/gengo"
   packages = [
     "args",
     "examples/deepcopy-gen/generators",
     "examples/defaulter-gen/generators",
+    "examples/import-boss/generators",
+    "examples/set-gen/generators",
     "examples/set-gen/sets",
     "generator",
     "namer",
@@ -1334,9 +1442,17 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:42674e29bf0cf4662d49bd9528e24b9ecc4895b32d0be281f9cf04d3a7671846"
+  digest = "1:48eab5fdf8f404d81d4a513ce8f04c36603775de3edb25ddf756da27c6cf41d1"
   name = "k8s.io/kube-openapi"
-  packages = ["pkg/util/proto"]
+  packages = [
+    "cmd/openapi-gen",
+    "cmd/openapi-gen/args",
+    "pkg/common",
+    "pkg/generators",
+    "pkg/generators/rules",
+    "pkg/util/proto",
+    "pkg/util/sets",
+  ]
   pruneopts = "NUT"
   revision = "33be087ad058f99c78e067996202b60230737e49"
 
@@ -1369,14 +1485,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:dc9ba2b25034dbe099b604ce1e243b42502d4ea7b096f844abd1f1617e1151ac"
+  digest = "1:4d8d06fc8e0f7dbfad243aa377651234d422d523c2a3297366343b9ff5165922"
   name = "knative.dev/test-infra"
   packages = [
     "scripts",
     "tools/dep-collector",
   ]
   pruneopts = "UT"
-  revision = "f645de8d9a500a3fd00149f1b4e693029d678132"
+  revision = "e6e89d29e93a3f4dba44c4a694d704e3e8921c64"
 
 [[projects]]
   digest = "1:8730e0150dfb2b7e173890c8b9868e7a273082ef8e39f4940e3506a481cf895c"
@@ -1527,6 +1643,7 @@
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/util/retry",
     "k8s.io/client-go/util/workqueue",
+    "k8s.io/code-generator",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/client-gen/generators/util",
     "k8s.io/code-generator/cmd/client-gen/types",
@@ -1541,6 +1658,7 @@
     "k8s.io/gengo/namer",
     "k8s.io/gengo/types",
     "k8s.io/klog",
+    "k8s.io/kube-openapi/cmd/openapi-gen",
     "k8s.io/test-infra/boskos/client",
     "k8s.io/test-infra/boskos/common",
     "knative.dev/test-infra/scripts",

--- a/vendor/knative.dev/pkg/hack/tools.go
+++ b/vendor/knative.dev/pkg/hack/tools.go
@@ -1,0 +1,34 @@
+// +build tools
+
+/*
+Copyright 2020 The Knative Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+// This package imports things required by this repository, to force `go mod` to see them as dependencies
+import (
+	_ "k8s.io/code-generator"
+	_ "k8s.io/code-generator/cmd/client-gen"
+	_ "k8s.io/code-generator/cmd/deepcopy-gen"
+	_ "k8s.io/code-generator/cmd/defaulter-gen"
+	_ "k8s.io/code-generator/cmd/informer-gen"
+	_ "k8s.io/code-generator/cmd/lister-gen"
+	_ "k8s.io/kube-openapi/cmd/openapi-gen"
+
+	_ "knative.dev/pkg/codegen/cmd/injection-gen"
+
+	_ "knative.dev/test-infra/scripts"
+)

--- a/vendor/knative.dev/pkg/injection/context.go
+++ b/vendor/knative.dev/pkg/injection/context.go
@@ -18,6 +18,8 @@ package injection
 
 import (
 	"context"
+
+	"k8s.io/client-go/rest"
 )
 
 // nsKey is the key that namespaces are associated with on
@@ -46,4 +48,21 @@ func GetNamespaceScope(ctx context.Context) string {
 		return ""
 	}
 	return value.(string)
+}
+
+// cfgKey is the key that the config is associated with.
+type cfgKey struct{}
+
+// WithConfig associates a given config with the context.
+func WithConfig(ctx context.Context, cfg *rest.Config) context.Context {
+	return context.WithValue(ctx, cfgKey{}, cfg)
+}
+
+// GetConfig gets the current config from the context.
+func GetConfig(ctx context.Context) *rest.Config {
+	value := ctx.Value(cfgKey{})
+	if value == nil {
+		return nil
+	}
+	return value.(*rest.Config)
 }

--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
+++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
@@ -143,6 +143,7 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	// Adjust our client's rate limits based on the number of controllers we are running.
 	cfg.QPS = float32(len(ctors)) * rest.DefaultQPS
 	cfg.Burst = len(ctors) * rest.DefaultBurst
+	ctx = injection.WithConfig(ctx, cfg)
 
 	ctx, informers := injection.Default.SetupInformers(ctx, cfg)
 

--- a/vendor/knative.dev/pkg/metrics/stackdriver_exporter.go
+++ b/vendor/knative.dev/pkg/metrics/stackdriver_exporter.go
@@ -227,7 +227,7 @@ func getStackdriverSecret(sdconfig *StackdriverClientConfig) (*corev1.Secret, er
 	sec, secErr := kubeclient.CoreV1().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
 
 	if secErr != nil {
-		return nil, fmt.Errorf("Error getting Secret [%v] in namespace [%v]: %v", secretName, secretNamespace, secErr)
+		return nil, fmt.Errorf("Error getting Secret [%s] in namespace [%s]: %w", secretName, secretNamespace, secErr)
 	}
 
 	return sec, nil
@@ -238,7 +238,7 @@ func convertSecretToExporterOption(secret *corev1.Secret) (option.ClientOption, 
 	if data, ok := secret.Data[secretDataFieldKey]; ok {
 		return option.WithCredentialsJSON(data), nil
 	}
-	return nil, fmt.Errorf("Expected Secret to store key in data field named [%v]", secretDataFieldKey)
+	return nil, fmt.Errorf("Expected Secret to store key in data field named [%s]", secretDataFieldKey)
 }
 
 // ensureKubeclient is the lazy initializer for kubeclient.

--- a/vendor/knative.dev/pkg/network/prober/prober.go
+++ b/vendor/knative.dev/pkg/network/prober/prober.go
@@ -97,7 +97,7 @@ func ExpectsStatusCodes(statusCodes []int) Verifier {
 func Do(ctx context.Context, transport http.RoundTripper, target string, ops ...interface{}) (bool, error) {
 	req, err := http.NewRequest(http.MethodGet, target, nil)
 	if err != nil {
-		return false, fmt.Errorf("%s is not a valid URL: %v", target, err)
+		return false, fmt.Errorf("%s is not a valid URL: %w", target, err)
 	}
 	for _, op := range ops {
 		if po, ok := op.(Preparer); ok {
@@ -108,12 +108,12 @@ func Do(ctx context.Context, transport http.RoundTripper, target string, ops ...
 	req = req.WithContext(ctx)
 	resp, err := transport.RoundTrip(req)
 	if err != nil {
-		return false, fmt.Errorf("error roundtripping %s: %v", target, err)
+		return false, fmt.Errorf("error roundtripping %s: %w", target, err)
 	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return false, fmt.Errorf("error reading body: %v", err)
+		return false, fmt.Errorf("error reading body: %w", err)
 	}
 
 	for _, op := range ops {

--- a/vendor/knative.dev/pkg/resolver/addressable_resolver.go
+++ b/vendor/knative.dev/pkg/resolver/addressable_resolver.go
@@ -146,7 +146,7 @@ func (r *URIResolver) URIFromObjectReference(ref *corev1.ObjectReference, parent
 		Namespace:  ref.Namespace,
 		Name:       ref.Name,
 	}, parent); err != nil {
-		return nil, fmt.Errorf("failed to track %+v: %v", ref, err)
+		return nil, fmt.Errorf("failed to track %+v: %w", ref, err)
 	}
 
 	// K8s Services are special cased. They can be called, even though they do not satisfy the
@@ -164,12 +164,12 @@ func (r *URIResolver) URIFromObjectReference(ref *corev1.ObjectReference, parent
 	gvr, _ := meta.UnsafeGuessKindToResource(ref.GroupVersionKind())
 	_, lister, err := r.informerFactory.Get(gvr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get lister for %+v: %v", gvr, err)
+		return nil, fmt.Errorf("failed to get lister for %+v: %w", gvr, err)
 	}
 
 	obj, err := lister.ByNamespace(ref.Namespace).Get(ref.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get ref %+v: %v", ref, err)
+		return nil, fmt.Errorf("failed to get ref %+v: %w", ref, err)
 	}
 
 	addressable, ok := obj.(*duckv1.AddressableType)
@@ -181,7 +181,7 @@ func (r *URIResolver) URIFromObjectReference(ref *corev1.ObjectReference, parent
 	}
 	url := addressable.Status.Address.URL
 	if url == nil {
-		return nil, fmt.Errorf("url missing in address of %+v", ref)
+		return nil, fmt.Errorf("URL missing in address of %+v", ref)
 	}
 	if url.Host == "" {
 		return nil, fmt.Errorf("hostname missing in address of %+v", ref)

--- a/vendor/knative.dev/pkg/test/ghutil/client.go
+++ b/vendor/knative.dev/pkg/test/ghutil/client.go
@@ -146,7 +146,7 @@ func (gc *GithubClient) depaginate(message string, maxRetries int, options *gith
 	for ; options.Page <= lastPage; options.Page++ {
 		resp, err := gc.retry(message, maxRetries, wrapper)
 		if err != nil {
-			return allItems, fmt.Errorf("error while depaginating page %d/%d: %v", options.Page, lastPage, err)
+			return allItems, fmt.Errorf("error while depaginating page %d/%d: %w", options.Page, lastPage, err)
 		}
 		if resp.LastPage > 0 {
 			lastPage = resp.LastPage

--- a/vendor/knative.dev/pkg/test/helpers/dir.go
+++ b/vendor/knative.dev/pkg/test/helpers/dir.go
@@ -36,7 +36,7 @@ func CreateDir(dirPath string) error {
 func CreateDirWithFileMode(dirPath string, perm os.FileMode) error {
 	if _, err := os.Stat(dirPath); os.IsNotExist(err) {
 		if err = os.MkdirAll(dirPath, perm); err != nil {
-			return fmt.Errorf("error creating directory: %v", err)
+			return fmt.Errorf("error creating directory: %w", err)
 		}
 	}
 	return nil

--- a/vendor/knative.dev/pkg/test/mako/alerter/slack/message.go
+++ b/vendor/knative.dev/pkg/test/mako/alerter/slack/message.go
@@ -48,11 +48,11 @@ type MessageHandler struct {
 func Setup(userName, readTokenPath, writeTokenPath string, channels []config.Channel, dryrun bool) (*MessageHandler, error) {
 	readClient, err := slackutil.NewReadClient(userName, readTokenPath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot authenticate to slack read client: %v", err)
+		return nil, fmt.Errorf("cannot authenticate to slack read client: %w", err)
 	}
 	writeClient, err := slackutil.NewWriteClient(userName, writeTokenPath)
 	if err != nil {
-		return nil, fmt.Errorf("cannot authenticate to slack write client: %v", err)
+		return nil, fmt.Errorf("cannot authenticate to slack write client: %w", err)
 	}
 	return &MessageHandler{
 		readClient:  readClient,

--- a/vendor/knative.dev/pkg/test/monitoring/monitoring.go
+++ b/vendor/knative.dev/pkg/test/monitoring/monitoring.go
@@ -65,7 +65,7 @@ func PortForward(logf logging.FormatLogger, podList *v1.PodList, localPort, remo
 	portFwdProcess, err := executeCmdBackground(logf, portFwdCmd)
 
 	if err != nil {
-		return 0, fmt.Errorf("failed to port forward: %v", err)
+		return 0, fmt.Errorf("failed to port forward: %w", err)
 	}
 
 	logf("running %s port-forward in background, pid = %d", podName, portFwdProcess.Pid)
@@ -79,7 +79,7 @@ func executeCmdBackground(logf logging.FormatLogger, format string, args ...inte
 	parts := strings.Split(cmd, " ")
 	c := exec.Command(parts[0], parts[1:]...) // #nosec
 	if err := c.Start(); err != nil {
-		return nil, fmt.Errorf("%s command failed: %v", cmd, err)
+		return nil, fmt.Errorf("%s command failed: %w", cmd, err)
 	}
 	return c.Process, nil
 }

--- a/vendor/knative.dev/pkg/test/spoof/spoof.go
+++ b/vendor/knative.dev/pkg/test/spoof/spoof.go
@@ -109,7 +109,7 @@ func New(
 	opts ...TransportOption) (*SpoofingClient, error) {
 	endpoint, err := ResolveEndpoint(kubeClientset, domain, resolvable, endpointOverride)
 	if err != nil {
-		return nil, fmt.Errorf("failed get the cluster endpoint: %v", err)
+		return nil, fmt.Errorf("failed get the cluster endpoint: %w", err)
 	}
 
 	// Spoof the hostname at the resolver level
@@ -244,18 +244,18 @@ func (sc *SpoofingClient) Poll(req *http.Request, inState ResponseChecker, error
 // DefaultErrorRetryChecker implements the defaults for retrying on error.
 func DefaultErrorRetryChecker(err error) (bool, error) {
 	if isTCPTimeout(err) {
-		return true, fmt.Errorf("Retrying for TCP timeout: %v", err)
+		return true, fmt.Errorf("Retrying for TCP timeout: %w", err)
 	}
 	// Retrying on DNS error, since we may be using xip.io or nip.io in tests.
 	if isDNSError(err) {
-		return true, fmt.Errorf("Retrying for DNS error: %v", err)
+		return true, fmt.Errorf("Retrying for DNS error: %w", err)
 	}
 	// Repeat the poll on `connection refused` errors, which are usually transient Istio errors.
 	if isConnectionRefused(err) {
-		return true, fmt.Errorf("Retrying for connection refused: %v", err)
+		return true, fmt.Errorf("Retrying for connection refused: %w", err)
 	}
 	if isConnectionReset(err) {
-		return true, fmt.Errorf("Retrying for connection reset: %v", err)
+		return true, fmt.Errorf("Retrying for connection reset: %w", err)
 	}
 	return false, err
 }

--- a/vendor/knative.dev/pkg/test/webhook-apicoverage/coveragecalculator/ignorefields.go
+++ b/vendor/knative.dev/pkg/test/webhook-apicoverage/coveragecalculator/ignorefields.go
@@ -43,13 +43,13 @@ type inputIgnoredFields struct {
 func (ig *IgnoredFields) ReadFromFile(filePath string) error {
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return fmt.Errorf("Error reading file: %s Error : %v", filePath, err)
+		return fmt.Errorf("Error reading file: %s Error: %w", filePath, err)
 	}
 
 	var inputEntries []inputIgnoredFields
 	err = yaml.Unmarshal(data, &inputEntries)
 	if err != nil {
-		return fmt.Errorf("Error unmarshalling ignoredfields input yaml file: %s Content: %s Error: %v", filePath, string(data), err)
+		return fmt.Errorf("Error unmarshalling ignoredfields input yaml file: %s Content: %s Error: %w", filePath, string(data), err)
 	}
 
 	ig.ignoredFields = make(map[string]sets.String)

--- a/vendor/knative.dev/pkg/test/webhook-apicoverage/webhook/webhook.go
+++ b/vendor/knative.dev/pkg/test/webhook-apicoverage/webhook/webhook.go
@@ -87,12 +87,12 @@ type APICoverageWebhook struct {
 func (acw *APICoverageWebhook) generateServerConfig() (*tls.Config, error) {
 	serverKey, serverCert, caCert, err := certresources.CreateCerts(context.Background(), acw.ServiceName, acw.Namespace, time.Now().AddDate(1, 0, 0))
 	if err != nil {
-		return nil, fmt.Errorf("Error creating webhook certificates: %v", err)
+		return nil, fmt.Errorf("Error creating webhook certificates: %w", err)
 	}
 
 	cert, err := tls.X509KeyPair(serverCert, serverKey)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating X509 Key pair for webhook server: %v", err)
+		return nil, fmt.Errorf("Error creating X509 Key pair for webhook server: %w", err)
 	}
 
 	acw.CaCert = caCert
@@ -139,14 +139,14 @@ func (acw *APICoverageWebhook) registerWebhook(rules []admissionregistrationv1be
 
 	deployment, err := acw.KubeClient.ExtensionsV1beta1().Deployments(namespace).Get(acw.DeploymentName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("Error retrieving Deployment Extension object: %v", err)
+		return fmt.Errorf("Error retrieving Deployment Extension object: %w", err)
 	}
 	deploymentRef := metav1.NewControllerRef(deployment, deploymentKind)
 	webhook.OwnerReferences = append(webhook.OwnerReferences, *deploymentRef)
 
 	_, err = acw.KubeClient.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations().Create(webhook)
 	if err != nil {
-		return fmt.Errorf("Error creating ValidatingWebhookConfigurations object: %v", err)
+		return fmt.Errorf("Error creating ValidatingWebhookConfigurations object: %w", err)
 	}
 
 	return nil
@@ -177,14 +177,14 @@ func (acw *APICoverageWebhook) SetupWebhook(handler http.Handler, resources map[
 	server, err := acw.getWebhookServer(handler)
 	rules := acw.getValidationRules(resources)
 	if err != nil {
-		return fmt.Errorf("Webhook server object creation failed: %v", err)
+		return fmt.Errorf("Webhook server object creation failed: %w", err)
 	}
 
 	select {
 	case <-time.After(acw.RegistrationDelay):
 		err = acw.registerWebhook(rules, namespace)
 		if err != nil {
-			return fmt.Errorf("Webhook registration failed: %v", err)
+			return fmt.Errorf("Webhook registration failed: %w", err)
 		}
 		acw.Logger.Info("Successfully registered webhook")
 	case <-stop:

--- a/vendor/knative.dev/pkg/test/zipkin/util.go
+++ b/vendor/knative.dev/pkg/test/zipkin/util.go
@@ -183,7 +183,7 @@ func jsonTrace(traceID string) ([]model.SpanModel, error) {
 	var models []model.SpanModel
 	err = json.Unmarshal(body, &models)
 	if err != nil {
-		return empty, fmt.Errorf("got an error in unmarshalling JSON %q: %v", body, err)
+		return empty, fmt.Errorf("got an error in unmarshalling JSON %q: %w", body, err)
 	}
 	return models, nil
 }

--- a/vendor/knative.dev/pkg/testutils/clustermanager/e2e-tests/boskos/boskos.go
+++ b/vendor/knative.dev/pkg/testutils/clustermanager/e2e-tests/boskos/boskos.go
@@ -79,7 +79,7 @@ func (c *Client) AcquireGKEProject(resType string) (*boskoscommon.Resource, erro
 	defer cancel()
 	p, err := c.AcquireWait(ctx, resType, boskoscommon.Free, boskoscommon.Busy)
 	if err != nil {
-		return nil, fmt.Errorf("boskos failed to acquire GKE project: %v", err)
+		return nil, fmt.Errorf("boskos failed to acquire GKE project: %w", err)
 	}
 	if p == nil {
 		return nil, fmt.Errorf("boskos does not have a free %s at the moment", resType)
@@ -94,7 +94,7 @@ func (c *Client) AcquireGKEProject(resType string) (*boskoscommon.Resource, erro
 // other processes, regardless of where the other process is running.
 func (c *Client) ReleaseGKEProject(name string) error {
 	if err := c.Release(name, boskoscommon.Dirty); err != nil {
-		return fmt.Errorf("boskos failed to release GKE project '%s': %v", name, err)
+		return fmt.Errorf("boskos failed to release GKE project %q: %w", name, err)
 	}
 	return nil
 }

--- a/vendor/knative.dev/pkg/testutils/clustermanager/e2e-tests/gke.go
+++ b/vendor/knative.dev/pkg/testutils/clustermanager/e2e-tests/gke.go
@@ -238,7 +238,7 @@ func (gc *GKECluster) checkEnvironment() error {
 					}
 					cluster, err := client.GetCluster(project, region, zone, clusterName)
 					if err != nil {
-						return fmt.Errorf("couldn't find cluster %s in %s in %s, does it exist? %v", clusterName, project, location, err)
+						return fmt.Errorf("couldn't find cluster %s in %s in %s, does it exist? %w", clusterName, project, location, err)
 					}
 					gc.Cluster = cluster
 					gc.Project = project
@@ -251,7 +251,7 @@ func (gc *GKECluster) checkEnvironment() error {
 	// If output isn't empty then this is unexpected error, should shout out
 	// directly
 	if err != nil && len(output) > 0 {
-		return fmt.Errorf("failed running kubectl config current-context: '%s'", string(output))
+		return fmt.Errorf("failed running kubectl config current-context: %q", string(output))
 	}
 
 	if gc.Project != "" {
@@ -261,11 +261,10 @@ func (gc *GKECluster) checkEnvironment() error {
 	// if gcloud is pointing to a project, use it
 	output, err = common.StandardExec("gcloud", "config", "get-value", "project")
 	if err != nil {
-		return fmt.Errorf("failed getting gcloud project: '%v'", err)
+		return fmt.Errorf("failed getting gcloud project: %w", err)
 	}
-	if string(output) != "" {
-		project := strings.Trim(strings.TrimSpace(string(output)), "\n\r")
-		gc.Project = project
+	if os := string(output); os != "" {
+		gc.Project = strings.TrimSpace(os)
 	}
 	return nil
 }

--- a/vendor/knative.dev/pkg/testutils/clustermanager/perf-tests/pkg/benchmark.go
+++ b/vendor/knative.dev/pkg/testutils/clustermanager/perf-tests/pkg/benchmark.go
@@ -64,7 +64,7 @@ func benchmarkNames(benchmarkRoot string) ([]string, error) {
 	names := make([]string, 0)
 	dirs, err := ioutil.ReadDir(benchmarkRoot)
 	if err != nil {
-		return names, fmt.Errorf("failed to list all benchmarks under %q: %v", benchmarkRoot, err)
+		return names, fmt.Errorf("failed to list all benchmarks under %q: %w", benchmarkRoot, err)
 	}
 
 	for _, dir := range dirs {
@@ -150,8 +150,5 @@ func repoPrefix(repo string) string {
 // fileExists returns if the file exists or not
 func fileExists(fileName string) bool {
 	info, err := os.Stat(fileName)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return !info.IsDir()
+	return err == nil && !info.IsDir()
 }

--- a/vendor/knative.dev/pkg/tracing/config/tracing.go
+++ b/vendor/knative.dev/pkg/tracing/config/tracing.go
@@ -90,7 +90,7 @@ func NewTracingConfigFromMap(cfgMap map[string]string) (*Config, error) {
 		if enable, ok := cfgMap[enableKey]; ok {
 			enableBool, err := strconv.ParseBool(enable)
 			if err != nil {
-				return nil, fmt.Errorf("failed parsing tracing config %q: %v", enableKey, err)
+				return nil, fmt.Errorf("failed parsing tracing config %q: %w", enableKey, err)
 			}
 			if enableBool {
 				tc.Backend = Zipkin
@@ -109,7 +109,7 @@ func NewTracingConfigFromMap(cfgMap map[string]string) (*Config, error) {
 	} else if tc.Backend == Stackdriver {
 		projectID, err := metadata.ProjectID()
 		if err != nil {
-			return nil, fmt.Errorf("stackdriver tracing enabled without a project-id specified: %v", err)
+			return nil, fmt.Errorf("stackdriver tracing enabled without a project-id specified: %w", err)
 		}
 		tc.StackdriverProjectID = projectID
 	}

--- a/vendor/knative.dev/pkg/tracing/opencensus.go
+++ b/vendor/knative.dev/pkg/tracing/opencensus.go
@@ -136,7 +136,7 @@ func WithExporter(name string, logger *zap.SugaredLogger) ConfigOption {
 			if name == "" {
 				n, err := os.Hostname()
 				if err != nil {
-					return fmt.Errorf("unable to get hostname: %v", err)
+					return fmt.Errorf("unable to get hostname: %w", err)
 				}
 				name = n
 			}

--- a/vendor/knative.dev/pkg/webhook/psbinding/psbinding.go
+++ b/vendor/knative.dev/pkg/webhook/psbinding/psbinding.go
@@ -333,7 +333,7 @@ func (ac *Reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 
 	configuredWebhook, err := ac.MWHLister.Get(ac.Name)
 	if err != nil {
-		return fmt.Errorf("error retrieving webhook: %v", err)
+		return fmt.Errorf("error retrieving webhook: %w", err)
 	}
 	webhook := configuredWebhook.DeepCopy()
 
@@ -357,12 +357,12 @@ func (ac *Reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 	}
 
 	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
-		return fmt.Errorf("error diffing webhooks: %v", err)
+		return fmt.Errorf("error diffing webhooks: %w", err)
 	} else if !ok {
 		logging.FromContext(ctx).Info("Updating webhook")
 		mwhclient := ac.Client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 		if _, err := mwhclient.Update(webhook); err != nil {
-			return fmt.Errorf("failed to update webhook: %v", err)
+			return fmt.Errorf("failed to update webhook: %w", err)
 		}
 	} else {
 		logging.FromContext(ctx).Info("Webhook is valid")

--- a/vendor/knative.dev/pkg/webhook/psbinding/reconciler.go
+++ b/vendor/knative.dev/pkg/webhook/psbinding/reconciler.go
@@ -315,7 +315,7 @@ func (r *BaseReconciler) ReconcileSubject(ctx context.Context, fb Bindable, muta
 			fb.GetBindingStatus().MarkBindingUnavailable("SubjectMissing", err.Error())
 			return err
 		} else if err != nil {
-			return fmt.Errorf("error fetching Pod Speccable %v: %v", subject, err)
+			return fmt.Errorf("error fetching Pod Speccable %v: %w", subject, err)
 		}
 		err = r.labelNamespace(ctx, subject)
 		if err != nil {
@@ -331,7 +331,7 @@ func (r *BaseReconciler) ReconcileSubject(ctx context.Context, fb Bindable, muta
 		}
 		psObjs, err := lister.ByNamespace(subject.Namespace).List(selector)
 		if err != nil {
-			return fmt.Errorf("error fetching Pod Speccable %v: %v", subject, err)
+			return fmt.Errorf("error fetching Pod Speccable %v: %w", subject, err)
 		}
 		err = r.labelNamespace(ctx, subject)
 		if err != nil {

--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/conversion/reconciler.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/conversion/reconciler.go
@@ -77,7 +77,7 @@ func (r *reconciler) reconcileCRD(ctx context.Context, cacert []byte, key string
 
 	configuredCRD, err := r.crdLister.Get(key)
 	if err != nil {
-		return fmt.Errorf("error retrieving crd: %v", err)
+		return fmt.Errorf("error retrieving crd: %w", err)
 	}
 
 	crd := configuredCRD.DeepCopy()
@@ -93,12 +93,12 @@ func (r *reconciler) reconcileCRD(ctx context.Context, cacert []byte, key string
 	crd.Spec.Conversion.WebhookClientConfig.Service.Path = ptr.String(r.path)
 
 	if ok, err := kmp.SafeEqual(configuredCRD, crd); err != nil {
-		return fmt.Errorf("error diffing custom resource definitions: %v", err)
+		return fmt.Errorf("error diffing custom resource definitions: %w", err)
 	} else if !ok {
 		logger.Infof("updating CRD")
 		crdClient := r.client.ApiextensionsV1beta1().CustomResourceDefinitions()
 		if _, err := crdClient.Update(crd); err != nil {
-			return fmt.Errorf("failed to update webhook: %v", err)
+			return fmt.Errorf("failed to update webhook: %w", err)
 		}
 	} else {
 		logger.Info("CRD is up to date")

--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/defaulting.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/defaulting/defaulting.go
@@ -158,7 +158,7 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 
 	configuredWebhook, err := ac.mwhlister.Get(ac.name)
 	if err != nil {
-		return fmt.Errorf("error retrieving webhook: %v", err)
+		return fmt.Errorf("error retrieving webhook: %w", err)
 	}
 
 	webhook := configuredWebhook.DeepCopy()
@@ -180,12 +180,12 @@ func (ac *reconciler) reconcileMutatingWebhook(ctx context.Context, caCert []byt
 	}
 
 	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
-		return fmt.Errorf("error diffing webhooks: %v", err)
+		return fmt.Errorf("error diffing webhooks: %w", err)
 	} else if !ok {
 		logger.Info("Updating webhook")
 		mwhclient := ac.client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations()
 		if _, err := mwhclient.Update(webhook); err != nil {
-			return fmt.Errorf("failed to update webhook: %v", err)
+			return fmt.Errorf("failed to update webhook: %w", err)
 		}
 	} else {
 		logger.Info("Webhook is valid")
@@ -221,7 +221,7 @@ func (ac *reconciler) mutate(ctx context.Context, req *admissionv1beta1.Admissio
 			newDecoder.DisallowUnknownFields()
 		}
 		if err := newDecoder.Decode(&newObj); err != nil {
-			return nil, fmt.Errorf("cannot decode incoming new object: %v", err)
+			return nil, fmt.Errorf("cannot decode incoming new object: %w", err)
 		}
 	}
 	if len(oldBytes) != 0 {
@@ -231,7 +231,7 @@ func (ac *reconciler) mutate(ctx context.Context, req *admissionv1beta1.Admissio
 			oldDecoder.DisallowUnknownFields()
 		}
 		if err := oldDecoder.Decode(&oldObj); err != nil {
-			return nil, fmt.Errorf("cannot decode incoming old object: %v", err)
+			return nil, fmt.Errorf("cannot decode incoming old object: %w", err)
 		}
 	}
 	var patches duck.JSONPatch
@@ -244,7 +244,7 @@ func (ac *reconciler) mutate(ctx context.Context, req *admissionv1beta1.Admissio
 		// because it expects the round tripped through Golang fields to be present already.
 		rtp, err := roundTripPatch(newBytes, newObj)
 		if err != nil {
-			return nil, fmt.Errorf("cannot create patch for round tripped newBytes: %v", err)
+			return nil, fmt.Errorf("cannot create patch for round tripped newBytes: %w", err)
 		}
 		patches = append(patches, rtp...)
 	}
@@ -324,7 +324,7 @@ func roundTripPatch(bytes []byte, unmarshalled interface{}) (duck.JSONPatch, err
 	}
 	marshaledBytes, err := json.Marshal(unmarshalled)
 	if err != nil {
-		return nil, fmt.Errorf("cannot marshal interface: %v", err)
+		return nil, fmt.Errorf("cannot marshal interface: %w", err)
 	}
 	return jsonpatch.CreatePatch(bytes, marshaledBytes)
 }

--- a/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/reconcile_config.go
+++ b/vendor/knative.dev/pkg/webhook/resourcesemantics/validation/reconcile_config.go
@@ -121,7 +121,7 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 
 	configuredWebhook, err := ac.vwhlister.Get(ac.name)
 	if err != nil {
-		return fmt.Errorf("error retrieving webhook: %v", err)
+		return fmt.Errorf("error retrieving webhook: %w", err)
 	}
 
 	webhook := configuredWebhook.DeepCopy()
@@ -143,12 +143,12 @@ func (ac *reconciler) reconcileValidatingWebhook(ctx context.Context, caCert []b
 	}
 
 	if ok, err := kmp.SafeEqual(configuredWebhook, webhook); err != nil {
-		return fmt.Errorf("error diffing webhooks: %v", err)
+		return fmt.Errorf("error diffing webhooks: %w", err)
 	} else if !ok {
 		logger.Info("Updating webhook")
 		vwhclient := ac.client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations()
 		if _, err := vwhclient.Update(webhook); err != nil {
-			return fmt.Errorf("failed to update webhook: %v", err)
+			return fmt.Errorf("failed to update webhook: %w", err)
 		}
 	} else {
 		logger.Info("Webhook is valid")

--- a/vendor/knative.dev/pkg/webhook/webhook.go
+++ b/vendor/knative.dev/pkg/webhook/webhook.go
@@ -211,7 +211,7 @@ func (wh *Webhook) Run(stop <-chan struct{}) error {
 		}
 		return eg.Wait()
 	case <-ctx.Done():
-		return fmt.Errorf("webhook server bootstrap failed %v", ctx.Err())
+		return fmt.Errorf("webhook server bootstrap failed %w", ctx.Err())
 	}
 }
 

--- a/vendor/knative.dev/test-infra/scripts/library.sh
+++ b/vendor/knative.dev/test-infra/scripts/library.sh
@@ -479,22 +479,20 @@ function start_latest_knative_eventing() {
 #             $3..$n - parameters passed to the tool.
 function run_go_tool() {
   local tool=$2
-  if [[ -z "$(which ${tool})" ]]; then
-    local action=get
-    [[ $1 =~ ^[\./].* ]] && action=install
-    # Avoid running `go get` from root dir of the repository, as it can change go.sum and go.mod files.
-    # See discussions in https://github.com/golang/go/issues/27643.
-    if [[ ${action} == "get" && $(pwd) == "${REPO_ROOT_DIR}" ]]; then
-      local temp_dir="$(mktemp -d)"
-      local install_failed=0
-      # Swallow the output as we are returning the stdout in the end.
-      pushd "${temp_dir}" > /dev/null 2>&1
-      GOFLAGS="" go ${action} $1 || install_failed=1
-      popd > /dev/null 2>&1
-      (( install_failed )) && return ${install_failed}
-    else
-      GOFLAGS="" go ${action} $1
-    fi
+  local action=get
+  [[ $1 =~ ^[\./].* ]] && action=install
+  # Avoid running `go get` from root dir of the repository, as it can change go.sum and go.mod files.
+  # See discussions in https://github.com/golang/go/issues/27643.
+  if [[ ${action} == "get" && $(pwd) == "${REPO_ROOT_DIR}" ]]; then
+    local temp_dir="$(mktemp -d)"
+    local install_failed=0
+    # Swallow the output as we are returning the stdout in the end.
+    pushd "${temp_dir}" > /dev/null 2>&1
+    GOFLAGS="" go ${action} $1 || install_failed=1
+    popd > /dev/null 2>&1
+    (( install_failed )) && return ${install_failed}
+  else
+    GOFLAGS="" go ${action} $1
   fi
   shift 2
   ${tool} "$@"


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

Instead of passing a manually fetched config, we can now use the config that comes with the passed context to initialize controllers that need a config. Cuts down on boilerplate.

/assign @n3wscott 