### PR TITLE
Fix Kafka Channel dispatcher ownerRef

### DIFF
--- a/kafka/channel/config/500-dispatcher.yaml
+++ b/kafka/channel/config/500-dispatcher.yaml
@@ -1,4 +1,4 @@
-# Copyright 2018 The Knative Authors
+# Copyright 2020 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/kafka/channel/config/500-kafka-ch-dispatcher.yaml
+++ b/kafka/channel/config/500-kafka-ch-dispatcher.yaml
@@ -1,0 +1,83 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka-ch-dispatcher
+  namespace: knative-eventing
+  labels:
+    eventing.knative.dev/release: devel
+spec:
+  # this deployment is going to be scaled up by the
+  # controller when the very first KafkaChannel is created
+  replicas: 0
+  selector:
+    matchLabels:
+      messaging.knative.dev/channel: kafka-channel
+      messaging.knative.dev/role: dispatcher
+  template:
+    metadata:
+      labels:
+        messaging.knative.dev/channel: kafka-channel
+        messaging.knative.dev/role: dispatcher
+        eventing.knative.dev/release: devel
+    spec:
+      containers:
+        - name: dispatcher
+          image: ko://knative.dev/eventing-contrib/kafka/channel/cmd/channel_dispatcher
+          env:
+            - name: SYSTEM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: METRICS_DOMAIN
+              value: "knative.dev/eventing"
+            - name: CONFIG_LOGGING_NAME
+              value: "config-logging"
+            - name: CONFIG_LEADERELECTION_NAME
+              value: "config-leader-election-kafka"
+          ports:
+            - containerPort: 9090
+              name: metrics
+              protocol: TCP
+          volumeMounts:
+            - name: config-kafka
+              mountPath: /etc/config-kafka
+      serviceAccountName: kafka-ch-dispatcher
+      volumes:
+        - name: config-kafka
+          configMap:
+            name: config-kafka
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    messaging.knative.dev/channel: kafka-channel
+    messaging.knative.dev/role: dispatcher
+  name: kafka-ch-dispatcher
+  namespace: knative-eventing
+spec:
+  ports:
+  - name: http-dispatcher
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    messaging.knative.dev/channel: kafka-channel
+    messaging.knative.dev/role: dispatcher

--- a/kafka/channel/pkg/dispatcher/dispatcher.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher.go
@@ -90,7 +90,7 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 
 	producer, err := sarama.NewAsyncProducer(args.Brokers, conf)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create kafka producer for brokers %v : %v", args.Brokers, err)
+		return nil, fmt.Errorf("unable to create kafka producer against Kafka bootstrap servers %v : %v", args.Brokers, err)
 	}
 
 	dispatcher := &KafkaDispatcher{

--- a/kafka/channel/pkg/dispatcher/dispatcher.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher.go
@@ -90,7 +90,7 @@ func NewDispatcher(ctx context.Context, args *KafkaDispatcherArgs) (*KafkaDispat
 
 	producer, err := sarama.NewAsyncProducer(args.Brokers, conf)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create kafka producer: %v", err)
+		return nil, fmt.Errorf("unable to create kafka producer for brokers %v : %v", args.Brokers, err)
 	}
 
 	dispatcher := &KafkaDispatcher{

--- a/kafka/channel/pkg/reconciler/controller/kafkachannel.go
+++ b/kafka/channel/pkg/reconciler/controller/kafkachannel.go
@@ -337,8 +337,8 @@ func (r *Reconciler) reconcileDispatcher(ctx context.Context, scope string, disp
 				return d, nil
 			} else {
 				kc.Status.MarkServiceFailed("DispatcherDeploymentUpdateFailed", "Failed to update the dispatcher deployment: %v", err)
+				return d, newDeploymentWarn(err)
 			}
-			return d, newDeploymentWarn(err)
 		}
 	}
 

--- a/kafka/channel/pkg/reconciler/controller/kafkachannel.go
+++ b/kafka/channel/pkg/reconciler/controller/kafkachannel.go
@@ -275,6 +275,7 @@ func (r *Reconciler) reconcileDispatcher(ctx context.Context, scope string, disp
 		DispatcherScope:     scope,
 		DispatcherNamespace: dispatcherNamespace,
 		Image:               r.dispatcherImage,
+		Replicas:            1,
 	}
 
 	expected := resources.MakeDispatcher(args)

--- a/kafka/channel/pkg/reconciler/controller/kafkachannel.go
+++ b/kafka/channel/pkg/reconciler/controller/kafkachannel.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"reflect"
+
+	"k8s.io/utils/pointer"
 
 	"github.com/Shopify/sarama"
 
@@ -295,18 +296,41 @@ func (r *Reconciler) reconcileDispatcher(ctx context.Context, scope string, disp
 		kc.Status.MarkDispatcherUnknown("DispatcherDeploymentFailed", "Failed to get dispatcher deployment: %v", err)
 		return nil, err
 	} else {
+		existing := utils.FindContainer(d, resources.DispatcherContainerName)
+		if existing == nil {
+			logging.FromContext(ctx).Errorw("Container %s does not exist in existing dispatcher deployment. Updating the deployment", resources.DispatcherContainerName)
+			d, err := r.KubeClientSet.AppsV1().Deployments(dispatcherNamespace).Update(expected)
+			if err == nil {
+				controller.GetEventRecorder(ctx).Event(kc, corev1.EventTypeNormal, dispatcherDeploymentUpdated, "Dispatcher deployment updated")
+				kc.Status.PropagateDispatcherStatus(&d.Status)
+				return d, nil
+			} else {
+				kc.Status.MarkServiceFailed("DispatcherDeploymentUpdateFailed", "Failed to update the dispatcher deployment: %v", err)
+			}
+			return d, newDeploymentWarn(err)
+		}
+
+		expectedContainer := utils.FindContainer(expected, resources.DispatcherContainerName)
+		if expectedContainer == nil {
+			return nil, errors.New(fmt.Sprintf("Container %s does not exist in expected dispatcher deployment. Cannot check if the deployment needs an update.", resources.DispatcherContainerName))
+		}
+
 		needsUpdate := false
 
-		if !reflect.DeepEqual(expected.Spec.Template.Spec.Containers[0].Image, d.Spec.Template.Spec.Containers[0].Image) {
-			logging.FromContext(ctx).Infof("Deployment image is not what we expect it to be, updating Deployment Got: %q Expect: %q", expected.Spec.Template.Spec.Containers[0].Image, d.Spec.Template.Spec.Containers[0].Image)
+		if existing.Image != expectedContainer.Image {
+			logging.FromContext(ctx).Infof("Dispatcher deployment image is not what we expect it to be, updating Deployment Got: %q Expect: %q", expected.Spec.Template.Spec.Containers[0].Image, d.Spec.Template.Spec.Containers[0].Image)
+			existing.Image = expectedContainer.Image
 			needsUpdate = true
-		} else if !reflect.DeepEqual(expected.Spec.Replicas, d.Spec.Replicas) {
-			logging.FromContext(ctx).Infof("Deployment image is not what we expect it to be, updating Deployment Got: %q Expect: %q", expected.Spec.Template.Spec.Containers[0].Image, d.Spec.Template.Spec.Containers[0].Image)
+		}
+
+		if *d.Spec.Replicas == 0 {
+			logging.FromContext(ctx).Infof("Dispatcher deployment has 0 replicas. Scaling up deployment to 1 replicas")
+			d.Spec.Replicas = pointer.Int32Ptr(1)
 			needsUpdate = true
 		}
 
 		if needsUpdate {
-			d, err := r.KubeClientSet.AppsV1().Deployments(dispatcherNamespace).Update(expected)
+			d, err := r.KubeClientSet.AppsV1().Deployments(dispatcherNamespace).Update(d)
 			if err == nil {
 				controller.GetEventRecorder(ctx).Event(kc, corev1.EventTypeNormal, dispatcherDeploymentUpdated, "Dispatcher deployment updated")
 				kc.Status.PropagateDispatcherStatus(&d.Status)

--- a/kafka/channel/pkg/reconciler/controller/kafkachannel_test.go
+++ b/kafka/channel/pkg/reconciler/controller/kafkachannel_test.go
@@ -413,7 +413,7 @@ func TestDeploymentUpdatedOnImageChange(t *testing.T) {
 		Name: "Works, topic already exists",
 		Key:  kcKey,
 		Objects: []runtime.Object{
-			makeDeploymentWithImage("differentimage"),
+			makeDeploymentWithImageAndReplicas("differentimage", 1),
 			makeService(),
 			makeReadyEndpoints(),
 			reconcilekafkatesting.NewKafkaChannel(kcName, testNS,
@@ -441,6 +441,141 @@ func TestDeploymentUpdatedOnImageChange(t *testing.T) {
 		}},
 		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, dispatcherDeploymentUpdated, "Dispatcher deployment updated"),
+			Eventf(corev1.EventTypeNormal, "KafkaChannelReconciled", `KafkaChannel reconciled: "test-namespace/test-kc"`),
+		},
+	}
+
+	row.Test(t, reconcilertesting.MakeFactory(func(ctx context.Context, listers *reconcilekafkatesting.Listers, cmw configmap.Watcher) controller.Reconciler {
+
+		r := &Reconciler{
+			systemNamespace: testNS,
+			dispatcherImage: testDispatcherImage,
+			kafkaConfig: &KafkaConfig{
+				Brokers: []string{brokerName},
+			},
+			kafkachannelLister: listers.GetKafkaChannelLister(),
+			// TODO fix
+			kafkachannelInformer: nil,
+			deploymentLister:     listers.GetDeploymentLister(),
+			serviceLister:        listers.GetServiceLister(),
+			endpointsLister:      listers.GetEndpointsLister(),
+			kafkaClusterAdmin: &mockClusterAdmin{
+				mockCreateTopicFunc: func(topic string, detail *sarama.TopicDetail, validateOnly bool) error {
+					errMsg := sarama.ErrTopicAlreadyExists.Error()
+					return &sarama.TopicError{
+						Err:    sarama.ErrTopicAlreadyExists,
+						ErrMsg: &errMsg,
+					}
+				},
+			},
+			kafkaClientSet:    fakekafkaclient.Get(ctx),
+			KubeClientSet:     kubeclient.Get(ctx),
+			EventingClientSet: eventingClient.Get(ctx),
+		}
+		return kafkachannel.NewReconciler(ctx, logging.FromContext(ctx), r.kafkaClientSet, listers.GetKafkaChannelLister(), controller.GetEventRecorder(ctx), r)
+	}, zap.L()))
+}
+
+func TestDeploymentZeroReplicas(t *testing.T) {
+	kcKey := testNS + "/" + kcName
+	row := TableRow{
+		Name: "Works, topic already exists",
+		Key:  kcKey,
+		Objects: []runtime.Object{
+			makeDeploymentWithImageAndReplicas(testDispatcherImage, 0),
+			makeService(),
+			makeReadyEndpoints(),
+			reconcilekafkatesting.NewKafkaChannel(kcName, testNS,
+				reconcilekafkatesting.WithKafkaFinalizer(finalizerName)),
+		},
+		WantErr: false,
+		WantCreates: []runtime.Object{
+			makeChannelService(reconcilekafkatesting.NewKafkaChannel(kcName, testNS)),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: makeDeployment(),
+		}},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: reconcilekafkatesting.NewKafkaChannel(kcName, testNS,
+				reconcilekafkatesting.WithInitKafkaChannelConditions,
+				reconcilekafkatesting.WithKafkaFinalizer(finalizerName),
+				reconcilekafkatesting.WithKafkaChannelConfigReady(),
+				reconcilekafkatesting.WithKafkaChannelTopicReady(),
+				//				reconcilekafkatesting.WithKafkaChannelDeploymentReady(),
+				reconcilekafkatesting.WithKafkaChannelServiceReady(),
+				reconcilekafkatesting.WithKafkaChannelEndpointsReady(),
+				reconcilekafkatesting.WithKafkaChannelChannelServiceReady(),
+				reconcilekafkatesting.WithKafkaChannelAddress(channelServiceAddress),
+			),
+		}},
+		WantEvents: []string{
+			Eventf(corev1.EventTypeNormal, dispatcherDeploymentUpdated, "Dispatcher deployment updated"),
+			Eventf(corev1.EventTypeNormal, "KafkaChannelReconciled", `KafkaChannel reconciled: "test-namespace/test-kc"`),
+		},
+	}
+
+	row.Test(t, reconcilertesting.MakeFactory(func(ctx context.Context, listers *reconcilekafkatesting.Listers, cmw configmap.Watcher) controller.Reconciler {
+
+		r := &Reconciler{
+			systemNamespace: testNS,
+			dispatcherImage: testDispatcherImage,
+			kafkaConfig: &KafkaConfig{
+				Brokers: []string{brokerName},
+			},
+			kafkachannelLister: listers.GetKafkaChannelLister(),
+			// TODO fix
+			kafkachannelInformer: nil,
+			deploymentLister:     listers.GetDeploymentLister(),
+			serviceLister:        listers.GetServiceLister(),
+			endpointsLister:      listers.GetEndpointsLister(),
+			kafkaClusterAdmin: &mockClusterAdmin{
+				mockCreateTopicFunc: func(topic string, detail *sarama.TopicDetail, validateOnly bool) error {
+					errMsg := sarama.ErrTopicAlreadyExists.Error()
+					return &sarama.TopicError{
+						Err:    sarama.ErrTopicAlreadyExists,
+						ErrMsg: &errMsg,
+					}
+				},
+			},
+			kafkaClientSet:    fakekafkaclient.Get(ctx),
+			KubeClientSet:     kubeclient.Get(ctx),
+			EventingClientSet: eventingClient.Get(ctx),
+		}
+		return kafkachannel.NewReconciler(ctx, logging.FromContext(ctx), r.kafkaClientSet, listers.GetKafkaChannelLister(), controller.GetEventRecorder(ctx), r)
+	}, zap.L()))
+}
+
+func TestDeploymentMoreThanOneReplicas(t *testing.T) {
+	kcKey := testNS + "/" + kcName
+	row := TableRow{
+		Name: "Works, topic already exists",
+		Key:  kcKey,
+		Objects: []runtime.Object{
+			makeDeploymentWithImageAndReplicas(testDispatcherImage, 3),
+			makeService(),
+			makeReadyEndpoints(),
+			reconcilekafkatesting.NewKafkaChannel(kcName, testNS,
+				reconcilekafkatesting.WithKafkaFinalizer(finalizerName)),
+		},
+		WantErr: false,
+		WantCreates: []runtime.Object{
+			makeChannelService(reconcilekafkatesting.NewKafkaChannel(kcName, testNS)),
+		},
+		WantUpdates: []clientgotesting.UpdateActionImpl{},
+		WantStatusUpdates: []clientgotesting.UpdateActionImpl{{
+			Object: reconcilekafkatesting.NewKafkaChannel(kcName, testNS,
+				reconcilekafkatesting.WithInitKafkaChannelConditions,
+				reconcilekafkatesting.WithKafkaFinalizer(finalizerName),
+				reconcilekafkatesting.WithKafkaChannelConfigReady(),
+				reconcilekafkatesting.WithKafkaChannelTopicReady(),
+				//				reconcilekafkatesting.WithKafkaChannelDeploymentReady(),
+				reconcilekafkatesting.WithKafkaChannelServiceReady(),
+				reconcilekafkatesting.WithKafkaChannelEndpointsReady(),
+				reconcilekafkatesting.WithKafkaChannelChannelServiceReady(),
+				reconcilekafkatesting.WithKafkaChannelAddress(channelServiceAddress),
+			),
+		}},
+		WantEvents: []string{
 			Eventf(corev1.EventTypeNormal, "KafkaChannelReconciled", `KafkaChannel reconciled: "test-namespace/test-kc"`),
 		},
 	}
@@ -570,15 +705,16 @@ func (ca *mockClusterAdmin) DeleteConsumerGroup(group string) error {
 
 var _ sarama.ClusterAdmin = (*mockClusterAdmin)(nil)
 
-func makeDeploymentWithImage(image string) *appsv1.Deployment {
+func makeDeploymentWithImageAndReplicas(image string, replicas int32) *appsv1.Deployment {
 	return resources.MakeDispatcher(resources.DispatcherArgs{
 		DispatcherNamespace: testNS,
 		Image:               image,
+		Replicas:            replicas,
 	})
 }
 
 func makeDeployment() *appsv1.Deployment {
-	return makeDeploymentWithImage(testDispatcherImage)
+	return makeDeploymentWithImageAndReplicas(testDispatcherImage, 1)
 }
 
 func makeReadyDeployment() *appsv1.Deployment {

--- a/kafka/channel/pkg/reconciler/controller/resources/dispatcher.go
+++ b/kafka/channel/pkg/reconciler/controller/resources/dispatcher.go
@@ -39,11 +39,12 @@ type DispatcherArgs struct {
 	DispatcherScope     string
 	DispatcherNamespace string
 	Image               string
+	Replicas            int32
 }
 
 // MakeDispatcher generates the dispatcher deployment for the KafKa channel
 func MakeDispatcher(args DispatcherArgs) *v1.Deployment {
-	replicas := int32(1)
+	replicas := args.Replicas
 
 	return &v1.Deployment{
 		TypeMeta: metav1.TypeMeta{

--- a/kafka/channel/pkg/reconciler/controller/resources/dispatcher.go
+++ b/kafka/channel/pkg/reconciler/controller/resources/dispatcher.go
@@ -24,6 +24,8 @@ import (
 	"knative.dev/pkg/system"
 )
 
+const DispatcherContainerName = "dispatcher"
+
 var (
 	serviceAccountName = "kafka-ch-dispatcher"
 	dispatcherName     = "kafka-ch-dispatcher"
@@ -65,7 +67,7 @@ func MakeDispatcher(args DispatcherArgs) *v1.Deployment {
 					ServiceAccountName: serviceAccountName,
 					Containers: []corev1.Container{
 						{
-							Name:  "dispatcher",
+							Name:  DispatcherContainerName,
 							Image: args.Image,
 							Env:   makeEnv(args),
 							Ports: []corev1.ContainerPort{{

--- a/kafka/channel/pkg/reconciler/controller/resources/dispatcher_test.go
+++ b/kafka/channel/pkg/reconciler/controller/resources/dispatcher_test.go
@@ -38,6 +38,7 @@ func TestNewDispatcher(t *testing.T) {
 		DispatcherScope:     "cluster",
 		DispatcherNamespace: testNS,
 		Image:               imageName,
+		Replicas:            1,
 	}
 
 	replicas := int32(1)
@@ -120,6 +121,7 @@ func TestNewNamespaceDispatcher(t *testing.T) {
 		DispatcherScope:     "namespace",
 		DispatcherNamespace: testNS,
 		Image:               imageName,
+		Replicas:            1,
 	}
 
 	replicas := int32(1)

--- a/kafka/channel/pkg/utils/util.go
+++ b/kafka/channel/pkg/utils/util.go
@@ -93,7 +93,7 @@ func TopicName(separator, namespace, name string) string {
 }
 
 func FindContainer(d *appsv1.Deployment, containerName string) *corev1.Container {
-	for i, _ := range d.Spec.Template.Spec.Containers {
+	for i := range d.Spec.Template.Spec.Containers {
 		if d.Spec.Template.Spec.Containers[i].Name == containerName {
 			return &d.Spec.Template.Spec.Containers[i]
 		}

--- a/kafka/channel/pkg/utils/util.go
+++ b/kafka/channel/pkg/utils/util.go
@@ -19,6 +19,8 @@ package utils
 import (
 	"errors"
 	"fmt"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"strings"
 
 	"knative.dev/pkg/configmap"
@@ -88,4 +90,14 @@ func GetKafkaConfig(configMap map[string]string) (*KafkaConfig, error) {
 func TopicName(separator, namespace, name string) string {
 	topic := []string{knativeKafkaTopicPrefix, namespace, name}
 	return strings.Join(topic, separator)
+}
+
+func FindContainer(d *appsv1.Deployment, containerName string) *corev1.Container {
+	for i, _ := range d.Spec.Template.Spec.Containers {
+		if d.Spec.Template.Spec.Containers[i].Name == containerName {
+			return &d.Spec.Template.Spec.Containers[i]
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
Fixes #1188

## Proposed Changes

- Create the dispatcher deployment and service in advance
- Deployment has 0 replicas initially and will be scaled up when the first KafkaChannel is created
- Existing reconcilation logic is kept as it is harmless
- Also tested with namespaced channels

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
🐛 Fix bug
Cluster scoped KafkaChannel dispatcher is now created with 0 replicas in advance and will be scaled up with the creation of the first KafkaChannel. No manual operation is needed when upgrading.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
