### PR TITLE
Export logs from system namespace

### DIFF
--- a/test/conformance/main_test.go
+++ b/test/conformance/main_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2020 The Knative Authors
 
@@ -25,6 +27,7 @@ import (
 	"knative.dev/eventing-contrib/test/lib/setupclientoptions"
 	eventingTest "knative.dev/eventing/test"
 	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/resources"
 	"knative.dev/pkg/test/zipkin"
 )
 
@@ -55,6 +58,7 @@ func TestMain(m *testing.M) {
 		// place that cleans it up. If an individual test calls this instead, then it will break other
 		// tests that need the tracing in place.
 		defer zipkin.CleanupZipkinTracingSetup(log.Printf)
+		defer testlib.ExportLogs(testlib.SystemLogsDir, resources.SystemNamespace)
 
 		return m.Run()
 	}())

--- a/test/conformance/source_crd_metadata_test.go
+++ b/test/conformance/source_crd_metadata_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2020 The Knative Authors
 

--- a/test/conformance/source_status_test.go
+++ b/test/conformance/source_status_test.go
@@ -1,3 +1,5 @@
+// +build e2e
+
 /*
 Copyright 2020 The Knative Authors
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,4 +1,4 @@
-//+build e2e
+// +build e2e
 
 /*
 Copyright 2019 The Knative Authors
@@ -24,6 +24,7 @@ import (
 	"knative.dev/eventing-contrib/test"
 	eventingTest "knative.dev/eventing/test"
 	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/resources"
 )
 
 var channelTestRunner testlib.ComponentsTestRunner
@@ -34,5 +35,9 @@ func TestMain(m *testing.M) {
 		ComponentFeatureMap: test.ChannelFeatureMap,
 		ComponentsToTest:    eventingTest.EventingFlags.Channels,
 	}
-	os.Exit(m.Run())
+	os.Exit(func() int {
+		defer testlib.ExportLogs(testlib.SystemLogsDir, resources.SystemNamespace)
+
+		return m.Run()
+	}())
 }


### PR DESCRIPTION
Exporting logs from `knative-eventing` namespace at the end of e2e
and conformance test suites can help to debug failed test runs.

Signed-off-by: Pierangelo Di Pilato <pierangelodipilato@gmail.com>

Related https://github.com/knative/eventing/pull/3687

## Proposed Changes

- Export logs from system namespace