### PR TITLE
Rename deprecated filter functions to new versions.

### DIFF
--- a/awssqs/pkg/reconciler/controller.go
+++ b/awssqs/pkg/reconciler/controller.go
@@ -68,7 +68,7 @@ func NewController(
 	awssqssourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupVersionKind(v1alpha1.SchemeGroupVersion.WithKind("AwsSqsSource")),
+		FilterFunc: controller.FilterControllerGVK(v1alpha1.SchemeGroupVersion.WithKind("AwsSqsSource")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/camel/source/pkg/reconciler/controller.go
+++ b/camel/source/pkg/reconciler/controller.go
@@ -57,7 +57,7 @@ func NewController(
 
 	_ = camelIntegrationInformer
 	camelIntegrationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1alpha1.Kind("CamelSource")),
+		FilterFunc: controller.FilterControllerGK(v1alpha1.Kind("CamelSource")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/couchdb/source/pkg/reconciler/controller.go
+++ b/couchdb/source/pkg/reconciler/controller.go
@@ -71,7 +71,7 @@ func NewController(
 	couchdbSourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1alpha1.Kind("CouchDbSource")),
+		FilterFunc: controller.FilterControllerGK(v1alpha1.Kind("CouchDbSource")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/github/pkg/reconciler/source/controller.go
+++ b/github/pkg/reconciler/source/controller.go
@@ -73,7 +73,7 @@ func NewController(
 	githubInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	serviceInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1alpha1.Kind("GitHubSource")),
+		FilterFunc: controller.FilterControllerGK(v1alpha1.Kind("GitHubSource")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/kafka/source/pkg/reconciler/source/controller.go
+++ b/kafka/source/pkg/reconciler/source/controller.go
@@ -69,7 +69,7 @@ func NewController(
 	kafkaInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1alpha1.Kind("KafkaSource")),
+		FilterFunc: controller.FilterControllerGK(v1alpha1.Kind("KafkaSource")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 

--- a/prometheus/pkg/reconciler/controller.go
+++ b/prometheus/pkg/reconciler/controller.go
@@ -58,7 +58,7 @@ func NewController(
 	prometheusSourceInformer.Informer().AddEventHandler(controller.HandleAll(impl.Enqueue))
 
 	deploymentInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controller.FilterGroupKind(v1alpha1.Kind("PrometheusSource")),
+		FilterFunc: controller.FilterControllerGK(v1alpha1.Kind("PrometheusSource")),
 		Handler:    controller.HandleAll(impl.EnqueueControllerOf),
 	})
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

As per title. The old `FilterGroup[Version]Kind` are deprecated and replaced by new ones that read a bit better.