### PR TITLE
CAMEL-14575, time pattern dropped in Camel 3.2

### DIFF
--- a/test/e2e/camel_source_test.go
+++ b/test/e2e/camel_source_test.go
@@ -66,7 +66,7 @@ func TestCamelSource(t *testing.T) {
 			Source: v1alpha1.CamelSourceOriginSpec{
 				Flow: &v1alpha1.Flow{
 					"from": &map[string]interface{}{
-						"uri": "timer:tick?period=1s",
+						"uri": "timer:tick?period=1000",
 						"steps": []interface{}{
 							&map[string]interface{}{
 								"set-body": &map[string]interface{}{


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
time pattern has been dropped in Camel 3.2, see https://issues.apache.org/jira/browse/CAMEL-14575

## Proposed Changes

- make TestCamelSource work with Camel 3.2 by not using the obsolete time pattern
