### PR TITLE
[0.18] Port https://github.com/knative-sandbox/eventing-kafka/pull/81

### DIFF
--- a/kafka/channel/config/deployments/webhook.yaml
+++ b/kafka/channel/config/deployments/webhook.yaml
@@ -66,7 +66,9 @@ spec:
             httpHeaders:
             - name: k-kubelet-probe
               value: "webhook"
-        livenessProbe: *probe
+        livenessProbe:
+          <<: *probe
+          initialDelaySeconds: 20
 
       # Our webhook should gracefully terminate by lame ducking first, set this to a sufficiently
       # high value that we respect whatever value it has configured for the lame duck grace period.

--- a/kafka/source/config/deployments/controller.yaml
+++ b/kafka/source/config/deployments/controller.yaml
@@ -60,7 +60,9 @@ spec:
             httpHeaders:
             - name: k-kubelet-probe
               value: "webhook"
-        livenessProbe: *probe
+        livenessProbe:
+          <<: *probe
+          initialDelaySeconds: 20
 
       serviceAccount: kafka-controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
Port https://github.com/knative-sandbox/eventing-kafka/pull/81

Relevant issue for master branch: https://github.com/knative/eventing-contrib/issues/1554

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Increase the livenessProbe's initialDelaySeconds to 20 secs so that the pod doesn't get killed before the cert reconciliation is done

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
Fixed the bug that caused Kafka channel webhook go in crash loop
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
