### PR TITLE
Prometheus source now supports logging/metrics/tracing CMs

### DIFF
--- a/prometheus/pkg/reconciler/controller.go
+++ b/prometheus/pkg/reconciler/controller.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/eventing-contrib/prometheus/pkg/apis/sources/v1alpha1"
+	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/logging"
@@ -50,6 +51,7 @@ func NewController(
 	r := &Reconciler{
 		kubeClientSet:    kubeclient.Get(ctx),
 		deploymentLister: deploymentInformer.Lister(),
+		configs:          source.WatchConfigurations(ctx, controllerAgentName, cmw),
 	}
 	impl := promreconciler.NewImpl(ctx, r)
 	r.sinkResolver = resolver.NewURIResolver(ctx, impl.EnqueueKey)

--- a/prometheus/pkg/reconciler/prometheussource.go
+++ b/prometheus/pkg/reconciler/prometheussource.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"k8s.io/client-go/kubernetes"
+	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/controller"
 
 	"github.com/kelseyhightower/envconfig"
@@ -65,6 +66,7 @@ type Reconciler struct {
 	deploymentLister appsv1listers.DeploymentLister
 
 	sinkResolver *resolver.URIResolver
+	configs      *source.ConfigWatcher
 }
 
 var _ promreconciler.Interface = (*Reconciler)(nil)
@@ -127,11 +129,12 @@ func (r *Reconciler) createReceiveAdapter(ctx context.Context, src *v1alpha1.Pro
 	}
 
 	adapterArgs := resources.ReceiveAdapterArgs{
-		EventSource: eventSource,
-		Image:       env.Image,
-		Source:      src,
-		Labels:      resources.Labels(src.Name),
-		SinkURI:     sinkURI.String(),
+		EventSource:    eventSource,
+		Image:          env.Image,
+		Source:         src,
+		Labels:         resources.Labels(src.Name),
+		SinkURI:        sinkURI.String(),
+		AdditionalEnvs: r.configs.ToEnvVars(),
 	}
 	expected := resources.MakeReceiveAdapter(&adapterArgs)
 

--- a/prometheus/pkg/reconciler/resources/receive_adapter.go
+++ b/prometheus/pkg/reconciler/resources/receive_adapter.go
@@ -31,11 +31,12 @@ import (
 // ReceiveAdapterArgs are the arguments needed to create a Prometheus Receive Adapter.
 // Every field is required.
 type ReceiveAdapterArgs struct {
-	EventSource string
-	Image       string
-	Source      *v1alpha1.PrometheusSource
-	Labels      map[string]string
-	SinkURI     string
+	EventSource    string
+	Image          string
+	Source         *v1alpha1.PrometheusSource
+	Labels         map[string]string
+	SinkURI        string
+	AdditionalEnvs []corev1.EnvVar
 }
 
 // MakeReceiveAdapter generates (but does not insert into K8s) the Receive Adapter Deployment for
@@ -66,7 +67,10 @@ func MakeReceiveAdapter(args *ReceiveAdapterArgs) *v1.Deployment {
 						{
 							Name:  "receive-adapter",
 							Image: args.Image,
-							Env:   makeEnv(args.EventSource, args.SinkURI, &args.Source.Spec),
+							Env: append(
+								makeEnv(args.EventSource, args.SinkURI, &args.Source.Spec),
+								args.AdditionalEnvs...,
+							),
 						},
 					},
 				},
@@ -132,11 +136,5 @@ func makeEnv(eventSource, sinkURI string, spec *v1alpha1.PrometheusSourceSpec) [
 	}, {
 		Name:  "METRICS_DOMAIN",
 		Value: "knative.dev/eventing",
-	}, {
-		Name:  "K_METRICS_CONFIG",
-		Value: "",
-	}, {
-		Name:  "K_LOGGING_CONFIG",
-		Value: "",
 	}}
 }


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Fixes #1196

## Proposed Changes

- PrometheusSource controller now uses source.WatchConfigurations to watch logging/metrics/tracing CMs