### PR TITLE
Configure conformance tests to run source status conf for KafkaSource

### DIFF
--- a/test/config.go
+++ b/test/config.go
@@ -38,3 +38,12 @@ var ChannelFeatureMap = map[metav1.TypeMeta][]testlib.Feature{
 		testlib.FeaturePersistence,
 	},
 }
+
+var KafkaSourceTypeMeta = metav1.TypeMeta{
+	APIVersion: resources.SourcesV1B1APIVersion,
+	Kind:       KafkaSourceKind,
+}
+
+var SourcesFeatureMap = map[metav1.TypeMeta][]testlib.Feature{
+	KafkaSourceTypeMeta: {testlib.FeatureBasic, testlib.FeatureLongLiving},
+}

--- a/test/conformance/source_status_test.go
+++ b/test/conformance/source_status_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Knative Authors
+Copyright 2020 The Knative Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,11 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package test
+package conformance
 
-// Kind for messaging resources.
-const (
-	KafkaChannelKind string = "KafkaChannel"
-	NatssChannelKind string = "NatssChannel"
-	KafkaSourceKind  string = "KafkaSource"
+import (
+	"testing"
+
+	srchelpers "knative.dev/eventing/test/conformance/helpers/sources"
+	testlib "knative.dev/eventing/test/lib"
 )
+
+func TestSourceStatus(t *testing.T) {
+	srchelpers.SourceStatusTestHelperWithComponentsTestRunner(t,
+		sourcesTestRunner, testlib.SetupClientOptionNoop)
+}

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -256,7 +256,7 @@ initialize $@ --skip-istio-addon
 
 go_test_e2e -timeout=20m -parallel=12 ./test/e2e -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1alpha1:KafkaChannel,messaging.knative.dev/v1beta1:KafkaChannel  || fail_test
 
-go_test_e2e -timeout=5m -parallel=12 ./test/conformance -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1alpha1:KafkaChannel -sources=sources.knative.dev/v1alpha1:CamelSource,sources.knative.dev/v1alpha1:KafkaSource || fail_test
+go_test_e2e -timeout=5m -parallel=12 ./test/conformance -channels=messaging.knative.dev/v1alpha1:NatssChannel,messaging.knative.dev/v1beta1:KafkaChannel -sources=sources.knative.dev/v1alpha1:CamelSource,sources.knative.dev/v1beta1:KafkaSource || fail_test
 
 # If you wish to use this script just as test setup, *without* teardown, just uncomment this line and comment all go_test_e2e commands
 # trap - SIGINT SIGQUIT SIGTSTP EXIT

--- a/test/lib/setupclientoptions/sources.go
+++ b/test/lib/setupclientoptions/sources.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package setupclientoptions
+
+import (
+	"github.com/google/uuid"
+
+	"knative.dev/eventing-contrib/test/e2e/helpers"
+	contribtestlib "knative.dev/eventing-contrib/test/lib"
+	contribresources "knative.dev/eventing-contrib/test/lib/resources"
+
+	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/recordevents"
+	"knative.dev/eventing/test/lib/resources"
+)
+
+// KafkaSourceV1B1ClientSetupOption returns a ClientSetupOption that can be used
+// to create a new KafkaSource. It creates a ServiceAccount, a Role, a
+// RoleBinding, a RecordEvents pod and an ApiServerSource object with the event
+// mode and RecordEvent pod as its sink.
+func KafkaSourceV1B1ClientSetupOption(name string, kafkaClusterName string, kafkaClusterNamespace string, kafkaBootstrapUrl string, recordEventsPodName string) testlib.SetupClientOption {
+	return func(client *testlib.Client) {
+
+		var (
+			kafkaTopicName = uuid.New().String()
+			consumerGroup  = uuid.New().String()
+		)
+
+		helpers.MustCreateTopic(client, kafkaClusterName, kafkaClusterNamespace, kafkaTopicName)
+
+		recordevents.StartEventRecordOrFail(client, recordEventsPodName)
+
+		contribtestlib.CreateKafkaSourceV1Beta1OrFail(client, contribresources.KafkaSourceV1Beta1(
+			kafkaBootstrapUrl,
+			kafkaTopicName,
+			resources.ServiceRef(recordEventsPodName),
+			contribresources.WithNameV1Beta1(name),
+			contribresources.WithConsumerGroupV1Beta1(consumerGroup),
+		))
+
+		client.WaitForAllTestResourcesReadyOrFail()
+	}
+}


### PR DESCRIPTION
Configure conformance tests to run source status conf for KafkaSource

Fixes #1410 

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Configure conformance tests to run source status conf for KafkaSource