### PR TITLE
Channel conformance test spec subscriber

### DIFF
--- a/test/conformance/channel_spec_test.go
+++ b/test/conformance/channel_spec_test.go
@@ -1,0 +1,30 @@
+//+build e2e
+
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conformance
+
+import (
+	"testing"
+
+	eventingconformancehelpers "knative.dev/eventing/test/conformance/helpers"
+	"knative.dev/eventing/test/lib"
+)
+
+func TestChannelSpec(t *testing.T) {
+	eventingconformancehelpers.ChannelSpecTestHelperWithChannelTestRunner(t, channelTestRunner, lib.SetupClientOptionNoop)
+}


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Enable the conformance tests implemented at https://github.com/knative/eventing/pull/3050

I couldn't wait until @mattmoor 's bot send a PR for the dependency updates and I also pushed a commit for that.