### PR TITLE
Fix/mitigate data race in kafka source

### DIFF
--- a/kafka/common/pkg/kafka/consumer_factory_test.go
+++ b/kafka/common/pkg/kafka/consumer_factory_test.go
@@ -40,7 +40,7 @@ func (m *mockConsumerGroup) Consume(ctx context.Context, topics []string, handle
 	if m.mustGenerateHandlerError {
 		go func() {
 			m.generateErrorOnce.Do(func() {
-				h := handler.(*saramaConsumerHandler)
+				h := handler.(*SaramaConsumerHandler)
 				h.errors <- errors.New("cgh")
 				_ = h.Cleanup(nil)
 			})


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

(Maybe) mitigate/fixes #1262 

From the diagnostic (https://github.com/knative/eventing-contrib/issues/1262#issuecomment-633988082), for some reason looks like `Cleanup()` is invoked two times, but i can't find why (I've analysed the code in sarama but it doesn't look like their problem). To mitigate it, I've added a `sync.Once`.

I've also moved the code to merge the error channels in another function