### PR TITLE
KafkaSource config cluster role correction

### DIFF
--- a/kafka/source/config/roles/clusterrole.yaml
+++ b/kafka/source/config/roles/clusterrole.yaml
@@ -49,14 +49,7 @@ rules:
   resources:
   - kafkabindings
   - kafkabindings/finalizers
-  verbs: &everything
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
+  verbs: *everything
 
 - apiGroups:
   - bindings.knative.dev
@@ -111,14 +104,7 @@ rules:
   resources:
     - "mutatingwebhookconfigurations"
     - "validatingwebhookconfigurations"
-  verbs: &everything
-    - "get"
-    - "list"
-    - "create"
-    - "update"
-    - "delete"
-    - "patch"
-    - "watch"
+  verbs: *everything
 
 # Necessary for conversion webhook. These are copied from the serving
 # TODO: Do we really need all these permissions?

--- a/kafka/source/config/roles/clusterrole.yaml
+++ b/kafka/source/config/roles/clusterrole.yaml
@@ -112,14 +112,7 @@ rules:
     - "apiextensions.k8s.io"
   resources:
     - "customresourcedefinitions"
-  verbs:
-    - "get"
-    - "list"
-    - "create"
-    - "update"
-    - "delete"
-    - "patch"
-    - "watch"
+  verbs: *everything
 
 ---
 # The role is needed for the aggregated role source-observer in knative-eventing to provide readonly access to "Sources".


### PR DESCRIPTION
The &everything reference was defined multiple times, which makes Ansible break when processing the file.
Correction to reuse the reference instead as it's already there.