### PR TITLE
use apiversion v1beta1 for channels

### DIFF
--- a/kafka/channel/README.md
+++ b/kafka/channel/README.md
@@ -42,7 +42,7 @@ topics.
 1. Create the `KafkaChannel` custom objects:
 
    ```yaml
-   apiVersion: messaging.knative.dev/v1alpha1
+   apiVersion: messaging.knative.dev/v1beta1
    kind: KafkaChannel
    metadata:
      name: my-kafka-channel
@@ -119,7 +119,7 @@ data:
 Then create a KafkaChannel:
 
 ```yaml
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1beta1
 kind: KafkaChannel
 metadata:
   name: my-kafka-channel


### PR DESCRIPTION
Fixes #
https://github.com/knative/eventing-contrib/issues/1239

## Proposed Changes

- update the Channels apiVersion to `v1beta1
