### PR TITLE
Release WebSocket Sources image

### DIFF
--- a/config/tools/websocket-source/websocket-source.yaml
+++ b/config/tools/websocket-source/websocket-source.yaml
@@ -1,0 +1,26 @@
+# Copyright 2020 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a very simple Knative Eventing Source for consuming WebSocket (Secure) messages.
+apiVersion: sources.knative.dev/v1alpha2
+kind: ContainerSource
+metadata:
+  name: websocket-source
+spec:
+  image: ko://knative.dev/eventing-contrib/cmd/websocketsource
+  sink:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -35,6 +35,7 @@ COMPONENTS=(
   ["kafka-channel.yaml"]="kafka/channel/config"
   ["natss-channel.yaml"]="natss/config"
   ["prometheus-source.yaml"]="prometheus/config"
+  ["websocket-source.yaml"]="config/tools/websocket-source"
 )
 readonly COMPONENTS
 


### PR DESCRIPTION
## Proposed Changes

- currently we have no image build for the websocket source. This leads to people not seeing it, like in the first community meeting. Folks did build a _similar_ source, used as `ContainerSource`. With this PR we will get a visible released yaml, and the image

