### PR TITLE
Workaround for missing monitoring namespace

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -92,6 +92,9 @@ function knative_setup() {
 
   # TODO install head if !is_release_branch
   echo "Installing Knative Monitoring"
+  # Hack hack hack. Why is this namespace not created as part of monitoring release.
+  # https://github.com/knative/eventing/issues/3469
+  kubectl create ns knative-monitoring
   kubectl create namespace istio-system
   kubectl apply --filename "${KNATIVE_MONITORING_RELEASE}" || return 1
   wait_until_pods_running istio-system || fail_test "Knative Monitoring did not come up"


### PR DESCRIPTION
Fixes https://github.com/knative/eventing/issues/3469 but for eventing-contrib

Similar to https://github.com/knative/eventing/pull/3470