### PR TITLE
Use apiversion v1beta1 for channel API resources

### DIFF
--- a/kafka/channel/README.md
+++ b/kafka/channel/README.md
@@ -42,7 +42,7 @@ topics.
 1. Create the `KafkaChannel` custom objects:
 
    ```yaml
-   apiVersion: messaging.knative.dev/v1alpha1
+   apiVersion: messaging.knative.dev/v1beta1
    kind: KafkaChannel
    metadata:
      name: my-kafka-channel
@@ -119,7 +119,7 @@ data:
 Then create a KafkaChannel:
 
 ```yaml
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1beta1
 kind: KafkaChannel
 metadata:
   name: my-kafka-channel


### PR DESCRIPTION
Updated README.md to use the Channel API version `v1beta1` instead of `v1alpha1` as alpha API are not creating the needed Kafka Channel and Topics.

Signed-off-by: Kamesh Sampath <ksampath@redhat.com>

Fixes #1239 

https://github.com/knative/eventing-contrib/issues/1239

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- README update to use v1beta1 of Channel API

