### PR TITLE
Assorted linting fixes.

### DIFF
--- a/github/pkg/mtadapter/adapter_test.go
+++ b/github/pkg/mtadapter/adapter_test.go
@@ -36,7 +36,6 @@ import (
 	"knative.dev/pkg/logging"
 	pkgtesting "knative.dev/pkg/reconciler/testing"
 
-	"knative.dev/eventing-contrib/github/pkg/apis/sources/v1alpha1"
 	"knative.dev/eventing-contrib/github/pkg/common"
 
 	// Fake injection informers
@@ -44,14 +43,8 @@ import (
 )
 
 const (
-	testSubject   = "1234"
-	testOwnerRepo = "test-user/test-repo"
-	secretToken   = "gitHubsecret"
-	eventID       = "12345"
-)
-
-var (
-	testSource = v1alpha1.GitHubEventSource(testOwnerRepo)
+	testSubject = "1234"
+	eventID     = "12345"
 )
 
 // testCase holds a single row of our GitHubSource table tests

--- a/github/pkg/mtadapter/router_test.go
+++ b/github/pkg/mtadapter/router_test.go
@@ -126,7 +126,3 @@ var (
 func sinkAccepted(writer http.ResponseWriter, req *http.Request) {
 	writer.WriteHeader(http.StatusOK)
 }
-
-func sinkRejected(writer http.ResponseWriter, _ *http.Request) {
-	writer.WriteHeader(http.StatusRequestTimeout)
-}

--- a/github/pkg/reconciler/source/fake_webhook_client_test.go
+++ b/github/pkg/reconciler/source/fake_webhook_client_test.go
@@ -17,23 +17,24 @@ limitations under the License.
 package source
 
 import (
+	"context"
 	"testing"
 )
 
 func TestNewFakeWebhookClient(t *testing.T) {
 	client := NewFakeWebhookClient()
 
-	_, err := client.Create(nil, nil, "")
+	_, err := client.Create(context.Background(), nil, "")
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
 
-	err = client.Reconcile(nil, nil, "", "")
+	err = client.Reconcile(context.Background(), nil, "", "")
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}
 
-	err = client.Delete(nil, nil, "", "")
+	err = client.Delete(context.Background(), nil, "", "")
 	if err != nil {
 		t.Errorf("unexpected error %v", err)
 	}

--- a/github/pkg/reconciler/source/githubsource.go
+++ b/github/pkg/reconciler/source/githubsource.go
@@ -54,12 +54,6 @@ import (
 )
 
 const (
-	raImageEnvVar = "GH_RA_IMAGE"
-
-	// controllerAgentName is the string used by this controller to identify
-	// itself when creating events.
-	controllerAgentName = "github-source-controller"
-
 	// The name of the mt receive adapter
 	adapterName = "github-adapter"
 )

--- a/kafka/source/pkg/adapter/message.go
+++ b/kafka/source/pkg/adapter/message.go
@@ -97,7 +97,7 @@ func makeEventSubject(partition int32, offset int64) string {
 var replaceBadCharacters = regexp.MustCompile(`[^a-zA-Z0-9]`).ReplaceAllString
 
 func dumpKafkaMetaToEvent(event *cloudevents.Event, keyTypeMapper func([]byte) interface{}, key []byte, msg *protocolkafka.Message) {
-	if key != nil && len(key) > 0 {
+	if len(key) > 0 {
 		event.SetExtension("key", keyTypeMapper(key))
 	}
 	for k, v := range msg.Headers {

--- a/kafka/source/pkg/apis/sources/v1alpha1/kafka_conversion.go
+++ b/kafka/source/pkg/apis/sources/v1alpha1/kafka_conversion.go
@@ -55,9 +55,7 @@ func (source *KafkaSource) ConvertTo(ctx context.Context, obj apis.Convertible) 
 		}
 		if source.Status.CloudEventAttributes != nil {
 			sink.Status.CloudEventAttributes = make([]duckv1.CloudEventAttributes, len(source.Status.CloudEventAttributes))
-			for i, cea := range source.Status.CloudEventAttributes {
-				sink.Status.CloudEventAttributes[i] = cea
-			}
+			copy(sink.Status.CloudEventAttributes, source.Status.CloudEventAttributes)
 		}
 		return nil
 	default:
@@ -93,9 +91,7 @@ func (sink *KafkaSource) ConvertFrom(ctx context.Context, obj apis.Convertible) 
 		}
 		if source.Status.CloudEventAttributes != nil {
 			sink.Status.CloudEventAttributes = make([]duckv1.CloudEventAttributes, len(source.Status.CloudEventAttributes))
-			for i, cea := range source.Status.CloudEventAttributes {
-				sink.Status.CloudEventAttributes[i] = cea
-			}
+			copy(sink.Status.CloudEventAttributes, source.Status.CloudEventAttributes)
 		}
 		return nil
 	default:


### PR DESCRIPTION
- Remove unused code.
- Use copy instead of a loop where appropriate.
- Don't pass nil contexts ever.
- Remove unneeded nil check for slice.