### PR TITLE
awssqs source - fix README.md to be consistent with secret yaml

### DIFF
--- a/awssqs/samples/README.md
+++ b/awssqs/samples/README.md
@@ -54,7 +54,7 @@ aws_secret_access_key = ...
 Then create a secret for the downloaded key:
 
 ```shell
-kubectl -n knative-sources create secret generic awssqs-source-credentials --from-file=credentials=PATH_TO_CREDENTIALS_FILE
+kubectl -n knative-sources create secret generic awssqs-credentials --from-file=credentials=PATH_TO_CREDENTIALS_FILE
 ```
 
 ### Set up [Kube2IAM](https://github.com/jtblin/kube2iam) credentials


### PR DESCRIPTION
README.md used awssqs-source-credentials while awssqs-source.yaml used
aws-credentials.  Just have both use aws-credentials for the secretname


----

#