### PR TITLE
[Backport 0.16] Fix KafkaChannel conversion (#1398)

### DIFF
--- a/kafka/channel/config/300-kafka-channel.yaml
+++ b/kafka/channel/config/300-kafka-channel.yaml
@@ -66,3 +66,10 @@ spec:
   - name: v1beta1
     served: true
     storage: false
+  conversion:
+    strategy: Webhook
+    conversionReviewVersions: ["v1beta1", "v1alpha1"]
+    webhookClientConfig:
+      service:
+        name: kafka-webhook
+        namespace: knative-eventing


### PR DESCRIPTION
(cherry picked from commit e4de8d36412c54da4722cc35eb2a748424c8edf5)

Fixes #1539

## Proposed Changes

- Backport https://github.com/knative/eventing-contrib/pull/1398 as it affects 0.16 too. See https://github.com/knative/eventing-contrib/issues/1539

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
Fix KafkaChannel conversion
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->

Verification:
- Try the instructions at https://github.com/knative/eventing-contrib/issues/1539