### PR TITLE
delete ra deployment when sink is not found

### DIFF
--- a/kafka/source/pkg/reconciler/source/kafkasource.go
+++ b/kafka/source/pkg/reconciler/source/kafkasource.go
@@ -31,6 +31,7 @@ import (
 	"knative.dev/eventing/pkg/reconciler/source"
 	"knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/eventing/pkg/utils"
 
 	"knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1beta1"
 	"knative.dev/eventing-contrib/kafka/source/pkg/reconciler/source/resources"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -38,6 +38,7 @@ fi
 # Eventing main config path from HEAD.
 readonly EVENTING_CONFIG="./config/"
 readonly EVENTING_MT_CHANNEL_BROKER_CONFIG="./config/brokers/mt-channel-broker"
+readonly EVENTING_IN_MEMORY_CHANNEL_CONFIG="./config/channels/in-memory-channel"
 
 # Vendored eventing test iamges.
 readonly VENDOR_EVENTING_TEST_IMAGES="vendor/knative.dev/eventing/test/test_images/"
@@ -75,6 +76,8 @@ readonly CAMELK_INSTALLATION_CONFIG="test/config/100-camel-k-1.1.0.yaml"
 # Camel source CRD config template directory
 readonly CAMEL_SOURCE_CRD_CONFIG_DIR="camel/source/config"
 
+# In-memory channel CRD config.
+readonly IN_MEMORY_CHANNEL_CRD_CONFIG_DIR="config/channels/in-memory-channel"
 
 function knative_setup() {
   if is_release_branch; then
@@ -89,6 +92,8 @@ function knative_setup() {
     ko apply -f ${EVENTING_CONFIG}
     # Install MT Channel Based Broker
     ko apply -f ${EVENTING_MT_CHANNEL_BROKER_CONFIG}
+    # Install IMC
+    ko apply -f ${EVENTING_IN_MEMORY_CHANNEL_CONFIG}
     popd
   fi
   wait_until_pods_running knative-eventing || fail_test "Knative Eventing did not come up"
@@ -172,7 +177,7 @@ function test_teardown() {
   uninstall_sources_crds
 }
 
-function install_channel_crds() {
+function install_channel_crds() { 
   echo "Installing NATSS Channel CRD"
   ko apply -f ${NATSS_CRD_CONFIG_DIR} || return 1
   wait_until_pods_running knative-eventing || fail_test "Failed to install the NATSS Channel CRD"

--- a/test/e2e-tests.sh
+++ b/test/e2e-tests.sh
@@ -76,8 +76,6 @@ readonly CAMELK_INSTALLATION_CONFIG="test/config/100-camel-k-1.1.0.yaml"
 # Camel source CRD config template directory
 readonly CAMEL_SOURCE_CRD_CONFIG_DIR="camel/source/config"
 
-# In-memory channel CRD config.
-readonly IN_MEMORY_CHANNEL_CRD_CONFIG_DIR="config/channels/in-memory-channel"
 
 function knative_setup() {
   if is_release_branch; then
@@ -177,7 +175,7 @@ function test_teardown() {
   uninstall_sources_crds
 }
 
-function install_channel_crds() { 
+function install_channel_crds() {
   echo "Installing NATSS Channel CRD"
   ko apply -f ${NATSS_CRD_CONFIG_DIR} || return 1
   wait_until_pods_running knative-eventing || fail_test "Failed to install the NATSS Channel CRD"

--- a/test/e2e/helpers/kafka_helper.go
+++ b/test/e2e/helpers/kafka_helper.go
@@ -48,8 +48,8 @@ const (
 )
 
 var (
-	topicGVR        = schema.GroupVersionResource{Group: strimziApiGroup, Version: strimziApiVersion, Resource: strimziTopicResource}
-	ImcGVR = schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1beta1", Resource: "inmemorychannels"}
+	topicGVR = schema.GroupVersionResource{Group: strimziApiGroup, Version: strimziApiVersion, Resource: strimziTopicResource}
+	ImcGVR   = schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1beta1", Resource: "inmemorychannels"}
 )
 
 func MustPublishKafkaMessage(client *testlib.Client, bootstrapServer string, topic string, key string, headers map[string]string, value string) {

--- a/test/e2e/helpers/kafka_helper.go
+++ b/test/e2e/helpers/kafka_helper.go
@@ -49,7 +49,7 @@ const (
 
 var (
 	topicGVR        = schema.GroupVersionResource{Group: strimziApiGroup, Version: strimziApiVersion, Resource: strimziTopicResource}
-	KafkaChannelGVR = schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1beta1", Resource: "kafkachannels"}
+	ImcGVR = schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1beta1", Resource: "inmemorychannels"}
 )
 
 func MustPublishKafkaMessage(client *testlib.Client, bootstrapServer string, topic string, key string, headers map[string]string, value string) {

--- a/test/e2e/helpers/kafka_helper.go
+++ b/test/e2e/helpers/kafka_helper.go
@@ -43,17 +43,13 @@ const (
 	strimziApiGroup      = "kafka.strimzi.io"
 	strimziApiVersion    = "v1beta1"
 	strimziTopicResource = "kafkatopics"
-	FlowsGroup           = "flows.knative.dev"
-	FlowsVersion         = "v1"
-	FlowsResource        = "sequences"
-	FlowsKind            = "Sequence"
 	interval             = 3 * time.Second
 	timeout              = 30 * time.Second
 )
 
 var (
-	topicGVR    = schema.GroupVersionResource{Group: strimziApiGroup, Version: strimziApiVersion, Resource: strimziTopicResource}
-	SequenceGVR = schema.GroupVersionResource{Group: FlowsGroup, Version: FlowsVersion, Resource: FlowsResource}
+	topicGVR        = schema.GroupVersionResource{Group: strimziApiGroup, Version: strimziApiVersion, Resource: strimziTopicResource}
+	KafkaChannelGVR = schema.GroupVersionResource{Group: "messaging.knative.dev", Version: "v1beta1", Resource: "kafkachannels"}
 )
 
 func MustPublishKafkaMessage(client *testlib.Client, bootstrapServer string, topic string, key string, headers map[string]string, value string) {

--- a/test/e2e/helpers/kafka_helper.go
+++ b/test/e2e/helpers/kafka_helper.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/davecgh/go-spew/spew"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
@@ -33,16 +34,26 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	testlib "knative.dev/eventing/test/lib"
 	pkgtest "knative.dev/pkg/test"
+
+	sourcesv1beta1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1beta1"
+	kafkaclientset "knative.dev/eventing-contrib/kafka/source/pkg/client/clientset/versioned"
 )
 
 const (
 	strimziApiGroup      = "kafka.strimzi.io"
 	strimziApiVersion    = "v1beta1"
 	strimziTopicResource = "kafkatopics"
+	FlowsGroup           = "flows.knative.dev"
+	FlowsVersion         = "v1"
+	FlowsResource        = "sequences"
+	FlowsKind            = "Sequence"
+	interval             = 3 * time.Second
+	timeout              = 30 * time.Second
 )
 
 var (
-	topicGVR = schema.GroupVersionResource{Group: strimziApiGroup, Version: strimziApiVersion, Resource: strimziTopicResource}
+	topicGVR    = schema.GroupVersionResource{Group: strimziApiGroup, Version: strimziApiVersion, Resource: strimziTopicResource}
+	SequenceGVR = schema.GroupVersionResource{Group: FlowsGroup, Version: FlowsVersion, Resource: FlowsResource}
 )
 
 func MustPublishKafkaMessage(client *testlib.Client, bootstrapServer string, topic string, key string, headers map[string]string, value string) {
@@ -231,4 +242,49 @@ func MustCreateTopic(client *testlib.Client, clusterName string, clusterNamespac
 	}
 
 	client.Tracker.Add(topicGVR.Group, topicGVR.Version, topicGVR.Resource, clusterNamespace, topicName)
+}
+
+//CheckKafkaSourceState waits for specified kafka source resource state
+//On timeout reports error
+func CheckKafkaSourceState(c *testlib.Client, name string, inState func(ks *sourcesv1beta1.KafkaSource) (bool, error)) error {
+	kafkaSourceClientSet, err := kafkaclientset.NewForConfig(c.Config)
+	if err != nil {
+		return err
+	}
+	kSources := kafkaSourceClientSet.SourcesV1beta1().KafkaSources(c.Namespace)
+	var lastState *sourcesv1beta1.KafkaSource
+	waitErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		var err error
+		lastState, err = kSources.Get(name, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+		return inState(lastState)
+	})
+	if waitErr != nil {
+		return fmt.Errorf("kafkasource %q is not in desired state, got: %+v: %w", name, lastState, waitErr)
+	}
+	return nil
+}
+
+//CheckRADeployment waits for desired state of receiver adapter
+//On timeout reports error
+func CheckRADeployment(c *testlib.Client, name string, inState func(deps *appsv1.DeploymentList) (bool, error)) error {
+	listOptions := metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", "eventing.knative.dev/SourceName", name),
+	}
+	kDeps := c.Kube.Kube.AppsV1().Deployments(c.Namespace)
+	var lastState *appsv1.DeploymentList
+	waitErr := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		var err error
+		lastState, err = kDeps.List(listOptions)
+		if err != nil {
+			return true, err
+		}
+		return inState(lastState)
+	})
+	if waitErr != nil {
+		return fmt.Errorf("receiver adapter deployments %q is not in desired state, got: %+v: %w", name, lastState, waitErr)
+	}
+	return nil
 }

--- a/test/e2e/kafka_source_reconciler_test.go
+++ b/test/e2e/kafka_source_reconciler_test.go
@@ -133,7 +133,7 @@ func createSink(c *testlib.Client) {
 
 func createSequence(c *testlib.Client) {
 	steps := []flowsv1.SequenceStep{
-		flowsv1.SequenceStep{
+		{
 			Destination: duckv1.Destination{
 				Ref: resources.KnativeRefForService(RTSeqStepperPodName, c.Namespace),
 			}},

--- a/test/e2e/kafka_source_reconciler_test.go
+++ b/test/e2e/kafka_source_reconciler_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	testlib "knative.dev/eventing/test/lib"
+	"knative.dev/eventing/test/lib/resources"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	pkgTest "knative.dev/pkg/test"
+
+	sourcesv1beta1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1beta1"
+	"knative.dev/eventing-contrib/test/e2e/helpers"
+	contribtestlib "knative.dev/eventing-contrib/test/lib"
+	contribresources "knative.dev/eventing-contrib/test/lib/resources"
+	flowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
+	eventingtesting "knative.dev/eventing/pkg/reconciler/testing/v1"
+)
+
+const (
+	RTSeqStepperPodName  = "e2e-rt-stepperpod"
+	RTKafkaSourceName    = "e2e-rt-kafka-source"
+	RTSequenceName       = "e2e-rt-sequence"
+	RTKafkaConsumerGroup = "e2e-rt-cg"
+	RTStepMessage        = "only step"
+	RTKafkaTopicName     = "e2e-rt-topic"
+)
+
+//TestKafkaSourceReconciler tests various kafka source reconciler statuses
+//RT is short for reconciler test
+func TestKafkaSourceReconciler(t *testing.T) {
+	client := testlib.Setup(t, true)
+	defer testlib.TearDown(client)
+
+	for _, test := range []struct {
+		name             string
+		action           func(c *testlib.Client)
+		expectedStatuses sets.String
+		wantRADepCount   int
+	}{{
+		"create_kafka_source",
+		createKafkaSourceWithSinkMissing,
+		sets.NewString("NotFound"),
+		0,
+	},
+		{
+			"create_sink",
+			createSink,
+			sets.NewString(""),
+			1,
+		},
+		{
+			"delete_sequence",
+			deleteSequence,
+			sets.NewString("NotFound"),
+			0,
+		},
+		{
+			"create_sequence",
+			createSequence,
+			sets.NewString(""),
+			1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			testKafkaSourceReconciler(client, test.name, test.action, test.expectedStatuses, test.wantRADepCount)
+		})
+	}
+}
+
+func testKafkaSourceReconciler(c *testlib.Client, name string, doAction func(c *testlib.Client), expectedStatuses sets.String, wantRADepCount int) {
+	doAction(c)
+
+	if err := helpers.CheckKafkaSourceState(c, RTKafkaSourceName, func(ks *sourcesv1beta1.KafkaSource) (bool, error) {
+		ready := ks.Status.GetCondition(apis.ConditionReady)
+		if ready != nil {
+			if expectedStatuses.Has(ready.Reason) {
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		c.T.Fatalf("Failed to validate kafkasource state, expected status : %v, err : %v", expectedStatuses.UnsortedList(), err)
+	}
+
+	if err := helpers.CheckRADeployment(c, RTKafkaSourceName, func(deps *appsv1.DeploymentList) (bool, error) {
+		if len(deps.Items) == wantRADepCount {
+			return true, nil
+		}
+		return false, nil
+	}); err != nil {
+		c.T.Fatal("Failed to validate adapter deployment state:", err)
+	}
+}
+
+func createKafkaSourceWithSinkMissing(c *testlib.Client) {
+	helpers.MustCreateTopic(c, kafkaClusterName, kafkaClusterNamespace, RTKafkaTopicName)
+
+	contribtestlib.CreateKafkaSourceV1Beta1OrFail(c, contribresources.KafkaSourceV1Beta1(
+		kafkaBootstrapUrl,
+		RTKafkaTopicName,
+		pkgTest.CoreV1ObjectReference(helpers.FlowsKind, fmt.Sprintf("%s/%s", helpers.FlowsGroup, helpers.FlowsVersion), RTSequenceName),
+		contribresources.WithNameV1Beta1(RTKafkaSourceName),
+		contribresources.WithConsumerGroupV1Beta1(RTKafkaConsumerGroup),
+	))
+}
+
+func createSink(c *testlib.Client) {
+	stepperPod := resources.SequenceStepperPod(RTSeqStepperPodName, RTStepMessage)
+	c.CreatePodOrFail(stepperPod, testlib.WithService(RTSeqStepperPodName))
+	createSequence(c)
+}
+
+func createSequence(c *testlib.Client) {
+	steps := []flowsv1.SequenceStep{
+		flowsv1.SequenceStep{
+			Destination: duckv1.Destination{
+				Ref: resources.KnativeRefForService(RTSeqStepperPodName, c.Namespace),
+			}},
+	}
+	// create the sequence object
+	sequence := eventingtesting.NewSequence(
+		RTSequenceName,
+		c.Namespace,
+		eventingtesting.WithSequenceSteps(steps),
+	)
+	c.CreateFlowsSequenceV1OrFail(sequence)
+}
+
+func deleteSequence(c *testlib.Client) {
+	contribtestlib.DeleteResourceOrFail(c, RTSequenceName, helpers.SequenceGVR)
+}

--- a/test/e2e/kafka_source_reconciler_test.go
+++ b/test/e2e/kafka_source_reconciler_test.go
@@ -122,10 +122,11 @@ func createKafkaSourceWithSinkMissing(c *testlib.Client) {
 func createChannel(c *testlib.Client) {
 	c.CreateChannelOrFail(rtChannelName, &metav1.TypeMeta{
 		APIVersion: resources.MessagingAPIVersion,
-		Kind:       test.KafkaChannelKind,
+		Kind:       resources.InMemoryChannelKind,
 	})
+	c.WaitForAllTestResourcesReadyOrFail()
 }
 
 func deleteChannel(c *testlib.Client) {
-	contribtestlib.DeleteResourceOrFail(c, rtChannelName, helpers.KafkaChannelGVR)
+	contribtestlib.DeleteResourceOrFail(c, rtChannelName, helpers.ImcGVR)
 }

--- a/test/e2e/kafka_source_reconciler_test.go
+++ b/test/e2e/kafka_source_reconciler_test.go
@@ -1,3 +1,5 @@
+//+build e2e
+
 /*
 Copyright 2020 The Knative Authors
 

--- a/test/e2e/kafka_source_reconciler_test.go
+++ b/test/e2e/kafka_source_reconciler_test.go
@@ -22,8 +22,8 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
@@ -31,15 +31,15 @@ import (
 	pkgTest "knative.dev/pkg/test"
 
 	sourcesv1beta1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1beta1"
+	"knative.dev/eventing-contrib/test"
 	"knative.dev/eventing-contrib/test/e2e/helpers"
 	contribtestlib "knative.dev/eventing-contrib/test/lib"
-	"knative.dev/eventing-contrib/test"
 	contribresources "knative.dev/eventing-contrib/test/lib/resources"
 )
 
 const (
 	rtKafkaSourceName    = "e2e-rt-kafka-source"
-	rtChannelName       = "e2e-rt-channel"
+	rtChannelName        = "e2e-rt-channel"
 	rtKafkaConsumerGroup = "e2e-rt-cg"
 	rtKafkaTopicName     = "e2e-rt-topic"
 )
@@ -60,21 +60,21 @@ func TestKafkaSourceReconciler(t *testing.T) {
 		createKafkaSourceWithSinkMissing,
 		sets.NewString("NotFound"),
 		0,
-	},{
-			"create_sink",
-			createChannel,
-			sets.NewString(""),
-			1,
-	},{
-			"delete_sink",
-			deleteChannel,
-			sets.NewString("NotFound"),
-			0,
-	},{
-			"create_sink_after_delete",
-			createChannel,
-			sets.NewString(""),
-			1,
+	}, {
+		"create_sink",
+		createChannel,
+		sets.NewString(""),
+		1,
+	}, {
+		"delete_sink",
+		deleteChannel,
+		sets.NewString("NotFound"),
+		0,
+	}, {
+		"create_sink_after_delete",
+		createChannel,
+		sets.NewString(""),
+		1,
 	}} {
 		t.Run(test.name, func(t *testing.T) {
 			testKafkaSourceReconciler(client, test.name, test.action, test.expectedStatuses, test.wantRADepCount)
@@ -121,8 +121,8 @@ func createKafkaSourceWithSinkMissing(c *testlib.Client) {
 
 func createChannel(c *testlib.Client) {
 	c.CreateChannelOrFail(rtChannelName, &metav1.TypeMeta{
-				APIVersion: resources.MessagingAPIVersion,
-				Kind:       test.KafkaChannelKind,
+		APIVersion: resources.MessagingAPIVersion,
+		Kind:       test.KafkaChannelKind,
 	})
 }
 

--- a/test/e2e/kafka_source_reconciler_test.go
+++ b/test/e2e/kafka_source_reconciler_test.go
@@ -31,7 +31,6 @@ import (
 	pkgTest "knative.dev/pkg/test"
 
 	sourcesv1beta1 "knative.dev/eventing-contrib/kafka/source/pkg/apis/sources/v1beta1"
-	"knative.dev/eventing-contrib/test"
 	"knative.dev/eventing-contrib/test/e2e/helpers"
 	contribtestlib "knative.dev/eventing-contrib/test/lib"
 	contribresources "knative.dev/eventing-contrib/test/lib/resources"
@@ -113,7 +112,7 @@ func createKafkaSourceWithSinkMissing(c *testlib.Client) {
 	contribtestlib.CreateKafkaSourceV1Beta1OrFail(c, contribresources.KafkaSourceV1Beta1(
 		kafkaBootstrapUrl,
 		rtKafkaTopicName,
-		pkgTest.CoreV1ObjectReference(test.KafkaChannelKind, resources.MessagingAPIVersion, rtChannelName),
+		pkgTest.CoreV1ObjectReference(resources.InMemoryChannelKind, resources.MessagingAPIVersion, rtChannelName),
 		contribresources.WithNameV1Beta1(rtKafkaSourceName),
 		contribresources.WithConsumerGroupV1Beta1(rtKafkaConsumerGroup),
 	))

--- a/test/e2e/kafka_source_reconciler_test.go
+++ b/test/e2e/kafka_source_reconciler_test.go
@@ -24,6 +24,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	testlib "knative.dev/eventing/test/lib"
 	"knative.dev/eventing/test/lib/resources"
@@ -37,6 +38,7 @@ import (
 	contribresources "knative.dev/eventing-contrib/test/lib/resources"
 	flowsv1 "knative.dev/eventing/pkg/apis/flows/v1"
 	eventingtesting "knative.dev/eventing/pkg/reconciler/testing/v1"
+	messagingv1 "knative.dev/eventing/pkg/apis/messaging/v1"
 )
 
 const (
@@ -145,6 +147,12 @@ func createSequence(c *testlib.Client) {
 		RTSequenceName,
 		c.Namespace,
 		eventingtesting.WithSequenceSteps(steps),
+		eventingtesting.WithSequenceChannelTemplateSpec(&messagingv1.ChannelTemplateSpec{
+			TypeMeta: 	metav1.TypeMeta{
+				APIVersion: resources.MessagingAPIVersion,
+				Kind:       "KafkaChannel",
+			},
+		}),
 	)
 	c.CreateFlowsSequenceV1OrFail(sequence)
 }

--- a/test/lib/deletion.go
+++ b/test/lib/deletion.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lib
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	testlib "knative.dev/eventing/test/lib"
+)
+
+func DeleteResourceOrFail(c *testlib.Client, name string, gvr schema.GroupVersionResource) {
+	unstructured := c.Dynamic.Resource(gvr).Namespace(c.Namespace)
+	if err := unstructured.Delete(name, nil); err != nil {
+		c.T.Fatalf("Failed to delete the resource %q : %v", name, err)
+	}
+}


### PR DESCRIPTION
Fixes #1493

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- When sink is not found delete the RA deployment, this will ensure that events are not dropped
- Add e2e for checking various kafka source reconciler states

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Fix bug - when kafkasource goes into "sink not found" status, receiver adapter will be deleted. The receiver adapter will be created again when the sink is available and ready to receive events.
```
