### PR TITLE
Rename ConfigWatcher constructor, use ConfigAccessor interface

### DIFF
--- a/gitlab/pkg/reconciler/source/controller.go
+++ b/gitlab/pkg/reconciler/source/controller.go
@@ -62,7 +62,7 @@ func NewController(
 		gitlabClientSet:  gitlabclient.Get(ctx),
 		gitlabLister:     gitlabInformer.Lister(),
 		loggingContext:   ctx,
-		configs:          source.StartWatchingSourceConfigurations(ctx, "gitlab_controller", cmw),
+		configs:          source.WatchConfigurations(ctx, "gitlab_controller", cmw),
 	}
 
 	env := &envConfig{}

--- a/gitlab/pkg/reconciler/source/gitlabsource.go
+++ b/gitlab/pkg/reconciler/source/gitlabsource.go
@@ -67,7 +67,7 @@ type Reconciler struct {
 
 	loggingContext context.Context
 
-	configs *source.ConfigWatcher
+	configs source.ConfigAccessor
 }
 
 func (r *Reconciler) ReconcileKind(ctx context.Context, source *sourcesv1alpha1.GitLabSource) reconciler.Event {

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	k8s.io/api v0.17.4
 	k8s.io/apimachinery v0.17.4
 	k8s.io/client-go v12.0.0+incompatible
-	knative.dev/eventing v0.14.1-0.20200508151645-a65602d38427
+	knative.dev/eventing v0.14.1-0.20200511124346-685fe5fa1464
 	knative.dev/pkg v0.0.0-20200508041145-19b1d7b64df3
 	knative.dev/serving v0.14.1-0.20200508144754-1b8f6fc30e3f
 	knative.dev/test-infra v0.0.0-20200508015845-8d7d46a46176

--- a/go.sum
+++ b/go.sum
@@ -1523,8 +1523,8 @@ k8s.io/utils v0.0.0-20200124190032-861946025e34 h1:HjlUD6M0K3P8nRXmr2B9o4F9dUy9T
 k8s.io/utils v0.0.0-20200124190032-861946025e34/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 knative.dev/caching v0.0.0-20190719140829-2032732871ff/go.mod h1:dHXFU6CGlLlbzaWc32g80cR92iuBSpsslDNBWI8C7eg=
 knative.dev/caching v0.0.0-20200506161844-ca448db68d1e/go.mod h1:wz6R2jeEPHXnnjpClXymiumyqixYFb/2luEjZyI/wQE=
-knative.dev/eventing v0.14.1-0.20200508151645-a65602d38427 h1:U0bFcTx3qri16kzO7BGQSxZPJWOVpj/5BySs/eTBzB8=
-knative.dev/eventing v0.14.1-0.20200508151645-a65602d38427/go.mod h1:fO3vWf/dAXF3pvRV7M3M2GVEn5BoRo+7cfu3zZNrfo8=
+knative.dev/eventing v0.14.1-0.20200511124346-685fe5fa1464 h1:mtAgsWl8gGPCIOD4nGJJ30TnIArUdeKOgg7iItDsTmU=
+knative.dev/eventing v0.14.1-0.20200511124346-685fe5fa1464/go.mod h1:hJlo8k4fv9qwG5ylb5z6QzCk5oFlq7E30P+qluvj+Fk=
 knative.dev/eventing-contrib v0.6.1-0.20190723221543-5ce18048c08b/go.mod h1:SnXZgSGgMSMLNFTwTnpaOH7hXDzTFtw0J8OmHflNx3g=
 knative.dev/pkg v0.0.0-20191101194912-56c2594e4f11/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=
 knative.dev/pkg v0.0.0-20191111150521-6d806b998379/go.mod h1:pgODObA1dTyhNoFxPZTTjNWfx6F0aKsKzn+vaT9XO/Q=

--- a/kafka/source/pkg/reconciler/source/controller.go
+++ b/kafka/source/pkg/reconciler/source/controller.go
@@ -21,19 +21,19 @@ import (
 	"os"
 
 	"k8s.io/client-go/tools/cache"
+
 	"knative.dev/eventing/pkg/apis/sources/v1alpha1"
 	"knative.dev/eventing/pkg/reconciler/source"
+
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
 	deploymentinformer "knative.dev/pkg/client/injection/kube/informers/apps/v1/deployment"
-
-	kafkaclient "knative.dev/eventing-contrib/kafka/source/pkg/client/injection/client"
-	kafkainformer "knative.dev/eventing-contrib/kafka/source/pkg/client/injection/informers/sources/v1alpha1/kafkasource"
-
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/resolver"
 
+	kafkaclient "knative.dev/eventing-contrib/kafka/source/pkg/client/injection/client"
+	kafkainformer "knative.dev/eventing-contrib/kafka/source/pkg/client/injection/informers/sources/v1alpha1/kafkasource"
 	"knative.dev/eventing-contrib/kafka/source/pkg/client/injection/reconciler/sources/v1alpha1/kafkasource"
 )
 
@@ -58,7 +58,7 @@ func NewController(
 		deploymentLister:    deploymentInformer.Lister(),
 		receiveAdapterImage: raImage,
 		loggingContext:      ctx,
-		configs:             source.StartWatchingSourceConfigurations(ctx, component, cmw),
+		configs:             source.WatchConfigurations(ctx, component, cmw),
 	}
 
 	impl := kafkasource.NewImpl(ctx, c)

--- a/kafka/source/pkg/reconciler/source/kafkasource.go
+++ b/kafka/source/pkg/reconciler/source/kafkasource.go
@@ -96,7 +96,7 @@ type Reconciler struct {
 
 	sinkResolver *resolver.URIResolver
 
-	configs *source.ConfigWatcher
+	configs source.ConfigAccessor
 }
 
 // Check that our Reconciler implements Interface

--- a/kafka/source/pkg/reconciler/source/resources/receive_adapter_test.go
+++ b/kafka/source/pkg/reconciler/source/resources/receive_adapter_test.go
@@ -19,10 +19,11 @@ package resources
 import (
 	"testing"
 
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	bindingsv1alpha1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/bindings/v1alpha1"
 	"knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1alpha1"
 	"knative.dev/pkg/kmp"
@@ -103,7 +104,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 	})
 
 	one := int32(1)
-	want := &v1.Deployment{
+	want := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    "source-namespace",
 			GenerateName: "source-name-",
@@ -112,7 +113,7 @@ func TestMakeReceiveAdapter(t *testing.T) {
 				"test-key2": "test-value2",
 			},
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"test-key1": "test-value1",
@@ -274,7 +275,7 @@ func TestMakeReceiveAdapterNoNet(t *testing.T) {
 	})
 
 	one := int32(1)
-	want := &v1.Deployment{
+	want := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    "source-namespace",
 			GenerateName: "source-name-",
@@ -283,7 +284,7 @@ func TestMakeReceiveAdapterNoNet(t *testing.T) {
 				"test-key2": "test-value2",
 			},
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"test-key1": "test-value1",
@@ -504,7 +505,7 @@ func TestMakeReceiveAdapterKeyType(t *testing.T) {
 	})
 
 	one := int32(1)
-	want := &v1.Deployment{
+	want := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    "source-namespace",
 			GenerateName: "source-name-",
@@ -513,7 +514,7 @@ func TestMakeReceiveAdapterKeyType(t *testing.T) {
 				"test-key2": "test-value2",
 			},
 		},
-		Spec: v1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"test-key1": "test-value1",

--- a/vendor/knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1alpha1/broker/reconciler.go
+++ b/vendor/knative.dev/eventing/pkg/client/injection/reconciler/eventing/v1alpha1/broker/reconciler.go
@@ -20,15 +20,15 @@ package broker
 
 import (
 	context "context"
-	"encoding/json"
-	"reflect"
+	json "encoding/json"
+	reflect "reflect"
 
 	zap "go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
+	equality "k8s.io/apimachinery/pkg/api/equality"
 	errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+	types "k8s.io/apimachinery/pkg/types"
 	sets "k8s.io/apimachinery/pkg/util/sets"
 	cache "k8s.io/client-go/tools/cache"
 	record "k8s.io/client-go/tools/record"

--- a/vendor/knative.dev/eventing/pkg/reconciler/source/config_watcher.go
+++ b/vendor/knative.dev/eventing/pkg/reconciler/source/config_watcher.go
@@ -20,143 +20,263 @@ import (
 	"context"
 
 	"go.uber.org/zap"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/configmap"
-	pkgLogging "knative.dev/pkg/logging"
-	"knative.dev/pkg/metrics"
-	tracingconfig "knative.dev/pkg/tracing/config"
 
 	"knative.dev/eventing/pkg/logging"
+	"knative.dev/pkg/configmap"
+	pkglogging "knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
+	tracingconfig "knative.dev/pkg/tracing/config"
 )
 
+const (
+	EnvLoggingCfg = "K_LOGGING_CONFIG"
+	EnvMetricsCfg = "K_METRICS_CONFIG"
+	EnvTracingCfg = "K_TRACING_CONFIG"
+)
+
+type ConfigAccessor interface {
+	ToEnvVars() []corev1.EnvVar
+	LoggingConfig() *pkglogging.Config
+	MetricsConfig() *metrics.ExporterOptions
+	TracingConfig() *tracingconfig.Config
+}
+
+var _ ConfigAccessor = (*ConfigWatcher)(nil)
+
+// ConfigWatcher keeps track of logging, metrics and tracing configurations by
+// watching corresponding ConfigMaps.
 type ConfigWatcher struct {
 	logger *zap.Logger
 
 	component string
 
-	loggingConfig *pkgLogging.Config
-	metricsConfig *metrics.ExporterOptions
-	tracingCfg    *tracingconfig.Config
+	// configurations remain nil if disabled
+	loggingCfg *pkglogging.Config
+	metricsCfg *metrics.ExporterOptions
+	tracingCfg *tracingconfig.Config
 }
 
-func StartWatchingSourceConfigurations(loggingContext context.Context, component string, cmw configmap.Watcher) *ConfigWatcher {
-	cw := ConfigWatcher{
-		logger:    logging.FromContext(loggingContext),
+// configWatcherOption is a function option for ConfigWatchers.
+type configWatcherOption func(*ConfigWatcher, configmap.Watcher)
+
+// WatchConfigurations returns a ConfigWatcher initialized with the given
+// options. If no option is passed, the ConfigWatcher observes ConfigMaps for
+// logging, metrics and tracing.
+func WatchConfigurations(loggingCtx context.Context, component string,
+	cmw configmap.Watcher, opts ...configWatcherOption) *ConfigWatcher {
+
+	cw := &ConfigWatcher{
+		logger:    logging.FromContext(loggingCtx),
 		component: component,
 	}
 
+	if len(opts) == 0 {
+		WithLogging(cw, cmw)
+		WithMetrics(cw, cmw)
+		WithTracing(cw, cmw)
+
+	} else {
+		for _, opt := range opts {
+			opt(cw, cmw)
+		}
+	}
+
+	return cw
+}
+
+// WithLogging observes a logging ConfigMap.
+func WithLogging(cw *ConfigWatcher, cmw configmap.Watcher) {
+	cw.loggingCfg = &pkglogging.Config{}
+	watchConfigMap(cmw, pkglogging.ConfigMapName(), cw.updateFromLoggingConfigMap)
+}
+
+// WithMetrics observes a metrics ConfigMap.
+func WithMetrics(cw *ConfigWatcher, cmw configmap.Watcher) {
+	cw.metricsCfg = &metrics.ExporterOptions{}
+	watchConfigMap(cmw, metrics.ConfigMapName(), cw.updateFromMetricsConfigMap)
+}
+
+// WithTracing observes a tracing ConfigMap.
+func WithTracing(cw *ConfigWatcher, cmw configmap.Watcher) {
+	cw.tracingCfg = &tracingconfig.Config{}
+	watchConfigMap(cmw, tracingconfig.ConfigName, cw.updateFromTracingConfigMap)
+}
+
+func watchConfigMap(cmw configmap.Watcher, cmName string, obs configmap.Observer) {
 	if dcmw, ok := cmw.(configmap.DefaultingWatcher); ok {
 		dcmw.WatchWithDefault(corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: pkgLogging.ConfigMapName()},
+			ObjectMeta: metav1.ObjectMeta{Name: cmName},
 			Data:       map[string]string{},
-		}, cw.UpdateFromLoggingConfigMap)
-		dcmw.WatchWithDefault(corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: metrics.ConfigMapName()},
-			Data:       map[string]string{},
-		}, cw.UpdateFromMetricsConfigMap)
-		dcmw.WatchWithDefault(corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{Name: tracingconfig.ConfigName},
-			Data:       map[string]string{},
-		}, cw.UpdateFromTracingConfigMap)
+		}, obs)
+
 	} else {
-		cmw.Watch(pkgLogging.ConfigMapName(), cw.UpdateFromLoggingConfigMap)
-		cmw.Watch(metrics.ConfigMapName(), cw.UpdateFromMetricsConfigMap)
-		cmw.Watch(tracingconfig.ConfigName, cw.UpdateFromTracingConfigMap)
-	}
-
-	return &cw
-}
-
-func (r *ConfigWatcher) UpdateFromLoggingConfigMap(cfg *corev1.ConfigMap) {
-	if cfg != nil {
-		delete(cfg.Data, "_example")
-
-		logcfg, err := pkgLogging.NewConfigFromConfigMap(cfg)
-		if err != nil {
-			r.logger.Warn("failed to create logging config from configmap", zap.String("cfg.Name", cfg.Name))
-			return
-		}
-		r.loggingConfig = logcfg
-		r.logger.Debug("Update from logging ConfigMap", zap.Any("ConfigMap", cfg))
+		cmw.Watch(cmName, obs)
 	}
 }
 
-func (r *ConfigWatcher) UpdateFromMetricsConfigMap(cfg *corev1.ConfigMap) {
-	if cfg != nil {
-		delete(cfg.Data, "_example")
-
-		r.metricsConfig = &metrics.ExporterOptions{
-			Domain:    metrics.Domain(),
-			Component: r.component,
-			ConfigMap: cfg.Data,
-		}
-		r.logger.Debug("Update from metrics ConfigMap", zap.Any("ConfigMap", cfg))
-	}
-}
-
-func (r *ConfigWatcher) UpdateFromTracingConfigMap(cfg *corev1.ConfigMap) {
-	if cfg != nil {
-		delete(cfg.Data, "_example")
-
-		tracingCfg, err := tracingconfig.NewTracingConfigFromMap(cfg.Data)
-		if err != nil {
-			r.logger.Warn("failed to create tracing config from configmap", zap.String("cfg.Name", cfg.Name))
-			return
-		}
-
-		r.tracingCfg = tracingCfg
-		r.logger.Debug("Update from tracing ConfigMap", zap.Any("ConfigMap", cfg))
-	}
-}
-
-func (r *ConfigWatcher) LoggingConfig() *pkgLogging.Config {
-	if r == nil {
+// LoggingConfig returns the logging configuration from the ConfigWatcher.
+func (cw *ConfigWatcher) LoggingConfig() *pkglogging.Config {
+	if cw == nil {
 		return nil
 	}
-	return r.loggingConfig
+	return cw.loggingCfg
 }
 
-func (r *ConfigWatcher) MetricsConfig() *metrics.ExporterOptions {
-	if r == nil {
+// MetricsConfig returns the metrics configuration from the ConfigWatcher.
+func (cw *ConfigWatcher) MetricsConfig() *metrics.ExporterOptions {
+	if cw == nil {
 		return nil
 	}
-	return r.metricsConfig
+	return cw.metricsCfg
 }
 
-func (r *ConfigWatcher) TracingConfig() *tracingconfig.Config {
-	if r == nil {
+// TracingConfig returns the tracing configuration from the ConfigWatcher.
+func (cw *ConfigWatcher) TracingConfig() *tracingconfig.Config {
+	if cw == nil {
 		return nil
 	}
-	return r.tracingCfg
+	return cw.tracingCfg
 }
 
-func (r *ConfigWatcher) ToEnvVars() []corev1.EnvVar {
-	loggingConfig, err := pkgLogging.LoggingConfigToJson(r.LoggingConfig())
-	if err != nil {
-		r.logger.Warn("Error while serializing logging config", zap.Error(err))
+func (cw *ConfigWatcher) updateFromLoggingConfigMap(cfg *corev1.ConfigMap) {
+	if cfg == nil {
+		return
 	}
 
-	metricsConfig, err := metrics.MetricsOptionsToJson(r.MetricsConfig())
+	delete(cfg.Data, "_example")
+
+	loggingCfg, err := pkglogging.NewConfigFromConfigMap(cfg)
 	if err != nil {
-		r.logger.Warn("Error while serializing metrics config", zap.Error(err))
+		cw.logger.Warn("failed to create logging config from ConfigMap", zap.String("cfg.Name", cfg.Name))
+		return
 	}
 
-	tracingConfig, err := tracingconfig.TracingConfigToJson(r.TracingConfig())
-	if err != nil {
-		r.logger.Warn("Error while serializing tracing config", zap.Error(err))
+	cw.loggingCfg = loggingCfg
+
+	cw.logger.Debug("Updated logging config from ConfigMap", zap.Any("ConfigMap", cfg))
+}
+
+func (cw *ConfigWatcher) updateFromMetricsConfigMap(cfg *corev1.ConfigMap) {
+	if cfg == nil {
+		return
 	}
 
+	delete(cfg.Data, "_example")
+
+	cw.metricsCfg = &metrics.ExporterOptions{
+		Domain:    metrics.Domain(),
+		Component: cw.component,
+		ConfigMap: cfg.Data,
+	}
+
+	cw.logger.Debug("Updated metrics config from ConfigMap", zap.Any("ConfigMap", cfg))
+}
+
+func (cw *ConfigWatcher) updateFromTracingConfigMap(cfg *corev1.ConfigMap) {
+	if cfg == nil {
+		return
+	}
+
+	delete(cfg.Data, "_example")
+
+	tracingCfg, err := tracingconfig.NewTracingConfigFromMap(cfg.Data)
+	if err != nil {
+		cw.logger.Warn("failed to create tracing config from ConfigMap", zap.String("cfg.Name", cfg.Name))
+		return
+	}
+
+	cw.tracingCfg = tracingCfg
+
+	cw.logger.Debug("Updated tracing config from ConfigMap", zap.Any("ConfigMap", cfg))
+}
+
+// ToEnvVars serializes the contents of the ConfigWatcher to individual
+// environment variables.
+func (cw *ConfigWatcher) ToEnvVars() []corev1.EnvVar {
+	envs := make([]corev1.EnvVar, 0, 3)
+
+	envs = maybeAppendEnvVar(envs, cw.loggingConfigEnvVar(), cw.LoggingConfig() != nil)
+	envs = maybeAppendEnvVar(envs, cw.metricsConfigEnvVar(), cw.MetricsConfig() != nil)
+	envs = maybeAppendEnvVar(envs, cw.tracingConfigEnvVar(), cw.TracingConfig() != nil)
+
+	return envs
+}
+
+// maybeAppendEnvVar appends an EnvVar only if the condition boolean is true.
+func maybeAppendEnvVar(envs []corev1.EnvVar, env corev1.EnvVar, cond bool) []corev1.EnvVar {
+	if !cond {
+		return envs
+	}
+
+	return append(envs, env)
+}
+
+// loggingConfigEnvVar returns an EnvVar containing the serialized logging
+// configuration from the ConfigWatcher.
+func (cw *ConfigWatcher) loggingConfigEnvVar() corev1.EnvVar {
+	cfg, err := pkglogging.LoggingConfigToJson(cw.LoggingConfig())
+	if err != nil {
+		cw.logger.Warn("Error while serializing logging config", zap.Error(err))
+	}
+
+	return corev1.EnvVar{
+		Name:  EnvLoggingCfg,
+		Value: cfg,
+	}
+}
+
+// metricsConfigEnvVar returns an EnvVar containing the serialized metrics
+// configuration from the ConfigWatcher.
+func (cw *ConfigWatcher) metricsConfigEnvVar() corev1.EnvVar {
+	cfg, err := metrics.MetricsOptionsToJson(cw.MetricsConfig())
+	if err != nil {
+		cw.logger.Warn("Error while serializing metrics config", zap.Error(err))
+	}
+
+	return corev1.EnvVar{
+		Name:  EnvMetricsCfg,
+		Value: cfg,
+	}
+}
+
+// tracingConfigEnvVar returns an EnvVar containing the serialized tracing
+// configuration from the ConfigWatcher.
+func (cw *ConfigWatcher) tracingConfigEnvVar() corev1.EnvVar {
+	cfg, err := tracingconfig.TracingConfigToJson(cw.TracingConfig())
+	if err != nil {
+		cw.logger.Warn("Error while serializing tracing config", zap.Error(err))
+	}
+
+	return corev1.EnvVar{
+		Name:  EnvTracingCfg,
+		Value: cfg,
+	}
+}
+
+// EmptyVarsGenerator generates empty env vars. Intended to be used in tests.
+type EmptyVarsGenerator struct{}
+
+var _ ConfigAccessor = (*EmptyVarsGenerator)(nil)
+
+func (g *EmptyVarsGenerator) ToEnvVars() []corev1.EnvVar {
 	return []corev1.EnvVar{
-		{
-			Name:  "K_METRICS_CONFIG",
-			Value: metricsConfig,
-		}, {
-			Name:  "K_LOGGING_CONFIG",
-			Value: loggingConfig,
-		}, {
-			Name:  "K_TRACING_CONFIG",
-			Value: tracingConfig,
-		},
+		{Name: EnvLoggingCfg},
+		{Name: EnvMetricsCfg},
+		{Name: EnvTracingCfg},
 	}
+}
+
+func (*EmptyVarsGenerator) LoggingConfig() *pkglogging.Config {
+	return nil
+}
+
+func (*EmptyVarsGenerator) MetricsConfig() *metrics.ExporterOptions {
+	return nil
+}
+
+func (*EmptyVarsGenerator) TracingConfig() *tracingconfig.Config {
+	return nil
 }

--- a/vendor/knative.dev/eventing/test/conformance/helpers/channel.go
+++ b/vendor/knative.dev/eventing/test/conformance/helpers/channel.go
@@ -27,6 +27,10 @@ import (
 	eventingduckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
 )
 
+const (
+	SubscribableAnnotationKey = "messaging.knative.dev/subscribable"
+)
+
 func getChannelDuckTypeSupportVersion(channelName string, client *lib.Client, channel *metav1.TypeMeta) (string, error) {
 	metaResource := resources.NewMetaResource(channelName, client.Namespace, channel)
 	obj, err := duck.GetGenericObject(client.Dynamic, metaResource, &eventingduckv1beta1.Channelable{})

--- a/vendor/knative.dev/eventing/test/conformance/helpers/channel_status_subscriber_test_helper.go
+++ b/vendor/knative.dev/eventing/test/conformance/helpers/channel_status_subscriber_test_helper.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"testing"
+
+	duckv1beta1 "knative.dev/eventing/pkg/apis/duck/v1beta1"
+	eventingv1alpha1 "knative.dev/eventing/pkg/apis/messaging/v1alpha1"
+	"knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ChannelStatusSubscriberTestHelperWithChannelTestRunner runs the tests of
+// subscriber field of status for all Channels in the ChannelTestRunner.
+func ChannelStatusSubscriberTestHelperWithChannelTestRunner(
+	t *testing.T,
+	channelTestRunner lib.ChannelTestRunner,
+	options ...lib.SetupClientOption,
+) {
+
+	channelTestRunner.RunTests(t, lib.FeatureBasic, func(st *testing.T, channel metav1.TypeMeta) {
+		client := lib.Setup(st, true, options...)
+		defer lib.TearDown(client)
+
+		t.Run("Channel has required status subscriber fields", func(t *testing.T) {
+			channelHasRequiredSubscriberStatus(st, client, channel, options...)
+		})
+	})
+}
+
+func channelHasRequiredSubscriberStatus(st *testing.T, client *lib.Client, channel metav1.TypeMeta, options ...lib.SetupClientOption) {
+	st.Logf("Running channel subscriber status conformance test with channel %q", channel)
+
+	channelName := "channel-req-status-subscriber"
+	subscriberServiceName := "channel-req-status-subscriber-svc"
+
+	client.T.Logf("Creating channel %+v-%s", channel, channelName)
+	client.CreateChannelOrFail(channelName, &channel)
+	client.WaitForResourceReadyOrFail(channelName, &channel)
+
+	pod := resources.EventDetailsPod(subscriberServiceName + "-pod")
+	client.CreatePodOrFail(pod, lib.WithService(subscriberServiceName))
+
+	subscription := client.CreateSubscriptionOrFail(
+		subscriberServiceName,
+		channelName,
+		&channel,
+		resources.WithSubscriberForSubscription(subscriberServiceName),
+	)
+
+	// wait for all test resources to be ready, so that we can start sending events
+	client.WaitForAllTestResourcesReadyOrFail()
+
+	dtsv, err := getChannelDuckTypeSupportVersion(channelName, client, &channel)
+	if err != nil {
+		st.Fatalf("Unable to check Channel duck type support version for %q: %q", channel, err)
+	}
+
+	if dtsv == "" || dtsv == "v1alpha1" {
+		// treat missing annotation value as v1alpha1, as written in the spec
+		channelable, err := getChannelAsV1Alpha1Channelable(channelName, client, channel)
+		if err != nil {
+			st.Fatalf("Unable to get channel %q to v1alpha1 duck type: %q", channel, err)
+		}
+
+		// SPEC:  Each subscription to a channel is added to the channel status.subscribableStatus.subscribers automatically.
+		if channelable.Status.SubscribableStatus == nil || channelable.Status.SubscribableStatus.Subscribers == nil {
+			st.Fatalf("%q does not have status.subscribers", channel)
+		}
+		ss := findSubscriberStatus(channelable.Status.SubscribableStatus.Subscribers, subscription)
+		if ss == nil {
+			st.Fatalf("No subscription status found for channel %q and subscription %v", channel, subscription)
+		}
+
+		// SPEC: The ready field of the subscriber identified by its uid MUST be set to True when the subscription is ready to be processed.
+		if ss.Ready != corev1.ConditionTrue {
+			st.Fatalf("Subscription not ready found for channel %q and subscription %v", channel, subscription)
+		}
+	} else if dtsv == "v1beta1" {
+		channelable, err := getChannelAsV1Beta1Channelable(channelName, client, channel)
+		if err != nil {
+			st.Fatalf("Unable to get channel %q to v1beta1 duck type: %q", channel, err)
+		}
+
+		// SPEC: Each subscription to a channel is added to the channel status.subscribers automatically.
+		if channelable.Status.Subscribers == nil {
+			st.Fatalf("%q does not have status.subscribers", channel)
+		}
+		ss := findSubscriberStatus(channelable.Status.Subscribers, subscription)
+		if ss == nil {
+			st.Fatalf("No subscription status found for channel %q and subscription %v", channel, subscription)
+		}
+
+		// SPEC: The ready field of the subscriber identified by its uid MUST be set to True when the subscription is ready to be processed.
+		if ss.Ready != corev1.ConditionTrue {
+			st.Fatalf("Subscription not ready found for channel %q and subscription %v", channel, subscription)
+		}
+	} else {
+		st.Fatalf("Channel doesn't support v1alpha1 nor v1beta1 Channel duck types: %v", channel)
+	}
+}
+
+func findSubscriberStatus(statusArr []duckv1beta1.SubscriberStatus, subscription *eventingv1alpha1.Subscription) *duckv1beta1.SubscriberStatus {
+	for _, v := range statusArr {
+		if v.UID == subscription.UID {
+			return &v
+		}
+	}
+	return nil
+}

--- a/vendor/knative.dev/eventing/test/conformance/helpers/channel_status_test_helper.go
+++ b/vendor/knative.dev/eventing/test/conformance/helpers/channel_status_test_helper.go
@@ -24,11 +24,7 @@ import (
 	"knative.dev/eventing/test/lib"
 )
 
-const (
-	SubscribableAnnotationKey = "messaging.knative.dev/subscribable"
-)
-
-// ChannelStatusTestHelperWithChannelTestRunner runs the Channel metadata tests for all Channels in
+// ChannelStatusTestHelperWithChannelTestRunner runs the Channel status tests for all Channels in
 // the ChannelTestRunner.
 func ChannelStatusTestHelperWithChannelTestRunner(
 	t *testing.T,
@@ -49,7 +45,7 @@ func ChannelStatusTestHelperWithChannelTestRunner(
 func channelHasRequiredStatus(st *testing.T, client *lib.Client, channel metav1.TypeMeta, options ...lib.SetupClientOption) {
 	st.Logf("Running channel status conformance test with channel %q", channel)
 
-	channelName := "channel-req-labels"
+	channelName := "channel-req-status"
 
 	client.T.Logf("Creating channel %+v-%s", channel, channelName)
 	client.CreateChannelOrFail(channelName, &channel)

--- a/vendor/knative.dev/eventing/test/lib/creation.go
+++ b/vendor/knative.dev/eventing/test/lib/creation.go
@@ -83,7 +83,7 @@ func (client *Client) CreateSubscriptionOrFail(
 	name, channelName string,
 	channelTypeMeta *metav1.TypeMeta,
 	options ...resources.SubscriptionOption,
-) {
+) *messagingv1alpha1.Subscription {
 	namespace := client.Namespace
 	subscription := resources.Subscription(name, channelName, channelTypeMeta, options...)
 	subscriptions := client.Eventing.MessagingV1alpha1().Subscriptions(namespace)
@@ -94,6 +94,7 @@ func (client *Client) CreateSubscriptionOrFail(
 		client.T.Fatalf("Failed to create subscription %q: %v", name, err)
 	}
 	client.Tracker.AddObj(subscription)
+	return subscription
 }
 
 // CreateSubscriptionOrFailV1Beta1 will create a Subscription or fail the test if there is an error.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -943,7 +943,7 @@ k8s.io/utils/buffer
 k8s.io/utils/integer
 k8s.io/utils/pointer
 k8s.io/utils/trace
-# knative.dev/eventing v0.14.1-0.20200508151645-a65602d38427
+# knative.dev/eventing v0.14.1-0.20200511124346-685fe5fa1464
 knative.dev/eventing/pkg/adapter/v2
 knative.dev/eventing/pkg/adapter/v2/test
 knative.dev/eventing/pkg/apis/config


### PR DESCRIPTION
Necessary after the breaking changes introduced in knative/eventing#3109