### PR TITLE
[Automated] Fix misspellings

### DIFF
--- a/test/config/100-strimzi-cluster-operator-0.19.0.yaml
+++ b/test/config/100-strimzi-cluster-operator-0.19.0.yaml
@@ -8428,7 +8428,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
-                            description: Refernce to a key in a ConfigMap.
+                            description: References to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:
@@ -11243,7 +11243,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
-                            description: Refernce to a key in a ConfigMap.
+                            description: References to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:
@@ -12543,7 +12543,7 @@ spec:
                                 type: string
                               optional:
                                 type: boolean
-                            description: Refernce to a key in a ConfigMap.
+                            description: References to a key in a ConfigMap.
                           secretKeyRef:
                             type: object
                             properties:


### PR DESCRIPTION
Produced via:
```shell
export FILES=( $(find . -type f -not -path './vendor/*' -not -path './third_party/*' -not -path './.git/*') )
misspell -w "${FILES[@]}"
```
/cc n3wscott grantr lberk matzew
/assign n3wscott grantr lberk matzew