### PR TITLE
Gitlabsource Prometheus port envvar set to 9092

### DIFF
--- a/gitlab/pkg/reconciler/source/gitlabsource.go
+++ b/gitlab/pkg/reconciler/source/gitlabsource.go
@@ -245,6 +245,9 @@ func (r *Reconciler) generateKnativeServiceObject(source *sourcesv1alpha1.GitLab
 		}, {
 			Name:  "METRICS_DOMAIN",
 			Value: "knative.dev/eventing",
+		}, {
+			Name:  "METRICS_PROMETHEUS_PORT",
+			Value: "9092",
 		}},
 		r.configs.ToEnvVars()...)
 	return &servingv1.Service{


### PR DESCRIPTION
Fixes #1331

Gitlabsource Prometheus port env variable is set to 9092 not to conflict with queue-proxy port (9090)