### PR TITLE
Add TOC as approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,7 @@
 # In order to be an approver you need to be an approver in the eventing repo
 # or fulfill the requirements in https://github.com/knative/community/blob/master/ROLES.md#approver
 approvers:
-- evankanderson
+- toc
 - grantr
 - Harwayne
 - vaikas
@@ -15,7 +15,6 @@ approvers:
 # list. To add reviewers while spreading the load among existing approvers,
 # copy the approvers to the reviewers list too.
 reviewers:
-- evankanderson
 - grantr
 - Harwayne
 - vaikas

--- a/OWNERS
+++ b/OWNERS
@@ -22,6 +22,7 @@ reviewers:
 - matzew
 - nachocano
 - lionelvillard
+- slinkydeveloper
 # Add reviewers below
 - aslom
 - lberk

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,4 +1,11 @@
 aliases:
+  toc:
+  - evankanderson
+  - grantr
+  - markusthoemmes
+  - mattmoor
+  - tcnghia
+
   # These aliases are for OWNERS of the various Source implementations. These
   # Are in addition to the repo level OWNERS.
 


### PR DESCRIPTION
Making TOC members approvers in every repository for consistency. An alias keeps this separate from repo-native approvers.

Also added @slinkydeveloper as reviewer in addition to approver, since all the other approvers are also listed as reviewers.

@markusthoemmes 