### PR TITLE
Use SyncProducer to provide safer delivery

### DIFF
--- a/kafka/channel/pkg/dispatcher/dispatcher_test.go
+++ b/kafka/channel/pkg/dispatcher/dispatcher_test.go
@@ -19,14 +19,12 @@ package dispatcher
 import (
 	"context"
 	"errors"
-	"net/http"
 	"net/url"
 	"testing"
 
 	"knative.dev/eventing/pkg/channel/fanout"
 
 	"github.com/Shopify/sarama"
-	"github.com/cloudevents/sdk-go/v2/binding"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"go.uber.org/zap"
@@ -425,25 +423,9 @@ func TestUnsubscribeUnknownSub(t *testing.T) {
 
 func TestKafkaDispatcher_Start(t *testing.T) {
 	d := &KafkaDispatcher{}
-
 	err := d.Start(context.TODO())
 	if err == nil {
 		t.Errorf("Expected error want %s, got %s", "message receiver is not set", err)
-	}
-
-	receiver, err := eventingchannels.NewMessageReceiver(
-		func(ctx context.Context, channel eventingchannels.ChannelReference, message binding.Message, _ []binding.Transformer, _ http.Header) error {
-			return nil
-		},
-		zap.NewNop(),
-		eventingchannels.ResolveMessageChannelFromHostHeader(d.getChannelReferenceFromHost))
-	if err != nil {
-		t.Fatalf("Error creating new message receiver. Error:%s", err)
-	}
-	d.receiver = receiver
-	err = d.Start(context.TODO())
-	if err == nil {
-		t.Errorf("Expected error want %s, got %s", "kafkaAsyncProducer is not set", err)
 	}
 }
 


### PR DESCRIPTION
Backporting https://github.com/knative-sandbox/eventing-kafka/pull/181

<!-- Please include the 'why' behind your changes if no issue exists -->

## Proposed Changes

-
-
-

<!--
If this change has user-visible impact, follow the instructions below.
Examples include:

- 🎁 Add new feature
- 🐛 Fix bug
- 🧽 Update or clean up current behavior
- 🗑️ Remove feature or internal logic

Otherwise delete the rest of this template.
-->

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- 🧽 The consolidated KafkaChannel now relies by default on SyncProducer for safer event production.
```

**Docs**

<!--
📖 If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.
-->
