### PR TITLE
Use portable bash environment in shell scripts

### DIFF
--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright 2019 The Knative Authors
 #


### PR DESCRIPTION
Using the portable bash environment shebang "#!/usr/bin/env bash" seems to follow the convention used elsewhere in the scripts and is also friendlier to Mac users. The test/e2e-tests.sh is the only file in knative/eventing-contrib which does not follow this convention already.

## Proposed Changes

- Follow the convention of using portable bash environment in every shell script
