### PR TITLE
KafkaChannel v1beta1 e2e

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -14,5 +14,5 @@ Run test with e2e tag and optionally select conformance test
 ```bash
 go test -v -tags=e2e -count=1 ./test/conformance/...
 
-go test -v -timeout 30s -tags e2e knative.dev/eventing/test/conformance -run ^TestChannelStatus$ -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1alpha1:KafkaChannel
+go test -v -timeout 30s -tags e2e knative.dev/eventing/test/conformance -run ^TestChannelStatus$ -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1alpha1:KafkaChannel,messaging.knative.dev/v1beta1:KafkaChannel
 ```

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -245,7 +245,7 @@ function camel_teardown() {
 
 initialize $@ --skip-istio-addon
 
-go_test_e2e -timeout=20m -parallel=12 ./test/e2e -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1alpha1:KafkaChannel  || fail_test
+go_test_e2e -timeout=20m -parallel=12 ./test/e2e -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1alpha1:KafkaChannel,messaging.knative.dev/v1beta1:KafkaChannel  || fail_test
 
 go_test_e2e -timeout=5m -parallel=12 ./test/conformance -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1alpha1:KafkaChannel -sources=sources.knative.dev/v1alpha1:CamelSource,sources.knative.dev/v1alpha1:KafkaSource || fail_test
 

--- a/test/performance/broker-kafka/100-broker-perf-setup.yaml
+++ b/test/performance/broker-kafka/100-broker-perf-setup.yaml
@@ -94,7 +94,7 @@ metadata:
   namespace: perf-eventing
 data:
   channelTemplateSpec: |
-    apiVersion: messaging.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1beta1
     kind: KafkaChannel
 
 ---

--- a/test/performance/channel-kafka/100-channel-perf-setup.yaml
+++ b/test/performance/channel-kafka/100-channel-perf-setup.yaml
@@ -153,7 +153,7 @@ roleRef:
 
 ---
 
-apiVersion: messaging.knative.dev/v1alpha1
+apiVersion: messaging.knative.dev/v1beta1
 kind: KafkaChannel
 metadata:
   name: kafka-channel-test-channel

--- a/test/performance/channel-kafka/101-channel-perf-setup.yaml
+++ b/test/performance/channel-kafka/101-channel-perf-setup.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: perf-eventing
 spec:
   channel:
-    apiVersion: messaging.knative.dev/v1alpha1
+    apiVersion: messaging.knative.dev/v1beta1
     kind: KafkaChannel
     name: kafka-channel-test-channel
   subscriber:


### PR DESCRIPTION
Fixes #1376 

## Proposed Changes

- Add KafkaChannel v1beta1 to the channels that are tested e2e
- Use v1beta1 KafkaChannel in performance tests