### PR TITLE
Gitlabsource leader election RBAC

### DIFF
--- a/gitlab/cmd/controller/main.go
+++ b/gitlab/cmd/controller/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	component = "gitlab_controller"
+	component = "gitlab-controller"
 )
 
 func main() {

--- a/gitlab/config/201-clusterrole.yaml
+++ b/gitlab/config/201-clusterrole.yaml
@@ -80,6 +80,23 @@ rules:
   - configmaps
   verbs: *everything
 
+# Acquire leases for leader election
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
+  - coordination.k8s.io
+  resourceNames:
+  - gitlab-controller.knative.dev-eventing-contrib-gitlab-pkg-reconciler-source.reconciler.00-of-01
+  resources:
+  - leases
+  verbs:
+  - get
+  - update
+
 ---
 # The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".
 # See https://knative.dev/eventing/blob/master/config/200-source-observer-clusterrole.yaml.

--- a/gitlab/pkg/reconciler/source/controller.go
+++ b/gitlab/pkg/reconciler/source/controller.go
@@ -62,7 +62,7 @@ func NewController(
 		gitlabClientSet:  gitlabclient.Get(ctx),
 		gitlabLister:     gitlabInformer.Lister(),
 		loggingContext:   ctx,
-		configs:          source.WatchConfigurations(ctx, "gitlab_controller", cmw),
+		configs:          source.WatchConfigurations(ctx, "gitlab-controller", cmw),
 	}
 
 	env := &envConfig{}


### PR DESCRIPTION
Fix for Gitlabsource controller error caused by missing permissions:

```
error retrieving resource lock knative-sources/gitlab_controller.knative.dev-eventing-contrib-gitlab-pkg-reconciler-source.reconciler.00-of-01: leases.coordination.k8s.io "gitlab_controller.knative.dev-eventing-contrib-gitlab-pkg-reconciler-source.reconciler.00-of-01" is forbidden: User "system:serviceaccount:knative-sources:gitlab-controller-manager" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "knative-sources"
```