### PR TITLE
GithubSource webhook role fix

### DIFF
--- a/github/config/201-clusterrole.yaml
+++ b/github/config/201-clusterrole.yaml
@@ -83,19 +83,6 @@ rules:
   - configmaps
   verbs: *everything
 
-# Namespace labelling for webhook
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - create
-  - update
-  - list
-  - watch
-  - patch
-
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/github/config/203-webhook-clusterrole.yaml
+++ b/github/config/203-webhook-clusterrole.yaml
@@ -102,6 +102,20 @@ rules:
     - "list"
     - "watch"
 
+# Namespace labelling for webhook
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+  - patch
+
+
 # For actually registering our webhook.
 - apiGroups:
   - "admissionregistration.k8s.io"


### PR DESCRIPTION
GithubSource webhook cannot access `namespace` resource after it was moved to separate deployment:

```
E0428 15:10:27.239494       1 reflector.go:123] runtime/asm_amd64.s:1373: Failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:knative-sources:github-webhook" cannot list resource "namespaces" in API group "" at the cluster scope
```
