### PR TITLE
Rename ReceiveAdapterConfigured condition to Deployed

### DIFF
--- a/gitlab/config/300-gitlabsource.yaml
+++ b/gitlab/config/300-gitlabsource.yaml
@@ -55,13 +55,13 @@ spec:
   additionalPrinterColumns:
   - name: Ready
     type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+    JSONPath: .status.conditions[?(@.type=='Ready')].status
   - name: Reason
     type: string
-    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+    JSONPath: .status.conditions[?(@.type=='Ready')].reason
   - name: Sink
     type: string
-    JSONPath: ".status.sinkUri"
+    JSONPath: .status.sinkUri
   - name: Age
     type: date
     JSONPath: .metadata.creationTimestamp

--- a/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types.go
+++ b/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types.go
@@ -54,7 +54,7 @@ type GitLabSourceSpec struct {
 	// +kubebuilder:validation:MinLength=1
 	ProjectUrl string `json:"projectUrl"`
 
-	// EventType is the type of event to receive from Gitlab. These
+	// EventType is the type of event to receive from GitLab. These
 	// correspond to supported events to the add project hook
 	// https://docs.gitlab.com/ee/api/projects.html#add-project-hook
 	// +kubebuilder:validation:MinItems=1
@@ -105,29 +105,29 @@ const (
 	GitLabSourceConditionReady = apis.ConditionReady
 
 	// GitLabSourceConditionSinkProvided has status True when the
-	// GitlabSource has been configured with a sink target.
+	// GitLabSource has been configured with a sink target.
 	GitLabSourceConditionSinkProvided apis.ConditionType = "SinkProvided"
 
 	// GitLabSourceConditionSecretProvided has status True when the
-	// GitlabSource can read secret with gitlab tokens.
+	// GitLabSource can read the secret containing GitLab tokens.
 	GitLabSourceConditionSecretProvided apis.ConditionType = "SecretProvided"
 
 	// GitLabSourceConditionWebhookConfigured has a status True when the
 	// GitLabSource has been configured with a webhook.
 	GitLabSourceConditionWebhookConfigured apis.ConditionType = "WebhookConfigured"
 
-	// GitLabSourceConditionReceiveAdapterConfigured has status True when the
-	// GitLabSource has successfully created receive adapter Knative Service.
-	GitLabSourceConditionReceiveAdapterConfigured apis.ConditionType = "ReceiveAdapterConfigured"
+	// GitLabSourceConditionDeployed has status True when the
+	// GitLabSource's receive adapter has been successfully deployed.
+	GitLabSourceConditionDeployed apis.ConditionType = "Deployed"
 )
 
 var gitLabSourceCondSet = apis.NewLivingConditionSet(
 	GitLabSourceConditionSecretProvided,
 	GitLabSourceConditionSinkProvided,
 	GitLabSourceConditionWebhookConfigured,
-	GitLabSourceConditionReceiveAdapterConfigured)
+	GitLabSourceConditionDeployed)
 
-// GetGroupVersionKind returns GitlabSource GVK
+// GetGroupVersionKind returns a GitLabSource GVK.
 func (*GitLabSource) GetGroupVersionKind() schema.GroupVersionKind {
 	return SchemeGroupVersion.WithKind("GitLabSource")
 }
@@ -157,7 +157,7 @@ func (s *GitLabSourceStatus) InitializeConditions() {
 	gitLabSourceCondSet.Manage(s).InitializeConditions()
 }
 
-// MarkSink sets the condition that the source has a sink configured.
+// MarkSink sets the SinkProvided condition to True.
 func (s *GitLabSourceStatus) MarkSink(uri *apis.URL) {
 	s.SinkURI = uri
 	if uri.IsEmpty() {
@@ -167,39 +167,39 @@ func (s *GitLabSourceStatus) MarkSink(uri *apis.URL) {
 	}
 }
 
-// MarkNoSink sets the condition that the source does not have a sink configured.
+// MarkNoSink sets the SinkProvided condition to False with the given reason and message.
 func (s *GitLabSourceStatus) MarkNoSink(reason, messageFormat string, messageA ...interface{}) {
 	gitLabSourceCondSet.Manage(s).MarkFalse(GitLabSourceConditionSinkProvided, reason, messageFormat, messageA...)
 }
 
-// MarkNoSecret sets the condition that the source does not have a gitlab secret created.
-func (s *GitLabSourceStatus) MarkNoSecret(reason, messageFormat string, messageA ...interface{}) {
-	gitLabSourceCondSet.Manage(s).MarkFalse(GitLabSourceConditionSecretProvided, reason, messageFormat, messageA...)
-}
-
-// MarkSecret sets the condition that the source have a gitlab secret.
+// MarkSecret sets the SecretProvided condition to True.
 func (s *GitLabSourceStatus) MarkSecret() {
 	gitLabSourceCondSet.Manage(s).MarkTrue(GitLabSourceConditionSecretProvided)
 }
 
-// MarkWebhook sets the condition that the source has set its webhook configured.
+// MarkNoSecret sets the SecretProvided condition to False with the given reason and message.
+func (s *GitLabSourceStatus) MarkNoSecret(reason, messageFormat string, messageA ...interface{}) {
+	gitLabSourceCondSet.Manage(s).MarkFalse(GitLabSourceConditionSecretProvided, reason, messageFormat, messageA...)
+}
+
+// MarkWebhook sets the WebhookConfigured condition to True.
 func (s *GitLabSourceStatus) MarkWebhook() {
 	gitLabSourceCondSet.Manage(s).MarkTrue(GitLabSourceConditionWebhookConfigured)
 }
 
-// MarkNoWebhook sets the condition that the source does not have its webhook configured.
+// MarkNoWebhook sets the WebhookConfigured condition to False with the given reason and message.
 func (s *GitLabSourceStatus) MarkNoWebhook(reason, messageFormat string, messageA ...interface{}) {
 	gitLabSourceCondSet.Manage(s).MarkFalse(GitLabSourceConditionWebhookConfigured, reason, messageFormat, messageA...)
 }
 
-// MarkReceiveAdapter sets the condition that the source has its Receive Adapter service ready.
-func (s *GitLabSourceStatus) MarkReceiveAdapter() {
-	gitLabSourceCondSet.Manage(s).MarkTrue(GitLabSourceConditionReceiveAdapterConfigured)
+// MarkWebhook sets the Deployed condition to True.
+func (s *GitLabSourceStatus) MarkDeployed() {
+	gitLabSourceCondSet.Manage(s).MarkTrue(GitLabSourceConditionDeployed)
 }
 
-// MarkNoReceiveAdapter sets the condition that the source doesn't have its Receive Adapter service ready.
-func (s *GitLabSourceStatus) MarkNoReceiveAdapter(reason, messageFormat string, messageA ...interface{}) {
-	gitLabSourceCondSet.Manage(s).MarkFalse(GitLabSourceConditionReceiveAdapterConfigured, reason, messageFormat, messageA...)
+// MarkNotDeployed sets the Deployed condition to False with the given reason and message.
+func (s *GitLabSourceStatus) MarkNotDeployed(reason, messageFormat string, messageA ...interface{}) {
+	gitLabSourceCondSet.Manage(s).MarkFalse(GitLabSourceConditionDeployed, reason, messageFormat, messageA...)
 }
 
 // +genclient

--- a/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types_test.go
+++ b/gitlab/pkg/apis/sources/v1alpha1/gitlabsource_types_test.go
@@ -130,7 +130,7 @@ func TestGitLabSourceStatusIsReady(t *testing.T) {
 		s: func() *GitLabSourceStatus {
 			s := &GitLabSourceStatus{}
 			s.InitializeConditions()
-			s.MarkNoReceiveAdapter("Testing", "")
+			s.MarkNotDeployed("Testing", "")
 			s.MarkSecret()
 			return s
 		}(),
@@ -142,7 +142,7 @@ func TestGitLabSourceStatusIsReady(t *testing.T) {
 			s.InitializeConditions()
 			s.MarkSecret()
 			s.MarkSink(sinkURL)
-			s.MarkReceiveAdapter()
+			s.MarkDeployed()
 			s.MarkNoWebhook("Testing", "")
 			s.MarkWebhook()
 			return s
@@ -154,7 +154,7 @@ func TestGitLabSourceStatusIsReady(t *testing.T) {
 			s := &GitLabSourceStatus{}
 			s.InitializeConditions()
 			s.MarkSink(&apis.URL{})
-			s.MarkReceiveAdapter()
+			s.MarkDeployed()
 			s.MarkWebhook()
 			s.MarkSecret()
 			s.MarkSink(sinkURL)
@@ -239,7 +239,7 @@ func TestGitLabSourceStatusGetCondition(t *testing.T) {
 			s.InitializeConditions()
 			s.MarkSink(sinkURL)
 			s.MarkSecret()
-			s.MarkNoReceiveAdapter("Testing", "hi")
+			s.MarkNotDeployed("Testing", "hi")
 			return s
 		}(),
 		condQuery: GitLabSourceConditionReady,
@@ -256,7 +256,7 @@ func TestGitLabSourceStatusGetCondition(t *testing.T) {
 			s.InitializeConditions()
 			s.MarkSink(sinkURL)
 			s.MarkSecret()
-			s.MarkReceiveAdapter()
+			s.MarkDeployed()
 			s.MarkNoWebhook("Testing", "hi")
 			return s
 		}(),
@@ -274,7 +274,7 @@ func TestGitLabSourceStatusGetCondition(t *testing.T) {
 			s.InitializeConditions()
 			s.MarkSink(sinkURL)
 			s.MarkSecret()
-			s.MarkReceiveAdapter()
+			s.MarkDeployed()
 			s.MarkWebhook()
 			return s
 		}(),
@@ -338,7 +338,7 @@ func TestGitLabSourceStatusGetCondition(t *testing.T) {
 		s: func() *GitLabSourceStatus {
 			s := &GitLabSourceStatus{}
 			s.InitializeConditions()
-			s.MarkReceiveAdapter()
+			s.MarkDeployed()
 			s.MarkWebhook()
 			s.MarkSink(&apis.URL{})
 			s.MarkSecret()

--- a/gitlab/pkg/reconciler/source/gitlabsource.go
+++ b/gitlab/pkg/reconciler/source/gitlabsource.go
@@ -140,19 +140,19 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, source *sourcesv1alpha1.
 			ksvc = r.generateKnativeServiceObject(source, r.receiveAdapterImage)
 			ksvc, err = r.servingClientSet.ServingV1().Services(ksvc.GetNamespace()).Create(ksvc)
 			if err != nil {
-				source.Status.MarkNoReceiveAdapter("ReceiveAdapterCreationError", "%s", err)
+				source.Status.MarkNotDeployed("ReceiveAdapterCreationError", "%s", err)
 				return err
 			}
 		} else {
-			source.Status.MarkNoReceiveAdapter("ReceiveAdapterNotOwned", "%s", err)
+			source.Status.MarkNotDeployed("ReceiveAdapterNotOwned", "%s", err)
 			return fmt.Errorf("Failed to verify if knative service is created for the gitlabsource: %v", err)
 		}
 	}
 	if !ksvc.IsReady() {
-		source.Status.MarkNoReceiveAdapter("ReceiveAdapterNotReady", "Receive adapter Service is not ready")
+		source.Status.MarkNotDeployed("ReceiveAdapterNotReady", "Receive adapter Service is not ready")
 		return nil
 	}
-	source.Status.MarkReceiveAdapter()
+	source.Status.MarkDeployed()
 
 	if ksvc.Status.URL == nil {
 		return nil


### PR DESCRIPTION
Addresses review comments from #1488 that didn't go through due to an early approval.

Most of those changes are nits, but I think renaming the status condition is important. Most (if not all) contrib sources use `Deployed` to describe that a receive adapter is ready to operate. I think we should try to avoid divergence within eventing-contrib while expressing the same thing as other sources do.