### PR TITLE
[0.17] Fix KafkaSource conversion

### DIFF
--- a/kafka/source/pkg/apis/sources/v1alpha1/kafka_conversion.go
+++ b/kafka/source/pkg/apis/sources/v1alpha1/kafka_conversion.go
@@ -44,8 +44,7 @@ func (source *KafkaSource) ConvertTo(ctx context.Context, obj apis.Convertible) 
 			Topics:        source.Spec.Topics,
 			ConsumerGroup: source.Spec.ConsumerGroup,
 		}
-		sink.Status.Status = source.Status.Status
-		source.Status.Status.ConvertTo(ctx, &sink.Status.Status)
+		source.Status.Status.DeepCopyInto(&sink.Status.Status)
 		// Optionals
 		if source.Spec.Sink != nil {
 			sink.Spec.Sink = *source.Spec.Sink.DeepCopy()
@@ -83,8 +82,7 @@ func (sink *KafkaSource) ConvertFrom(ctx context.Context, obj apis.Convertible) 
 		if reflect.DeepEqual(*sink.Spec.Sink, duckv1.Destination{}) {
 			sink.Spec.Sink = nil
 		}
-		sink.Status.Status = source.Status.Status
-		source.Status.Status.ConvertTo(ctx, &source.Status.Status)
+		source.Status.Status.DeepCopyInto(&sink.Status.Status)
 		// Optionals
 		if source.Status.SinkURI != nil {
 			sink.Status.SinkURI = source.Status.SinkURI.DeepCopy()

--- a/kafka/source/pkg/apis/sources/v1alpha1/kafka_conversion_test.go
+++ b/kafka/source/pkg/apis/sources/v1alpha1/kafka_conversion_test.go
@@ -163,6 +163,9 @@ func TestKafkaSourceConversionRoundTripV1alpha1(t *testing.T) {
 						Conditions: duckv1.Conditions{{
 							Type:   "Ready",
 							Status: "True",
+						}, {
+							Type:   "SinkProvided",
+							Status: "True",
 						}},
 						Annotations: map[string]string{
 							"foo": "bar",
@@ -326,6 +329,9 @@ func TestKafkaSourceConversionRoundTripV1beta1(t *testing.T) {
 						ObservedGeneration: 1,
 						Conditions: duckv1.Conditions{{
 							Type:   "Ready",
+							Status: "True",
+						}, {
+							Type:   "SinkProvided",
 							Status: "True",
 						}},
 						Annotations: map[string]string{


### PR DESCRIPTION
Fixes #1649

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

- Fix KafkaSource conversion

That conversion had 2 problems:
- It was wrong that it was converting the source status into the **source** status again and this caused unnecessary updates in the status
- It was truncating the conditions other than `Ready`

Conversion tests had roundtrip test cases but they didn't fail. Now with 2 conditions the previous code makes the tests fail.

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🐛 Fix bug
Fix KafkaSource conversion which resulted in reconcilation churn
```
