### PR TITLE
Prune eventTracker.Cleanup()

### DIFF
--- a/test/e2e/camel_source_test.go
+++ b/test/e2e/camel_source_test.go
@@ -26,12 +26,13 @@ import (
 	camelclientset "github.com/apache/camel-k/pkg/client/clientset/versioned"
 	"github.com/cloudevents/sdk-go/v2/test"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1"
-	camelsourceclient "knative.dev/eventing-contrib/camel/source/pkg/client/clientset/versioned"
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/recordevents"
 	"knative.dev/eventing/test/lib/resources"
 	knativeduck "knative.dev/pkg/apis/duck/v1beta1"
+
+	"knative.dev/eventing-contrib/camel/source/pkg/apis/sources/v1alpha1"
+	camelsourceclient "knative.dev/eventing-contrib/camel/source/pkg/client/clientset/versioned"
 )
 
 func TestCamelSource(t *testing.T) {
@@ -48,7 +49,6 @@ func TestCamelSource(t *testing.T) {
 
 	t.Logf("Creating event record")
 	eventTracker, _ := recordevents.StartEventRecordOrFail(client, loggerPodName)
-	defer eventTracker.Cleanup()
 
 	camelClient := getCamelKClient(client)
 


### PR DESCRIPTION
Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>

Reflect changes from https://github.com/knative/eventing/pull/3780

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Removed `eventTracker.Cleanup()` usage
