### PR TITLE
Enabled tracing/logging/metrics in gitlab source

### DIFF
--- a/gitlab/pkg/reconciler/source/controller.go
+++ b/gitlab/pkg/reconciler/source/controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	"github.com/kelseyhightower/envconfig"
-	"knative.dev/eventing/pkg/reconciler/source"
 
 	//k8s.io imports
 	"k8s.io/client-go/kubernetes/scheme"
@@ -30,18 +29,18 @@ import (
 	serviceclient "knative.dev/serving/pkg/client/injection/client"
 	kserviceinformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/service"
 
-	//Injection imports
 	"knative.dev/eventing-contrib/gitlab/pkg/apis/sources/v1alpha1"
 	sourcescheme "knative.dev/eventing-contrib/gitlab/pkg/client/clientset/versioned/scheme"
 	gitlabclient "knative.dev/eventing-contrib/gitlab/pkg/client/injection/client"
 	gitlabinformer "knative.dev/eventing-contrib/gitlab/pkg/client/injection/informers/sources/v1alpha1/gitlabsource"
 	v1alpha1gitlabsource "knative.dev/eventing-contrib/gitlab/pkg/client/injection/reconciler/sources/v1alpha1/gitlabsource"
 
-	//knative.dev/pkg imports
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/resolver"
+
+	"knative.dev/eventing/pkg/reconciler/source"
 )
 
 type envConfig struct {

--- a/gitlab/pkg/reconciler/source/gitlabsource.go
+++ b/gitlab/pkg/reconciler/source/gitlabsource.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	appsv1listers "k8s.io/client-go/listers/apps/v1"
+	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/kmeta"
 
 	//knative.dev/serving imports
@@ -45,7 +46,6 @@ import (
 
 	//knative.dev/pkg imports
 
-	"knative.dev/pkg/logging"
 	"knative.dev/pkg/reconciler"
 	"knative.dev/pkg/resolver"
 )
@@ -66,7 +66,8 @@ type Reconciler struct {
 	sinkResolver     *resolver.URIResolver
 
 	loggingContext context.Context
-	loggingConfig  *logging.Config
+
+	configs *source.ConfigWatcher
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, source *sourcesv1alpha1.GitLabSource) reconciler.Event {
@@ -230,7 +231,8 @@ func (r *Reconciler) generateKnativeServiceObject(source *sourcesv1alpha1.GitLab
 	labels := map[string]string{
 		"receive-adapter": "gitlab",
 	}
-	env := []corev1.EnvVar{
+
+	env := append([]corev1.EnvVar{
 		{
 			Name: "GITLAB_SECRET_TOKEN",
 			ValueFrom: &corev1.EnvVarSource{
@@ -245,14 +247,8 @@ func (r *Reconciler) generateKnativeServiceObject(source *sourcesv1alpha1.GitLab
 		}, {
 			Name:  "METRICS_DOMAIN",
 			Value: "knative.dev/eventing",
-		}, {
-			Name:  "K_METRICS_CONFIG",
-			Value: "",
-		}, {
-			Name:  "K_LOGGING_CONFIG",
-			Value: "",
-		},
-	}
+		}},
+		r.configs.ToEnvVars()...)
 	return &servingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", source.Name),

--- a/go.mod
+++ b/go.mod
@@ -38,9 +38,9 @@ require (
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v12.0.0+incompatible
-	knative.dev/eventing v0.14.1-0.20200508130445-bc8943084002
+	knative.dev/eventing v0.14.1-0.20200508151645-a65602d38427
 	knative.dev/pkg v0.0.0-20200508041145-19b1d7b64df3
-	knative.dev/serving v0.14.1-0.20200508125645-16c19636983b
+	knative.dev/serving v0.14.1-0.20200508144754-1b8f6fc30e3f
 	knative.dev/test-infra v0.0.0-20200508015845-8d7d46a46176
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1521,8 +1521,8 @@ k8s.io/utils v0.0.0-20200124190032-861946025e34 h1:HjlUD6M0K3P8nRXmr2B9o4F9dUy9T
 k8s.io/utils v0.0.0-20200124190032-861946025e34/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 knative.dev/caching v0.0.0-20190719140829-2032732871ff/go.mod h1:dHXFU6CGlLlbzaWc32g80cR92iuBSpsslDNBWI8C7eg=
 knative.dev/caching v0.0.0-20200506161844-ca448db68d1e/go.mod h1:wz6R2jeEPHXnnjpClXymiumyqixYFb/2luEjZyI/wQE=
-knative.dev/eventing v0.14.1-0.20200508130445-bc8943084002 h1:Nuqu9evuluevqfVeMDrXNXeZlAlKM2A6kdW9M/0Hu6k=
-knative.dev/eventing v0.14.1-0.20200508130445-bc8943084002/go.mod h1:fO3vWf/dAXF3pvRV7M3M2GVEn5BoRo+7cfu3zZNrfo8=
+knative.dev/eventing v0.14.1-0.20200508151645-a65602d38427 h1:U0bFcTx3qri16kzO7BGQSxZPJWOVpj/5BySs/eTBzB8=
+knative.dev/eventing v0.14.1-0.20200508151645-a65602d38427/go.mod h1:fO3vWf/dAXF3pvRV7M3M2GVEn5BoRo+7cfu3zZNrfo8=
 knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/pkg v0.0.0-20191101194912-56c2594e4f11/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 knative.dev/pkg v0.0.0-20191111150521-6d806b998379/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
@@ -1535,8 +1535,8 @@ knative.dev/pkg v0.0.0-20200507011344-2581370e4a37 h1:1YJwMfDREOHhMFtNEOSDqGO4Dv
 knative.dev/pkg v0.0.0-20200507011344-2581370e4a37/go.mod h1:MUQe/bW75GmlVeyHmdKag77FJWQrNH3rxt2Q9E1JZJs=
 knative.dev/pkg v0.0.0-20200508041145-19b1d7b64df3 h1:qNt1XRLZriXPA6JLZvticQCWnNvJGiRaBPX34xlI2y8=
 knative.dev/pkg v0.0.0-20200508041145-19b1d7b64df3/go.mod h1:MUQe/bW75GmlVeyHmdKag77FJWQrNH3rxt2Q9E1JZJs=
-knative.dev/serving v0.14.1-0.20200508125645-16c19636983b h1:D3+W/sguQZgjsXnKRI8WNRAHIXim7Eas3ITZyJfZg7w=
-knative.dev/serving v0.14.1-0.20200508125645-16c19636983b/go.mod h1:aTmoynyk4W9q3naDb7072+sL1XSbA6w7Cox3HCnEDU8=
+knative.dev/serving v0.14.1-0.20200508144754-1b8f6fc30e3f h1:1LSXB3uXyY/8d1P2Hxk8nWUEJROxDdpenodYppvKPhA=
+knative.dev/serving v0.14.1-0.20200508144754-1b8f6fc30e3f/go.mod h1:aTmoynyk4W9q3naDb7072+sL1XSbA6w7Cox3HCnEDU8=
 knative.dev/test-infra v0.0.0-20200407185800-1b88cb3b45a5 h1:BEfxItc0hPeQmojxoiOwbCbmdVz0+L2SYWKUSQeFF8g=
 knative.dev/test-infra v0.0.0-20200407185800-1b88cb3b45a5/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=
 knative.dev/test-infra v0.0.0-20200430225942-f7c1fafc1cde/go.mod h1:xcdUkMJrLlBswIZqL5zCuBFOC22WIPMQoVX1L35i0vQ=

--- a/vendor/knative.dev/eventing/pkg/reconciler/source/config_watcher.go
+++ b/vendor/knative.dev/eventing/pkg/reconciler/source/config_watcher.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package source
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/configmap"
+	pkgLogging "knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
+	tracingconfig "knative.dev/pkg/tracing/config"
+
+	"knative.dev/eventing/pkg/logging"
+)
+
+type ConfigWatcher struct {
+	logger *zap.Logger
+
+	component string
+
+	loggingConfig *pkgLogging.Config
+	metricsConfig *metrics.ExporterOptions
+	tracingCfg    *tracingconfig.Config
+}
+
+func StartWatchingSourceConfigurations(loggingContext context.Context, component string, cmw configmap.Watcher) *ConfigWatcher {
+	cw := ConfigWatcher{
+		logger:    logging.FromContext(loggingContext),
+		component: component,
+	}
+
+	if dcmw, ok := cmw.(configmap.DefaultingWatcher); ok {
+		dcmw.WatchWithDefault(corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: pkgLogging.ConfigMapName()},
+			Data:       map[string]string{},
+		}, cw.UpdateFromLoggingConfigMap)
+		dcmw.WatchWithDefault(corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: metrics.ConfigMapName()},
+			Data:       map[string]string{},
+		}, cw.UpdateFromMetricsConfigMap)
+		dcmw.WatchWithDefault(corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: tracingconfig.ConfigName},
+			Data:       map[string]string{},
+		}, cw.UpdateFromTracingConfigMap)
+	} else {
+		cmw.Watch(pkgLogging.ConfigMapName(), cw.UpdateFromLoggingConfigMap)
+		cmw.Watch(metrics.ConfigMapName(), cw.UpdateFromMetricsConfigMap)
+		cmw.Watch(tracingconfig.ConfigName, cw.UpdateFromTracingConfigMap)
+	}
+
+	return &cw
+}
+
+func (r *ConfigWatcher) UpdateFromLoggingConfigMap(cfg *corev1.ConfigMap) {
+	if cfg != nil {
+		delete(cfg.Data, "_example")
+
+		logcfg, err := pkgLogging.NewConfigFromConfigMap(cfg)
+		if err != nil {
+			r.logger.Warn("failed to create logging config from configmap", zap.String("cfg.Name", cfg.Name))
+			return
+		}
+		r.loggingConfig = logcfg
+		r.logger.Debug("Update from logging ConfigMap", zap.Any("ConfigMap", cfg))
+	}
+}
+
+func (r *ConfigWatcher) UpdateFromMetricsConfigMap(cfg *corev1.ConfigMap) {
+	if cfg != nil {
+		delete(cfg.Data, "_example")
+
+		r.metricsConfig = &metrics.ExporterOptions{
+			Domain:    metrics.Domain(),
+			Component: r.component,
+			ConfigMap: cfg.Data,
+		}
+		r.logger.Debug("Update from metrics ConfigMap", zap.Any("ConfigMap", cfg))
+	}
+}
+
+func (r *ConfigWatcher) UpdateFromTracingConfigMap(cfg *corev1.ConfigMap) {
+	if cfg != nil {
+		delete(cfg.Data, "_example")
+
+		tracingCfg, err := tracingconfig.NewTracingConfigFromMap(cfg.Data)
+		if err != nil {
+			r.logger.Warn("failed to create tracing config from configmap", zap.String("cfg.Name", cfg.Name))
+			return
+		}
+
+		r.tracingCfg = tracingCfg
+		r.logger.Debug("Update from tracing ConfigMap", zap.Any("ConfigMap", cfg))
+	}
+}
+
+func (r *ConfigWatcher) LoggingConfig() *pkgLogging.Config {
+	if r == nil {
+		return nil
+	}
+	return r.loggingConfig
+}
+
+func (r *ConfigWatcher) MetricsConfig() *metrics.ExporterOptions {
+	if r == nil {
+		return nil
+	}
+	return r.metricsConfig
+}
+
+func (r *ConfigWatcher) TracingConfig() *tracingconfig.Config {
+	if r == nil {
+		return nil
+	}
+	return r.tracingCfg
+}
+
+func (r *ConfigWatcher) ToEnvVars() []corev1.EnvVar {
+	loggingConfig, err := pkgLogging.LoggingConfigToJson(r.LoggingConfig())
+	if err != nil {
+		r.logger.Warn("Error while serializing logging config", zap.Error(err))
+	}
+
+	metricsConfig, err := metrics.MetricsOptionsToJson(r.MetricsConfig())
+	if err != nil {
+		r.logger.Warn("Error while serializing metrics config", zap.Error(err))
+	}
+
+	tracingConfig, err := tracingconfig.TracingConfigToJson(r.TracingConfig())
+	if err != nil {
+		r.logger.Warn("Error while serializing tracing config", zap.Error(err))
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name:  "K_METRICS_CONFIG",
+			Value: metricsConfig,
+		}, {
+			Name:  "K_LOGGING_CONFIG",
+			Value: loggingConfig,
+		}, {
+			Name:  "K_TRACING_CONFIG",
+			Value: tracingConfig,
+		},
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -943,7 +943,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/eventing v0.14.1-0.20200508130445-bc8943084002
+# knative.dev/eventing v0.14.1-0.20200508151645-a65602d38427
 knative.dev/eventing/pkg/adapter/v2
 knative.dev/eventing/pkg/adapter/v2/test
 knative.dev/eventing/pkg/apis/config
@@ -1025,6 +1025,7 @@ knative.dev/eventing/pkg/logconfig
 knative.dev/eventing/pkg/logging
 knative.dev/eventing/pkg/reconciler/names
 knative.dev/eventing/pkg/reconciler/namespace/resources
+knative.dev/eventing/pkg/reconciler/source
 knative.dev/eventing/pkg/reconciler/testing
 knative.dev/eventing/pkg/tracing
 knative.dev/eventing/pkg/utils
@@ -1135,7 +1136,7 @@ knative.dev/pkg/webhook/psbinding
 knative.dev/pkg/webhook/resourcesemantics
 knative.dev/pkg/webhook/resourcesemantics/defaulting
 knative.dev/pkg/webhook/resourcesemantics/validation
-# knative.dev/serving v0.14.1-0.20200508125645-16c19636983b
+# knative.dev/serving v0.14.1-0.20200508144754-1b8f6fc30e3f
 knative.dev/serving/pkg/apis/autoscaling
 knative.dev/serving/pkg/apis/autoscaling/v1alpha1
 knative.dev/serving/pkg/apis/config


### PR DESCRIPTION
Fixes #1197

Now Gitlab source correctly follows logging/tracing/metrics config from the various config maps

This also updates eventing

**Release Note**

```release-note
Now GitLab source implementation picks configuration for tracing/logging/metrics from config maps config-tracing/config-logging/config-observability, defaulting to no-op if they're not found
```