### PR TITLE
Gitlabsource additional Conditions and Printer Columns

### DIFF
--- a/gitlab/config/300-gitlabsource.yaml
+++ b/gitlab/config/300-gitlabsource.yaml
@@ -52,6 +52,19 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+  - name: Sink
+    type: string
+    JSONPath: ".status.sinkUri"
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
       description: GitLabSource is the Schema for the gitlabsources API

--- a/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types.go
+++ b/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types.go
@@ -111,12 +111,23 @@ const (
 	// GitLabSourceConditionSecretProvided has status True when the
 	// GitlabSource can read secret with gitlab tokens.
 	GitLabSourceConditionSecretProvided apis.ConditionType = "SecretProvided"
+
+	// GitLabSourceConditionWebhookConfigured has a status True when the
+	// GitLabSource has been configured with a webhook.
+	GitLabSourceConditionWebhookConfigured apis.ConditionType = "WebhookConfigured"
+
+	// GitLabSourceConditionReceiveAdapterConfigured has status True when the
+	// GitLabSource has successfully created receive adapter Knative Service.
+	GitLabSourceConditionReceiveAdapterConfigured apis.ConditionType = "ReceiveAdapterConfigured"
 )
 
 var gitLabSourceCondSet = apis.NewLivingConditionSet(
 	GitLabSourceConditionSecretProvided,
-	GitLabSourceConditionSinkProvided)
+	GitLabSourceConditionSinkProvided,
+	GitLabSourceConditionWebhookConfigured,
+	GitLabSourceConditionReceiveAdapterConfigured)
 
+// GetGroupVersionKind returns GitlabSource GVK
 func (*GitLabSource) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("GitLabSource")
 }
@@ -169,6 +180,26 @@ func (s *GitLabSourceStatus) MarkNoSecret(reason, messageFormat string, messageA
 // MarkSecret sets the condition that the source have a gitlab secret.
 func (s *GitLabSourceStatus) MarkSecret() {
 	gitLabSourceCondSet.Manage(s).MarkTrue(GitLabSourceConditionSecretProvided)
+}
+
+// MarkWebhook sets the condition that the source has set its webhook configured.
+func (s *GitLabSourceStatus) MarkWebhook() {
+	gitLabSourceCondSet.Manage(s).MarkTrue(GitLabSourceConditionWebhookConfigured)
+}
+
+// MarkNoWebhook sets the condition that the source does not have its webhook configured.
+func (s *GitLabSourceStatus) MarkNoWebhook(reason, messageFormat string, messageA ...interface{}) {
+	gitLabSourceCondSet.Manage(s).MarkFalse(GitLabSourceConditionWebhookConfigured, reason, messageFormat, messageA...)
+}
+
+// MarkReceiveAdapter sets the condition that the source has its Receive Adapter service ready.
+func (s *GitLabSourceStatus) MarkReceiveAdapter() {
+	gitLabSourceCondSet.Manage(s).MarkTrue(GitLabSourceConditionReceiveAdapterConfigured)
+}
+
+// MarkNoReceiveAdapter sets the condition that the source doesn't have its Receive Adapter service ready.
+func (s *GitLabSourceStatus) MarkNoReceiveAdapter(reason, messageFormat string, messageA ...interface{}) {
+	gitLabSourceCondSet.Manage(s).MarkFalse(GitLabSourceConditionReceiveAdapterConfigured, reason, messageFormat, messageA...)
 }
 
 // +genclient

--- a/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types_test.go
+++ b/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types_test.go
@@ -126,11 +126,36 @@ func TestGitLabSourceStatusIsReady(t *testing.T) {
 		}(),
 		want: false,
 	}, {
+		name: "mark receive adaper empty and secrets",
+		s: func() *GitLabSourceStatus {
+			s := &GitLabSourceStatus{}
+			s.InitializeConditions()
+			s.MarkNoReceiveAdapter("Testing", "")
+			s.MarkSecret()
+			return s
+		}(),
+		want: false,
+	}, {
+		name: "mark everything and switch webhook",
+		s: func() *GitLabSourceStatus {
+			s := &GitLabSourceStatus{}
+			s.InitializeConditions()
+			s.MarkSecret()
+			s.MarkSink(sinkURL)
+			s.MarkReceiveAdapter()
+			s.MarkNoWebhook("Testing", "")
+			s.MarkWebhook()
+			return s
+		}(),
+		want: true,
+	}, {
 		name: "mark sink empty, secrets, then sink",
 		s: func() *GitLabSourceStatus {
 			s := &GitLabSourceStatus{}
 			s.InitializeConditions()
 			s.MarkSink(&apis.URL{})
+			s.MarkReceiveAdapter()
+			s.MarkWebhook()
 			s.MarkSecret()
 			s.MarkSink(sinkURL)
 			return s
@@ -208,12 +233,49 @@ func TestGitLabSourceStatusGetCondition(t *testing.T) {
 			Status: corev1.ConditionUnknown,
 		},
 	}, {
-		name: "mark sink, secrets",
+		name: "mark sink, secrets, empty RA",
 		s: func() *GitLabSourceStatus {
 			s := &GitLabSourceStatus{}
 			s.InitializeConditions()
 			s.MarkSink(sinkURL)
 			s.MarkSecret()
+			s.MarkNoReceiveAdapter("Testing", "hi")
+			return s
+		}(),
+		condQuery: GitLabSourceConditionReady,
+		want: &apis.Condition{
+			Type:    GitLabSourceConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  "Testing",
+			Message: "hi",
+		},
+	}, {
+		name: "mark sink, secrets, RA, empty WH",
+		s: func() *GitLabSourceStatus {
+			s := &GitLabSourceStatus{}
+			s.InitializeConditions()
+			s.MarkSink(sinkURL)
+			s.MarkSecret()
+			s.MarkReceiveAdapter()
+			s.MarkNoWebhook("Testing", "hi")
+			return s
+		}(),
+		condQuery: GitLabSourceConditionReady,
+		want: &apis.Condition{
+			Type:    GitLabSourceConditionReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  "Testing",
+			Message: "hi",
+		},
+	}, {
+		name: "mark sink, secrets, webhook, RA",
+		s: func() *GitLabSourceStatus {
+			s := &GitLabSourceStatus{}
+			s.InitializeConditions()
+			s.MarkSink(sinkURL)
+			s.MarkSecret()
+			s.MarkReceiveAdapter()
+			s.MarkWebhook()
 			return s
 		}(),
 		condQuery: GitLabSourceConditionReady,
@@ -272,10 +334,12 @@ func TestGitLabSourceStatusGetCondition(t *testing.T) {
 			Message: "Sink has resolved to empty.",
 		},
 	}, {
-		name: "mark sink empty, secrets, then sink",
+		name: "mark sink empty, RA, webhook, secrets, then sink",
 		s: func() *GitLabSourceStatus {
 			s := &GitLabSourceStatus{}
 			s.InitializeConditions()
+			s.MarkReceiveAdapter()
+			s.MarkWebhook()
 			s.MarkSink(&apis.URL{})
 			s.MarkSecret()
 			s.MarkSink(sinkURL)


### PR DESCRIPTION
This PR contains two UX improvements for Gitlabsource:
- living condition set is extended with additional conditions to reflect Webhook and Receive Adapter states,
- CRD has additional printer columns to get more details in kubectl outputs.
