### PR TITLE
WIP: change storage version to v1beta1

### DIFF
--- a/kafka/channel/config/300-kafka-channel.yaml
+++ b/kafka/channel/config/300-kafka-channel.yaml
@@ -62,10 +62,10 @@ spec:
   versions:
   - name: v1alpha1
     served: true
-    storage: true
+    storage: false
   - name: v1beta1
     served: true
-    storage: false
+    storage: true
   conversion:
     strategy: Webhook
     conversionReviewVersions: ["v1beta1", "v1alpha1"]

--- a/kafka/channel/pkg/apis/messaging/v1alpha1/kafka_channel_defaults.go
+++ b/kafka/channel/pkg/apis/messaging/v1alpha1/kafka_channel_defaults.go
@@ -34,7 +34,7 @@ func (c *KafkaChannel) SetDefaults(ctx context.Context) {
 		c.Annotations = make(map[string]string)
 	}
 	if _, ok := c.Annotations[messaging.SubscribableDuckVersionAnnotation]; !ok {
-		c.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1alpha1"
+		c.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
 	}
 
 	c.Spec.SetDefaults(ctx)

--- a/kafka/channel/pkg/apis/messaging/v1alpha1/kafka_channel_defaults_test.go
+++ b/kafka/channel/pkg/apis/messaging/v1alpha1/kafka_channel_defaults_test.go
@@ -38,7 +38,7 @@ func TestKafkaChannelDefaults(t *testing.T) {
 			initial: KafkaChannel{},
 			expected: KafkaChannel{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1alpha1"},
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1beta1"},
 				},
 				Spec: KafkaChannelSpec{
 					NumPartitions:     utils.DefaultNumPartitions,
@@ -54,7 +54,7 @@ func TestKafkaChannelDefaults(t *testing.T) {
 			},
 			expected: KafkaChannel{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1alpha1"},
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1beta1"},
 				},
 				Spec: KafkaChannelSpec{
 					NumPartitions:     utils.DefaultNumPartitions,
@@ -70,7 +70,7 @@ func TestKafkaChannelDefaults(t *testing.T) {
 			},
 			expected: KafkaChannel{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1alpha1"},
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1beta1"},
 				},
 				Spec: KafkaChannelSpec{
 					NumPartitions:     testNumPartitions,

--- a/kafka/channel/pkg/apis/messaging/v1beta1/kafka_channel_defaults.go
+++ b/kafka/channel/pkg/apis/messaging/v1beta1/kafka_channel_defaults.go
@@ -34,7 +34,7 @@ func (c *KafkaChannel) SetDefaults(ctx context.Context) {
 		c.Annotations = make(map[string]string)
 	}
 	if _, ok := c.Annotations[messaging.SubscribableDuckVersionAnnotation]; !ok {
-		c.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1"
+		c.Annotations[messaging.SubscribableDuckVersionAnnotation] = "v1beta1"
 	}
 
 	c.Spec.SetDefaults(ctx)

--- a/kafka/channel/pkg/apis/messaging/v1beta1/kafka_channel_defaults_test.go
+++ b/kafka/channel/pkg/apis/messaging/v1beta1/kafka_channel_defaults_test.go
@@ -38,7 +38,7 @@ func TestKafkaChannelDefaults(t *testing.T) {
 			initial: KafkaChannel{},
 			expected: KafkaChannel{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1"},
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1beta1"},
 				},
 				Spec: KafkaChannelSpec{
 					NumPartitions:     utils.DefaultNumPartitions,
@@ -54,7 +54,7 @@ func TestKafkaChannelDefaults(t *testing.T) {
 			},
 			expected: KafkaChannel{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1"},
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1beta1"},
 				},
 				Spec: KafkaChannelSpec{
 					NumPartitions:     utils.DefaultNumPartitions,
@@ -70,7 +70,7 @@ func TestKafkaChannelDefaults(t *testing.T) {
 			},
 			expected: KafkaChannel{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1"},
+					Annotations: map[string]string{"messaging.knative.dev/subscribable": "v1beta1"},
 				},
 				Spec: KafkaChannelSpec{
 					NumPartitions:     testNumPartitions,


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Fixes #

## Proposed Changes

- setting storage version to `v1beta1`

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note

```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
