### PR TITLE
Add a name for the port

### DIFF
--- a/kafka/source/config/500-controller.yaml
+++ b/kafka/source/config/500-controller.yaml
@@ -76,7 +76,8 @@ metadata:
   namespace: knative-sources
 spec:
   ports:
-    - port: 443
+    - name: https-webhook
+      port: 443
       targetPort: 8443
   selector:
     control-plane: kafka-controller-manager


### PR DESCRIPTION
W/o this `istioctl analyze` complains:
```
Info [IST0118] (Service kafka-source-webhook.knative-sources) Port name  (port: 443, targetPort: 8443) doesn't follow the naming convention of Istio port.
```

Signed-off-by: Doug Davis <dug@us.ibm.com>