### PR TITLE
Adding v1beta1 to Kafka Source/Binding CRDs

### DIFF
--- a/kafka/source/config/300-kafkabinding.yaml
+++ b/kafka/source/config/300-kafkabinding.yaml
@@ -46,4 +46,10 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false

--- a/kafka/source/config/300-kafkasource.yaml
+++ b/kafka/source/config/300-kafkasource.yaml
@@ -28,6 +28,15 @@ metadata:
   name: kafkasources.sources.knative.dev
 spec:
   group: sources.knative.dev
+  preserveUnknownFields: false
+  validation:
+    openAPIV3Schema:
+      type: object
+        # this is a work around so we don't need to flush out the
+        # schema for each version at this time
+        #
+        # see issue: https://github.com/knative/serving/issues/912
+      x-kubernetes-preserve-unknown-fields: true
   names:
     categories:
     - all
@@ -39,6 +48,12 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  conversion:
+    strategy: Webhook
+    webhookClientConfig:
+      service:
+        name: kafka-source-webhook
+        namespace: knative-sources
   additionalPrinterColumns:
     - name: Topics
       type: string
@@ -55,151 +70,10 @@ spec:
     - name: Age
       type: date
       JSONPath: .metadata.creationTimestamp
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            bootstrapServers:
-              type: array
-              minLength: 1
-            topics:
-              type: array
-              minLength: 1
-            consumerGroup:
-              type: string
-            net:
-              properties:
-                sasl:
-                  properties:
-                    enable:
-                      type: boolean
-                    password:
-                      properties:
-                        secretKeyRef:
-                          type: object
-                      type: object
-                    user:
-                      properties:
-                        secretKeyRef:
-                          type: object
-                      type: object
-                  type: object
-                tls:
-                  properties:
-                    caCert:
-                      properties:
-                        secretKeyRef:
-                          type: object
-                      type: object
-                    cert:
-                      properties:
-                        secretKeyRef:
-                          type: object
-                      type: object
-                    enable:
-                      type: boolean
-                    key:
-                      properties:
-                        secretKeyRef:
-                          type: object
-                      type: object
-                  type: object
-              type: object
-            resources:
-              properties:
-                limits:
-                  properties:
-                    cpu:
-                      type: string
-                    memory:
-                      type: string
-                  type: object
-                requests:
-                  properties:
-                    cpu:
-                      type: string
-                    memory:
-                      type: string
-                  type: object
-              type: object
-            serviceAccountName:
-              type: string
-            sink:
-              anyOf:
-              - type: object
-                description: "the destination that should receive events."
-                properties:
-                  ref:
-                    type: object
-                    description: "a reference to a Kubernetes object from which to retrieve the target URI."
-                    required:
-                    - apiVersion
-                    - kind
-                    - name
-                    properties:
-                      apiVersion:
-                        type: string
-                        minLength: 1
-                      kind:
-                        type: string
-                        minLength: 1
-                      name:
-                        type: string
-                        minLength: 1
-                  uri:
-                    type: string
-                    description: "the target URI. If ref is provided, this must be relative URI reference."
-              - type: object
-                description: "DEPRECATED: a reference to a Kubernetes object from which to retrieve the target URI."
-                required:
-                - apiVersion
-                - kind
-                - name
-                properties:
-                  apiVersion:
-                    type: string
-                    minLength: 1
-                  kind:
-                    type: string
-                    minLength: 1
-                  name:
-                    type: string
-                    minLength: 1
-                  uri:
-                    type: string
-                    description: "the target URI. If ref is provided, this must be relative URI reference."
-          type: object
-          required:
-              - bootstrapServers
-              - topics
-              - consumerGroup
-        status:
-          properties:
-            conditions:
-              items:
-                properties:
-                  lastTransitionTime:
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  severity:
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    type: string
-                required:
-                - type
-                - status
-                type: object
-              type: array
-            observedGeneration:
-              format: int64
-              type: integer
-            sinkUri:
-              type: string
-          type: object
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+  - name: v1beta1
+    served: true
+    storage: false


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #1347 

## Proposed Changes

- relaxing validation
- adding v1beta1
-


TODO, update samples for this API usage:

```yaml
apiVersion: sources.knative.dev/v1beta1
kind: KafkaSource
metadata:
  name: kafka-source
spec:
  bootstrapServers:
   - my-cluster-kafka-bootstrap.kafka:9092
  topics:
   - my-topic
  sink:
    ref:
      # apiVersion: eventing.knative.dev/v1beta1
      # kind: Broker
      # name: default
      apiVersion: serving.knative.dev/v1
      kind: Service
      name: event-display
```

PR for that is here: https://github.com/knative/docs/pull/2625