### PR TITLE
[release-0.18] Remove SQS Source from release artifacts

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -25,7 +25,6 @@ export GO111MODULE=on
 declare -A COMPONENTS
 COMPONENTS=(
   ["appender.yaml"]="config/tools/appender"
-  ["awssqs.yaml"]="awssqs/config"
   ["event-display.yaml"]="config/tools/event-display"
   ["kafka-source.yaml"]="kafka/source/config"
   ["kafka-channel.yaml"]="kafka/channel/config"


### PR DESCRIPTION
Release failed :sob: : https://prow.knative.dev/view/gs/knative-prow/logs/ci-knative-eventing-contrib-auto-release/1311162317588664321#1:build-log.txt%3A7148
```
2020/09/30 05:08:35 Error enumerating files: lstat awssqs/config/: no such file or directory
```

# Proposed Changes

- [release-0.18] Remove AWS Source from release artifacts