### PR TITLE
Add missing PromoteFunc for bindings

### DIFF
--- a/github/pkg/reconciler/binding/controller.go
+++ b/github/pkg/reconciler/binding/controller.go
@@ -22,9 +22,11 @@ import (
 	ghbinformer "knative.dev/eventing-contrib/github/pkg/client/injection/informers/bindings/v1alpha1/githubbinding"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/podspecable"
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/namespace"
+	"knative.dev/pkg/reconciler"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -55,6 +57,21 @@ func NewController(
 	namespaceInformer := namespace.Get(ctx)
 
 	c := &psbinding.BaseReconciler{
+		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
+			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+				all, err := ghbInformer.Lister().List(labels.Everything())
+				if err != nil {
+					return err
+				}
+				for _, elt := range all {
+					enq(bkt, types.NamespacedName{
+						Namespace: elt.GetNamespace(),
+						Name:      elt.GetName(),
+					})
+				}
+				return nil
+			},
+		},
 		GVR: v1alpha1.SchemeGroupVersion.WithResource("githubbindings"),
 		Get: func(namespace string, name string) (psbinding.Bindable, error) {
 			return ghbInformer.Lister().GitHubBindings(namespace).Get(name)

--- a/gitlab/pkg/reconciler/binding/controller.go
+++ b/gitlab/pkg/reconciler/binding/controller.go
@@ -22,9 +22,11 @@ import (
 	glbinformer "knative.dev/eventing-contrib/gitlab/pkg/client/injection/informers/bindings/v1alpha1/gitlabbinding"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/podspecable"
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/namespace"
+	"knative.dev/pkg/reconciler"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -55,6 +57,21 @@ func NewController(
 	namespaceInformer := namespace.Get(ctx)
 
 	c := &psbinding.BaseReconciler{
+		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
+			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+				all, err := glbInformer.Lister().List(labels.Everything())
+				if err != nil {
+					return err
+				}
+				for _, elt := range all {
+					enq(bkt, types.NamespacedName{
+						Namespace: elt.GetNamespace(),
+						Name:      elt.GetName(),
+					})
+				}
+				return nil
+			},
+		},
 		GVR: v1alpha1.SchemeGroupVersion.WithResource("gitlabbindings"),
 		Get: func(namespace string, name string) (psbinding.Bindable, error) {
 			return glbInformer.Lister().GitLabBindings(namespace).Get(name)

--- a/kafka/source/pkg/reconciler/binding/controller.go
+++ b/kafka/source/pkg/reconciler/binding/controller.go
@@ -22,9 +22,11 @@ import (
 	kfkinformer "knative.dev/eventing-contrib/kafka/source/pkg/client/injection/informers/bindings/v1alpha1/kafkabinding"
 	"knative.dev/pkg/client/injection/ducks/duck/v1/podspecable"
 	"knative.dev/pkg/client/injection/kube/informers/core/v1/namespace"
+	"knative.dev/pkg/reconciler"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -55,6 +57,21 @@ func NewController(
 	namespaceInformer := namespace.Get(ctx)
 
 	c := &psbinding.BaseReconciler{
+		LeaderAwareFuncs: reconciler.LeaderAwareFuncs{
+			PromoteFunc: func(bkt reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+				all, err := kfkInformer.Lister().List(labels.Everything())
+				if err != nil {
+					return err
+				}
+				for _, elt := range all {
+					enq(bkt, types.NamespacedName{
+						Namespace: elt.GetNamespace(),
+						Name:      elt.GetName(),
+					})
+				}
+				return nil
+			},
+		},
 		GVR: v1alpha1.SchemeGroupVersion.WithResource("kafkabindings"),
 		Get: func(namespace string, name string) (psbinding.Bindable, error) {
 			return kfkInformer.Lister().KafkaBindings(namespace).Get(name)


### PR DESCRIPTION
Unlike our // +genreconciler friends, the psbinding.BaseReconciler needs consumers to implement the PromoteFunc method to properly resync when they are promoted to leader of a particular bucket.
