### PR TITLE
Set subscription readiness based on consumer group status

### DIFF
--- a/kafka/channel/cmd/channel_dispatcher/main.go
+++ b/kafka/channel/cmd/channel_dispatcher/main.go
@@ -35,8 +35,5 @@ func main() {
 		ctx = injection.WithNamespaceScope(ctx, ns)
 	}
 
-	// Do not run the dispatcher in leader-election mode
-	ctx = sharedmain.WithHADisabled(ctx)
-
 	sharedmain.MainWithContext(ctx, component, controller.NewController)
 }

--- a/kafka/channel/pkg/kafka/admin.go
+++ b/kafka/channel/pkg/kafka/admin.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"github.com/Shopify/sarama"
+	"knative.dev/pkg/logging"
+)
+
+var mutex sync.Mutex
+
+type ClusterAdminFactory func() (sarama.ClusterAdmin, error)
+
+type AdminClient interface {
+	// ListConsumerGroups Lists the consumer groups
+	ListConsumerGroups() ([]string, error)
+}
+
+// AdminClientManager manages a ClusterAdmin connection and recreates one when needed
+// it is made to overcome https://github.com/Shopify/sarama/issues/1162
+type AdminClientManager struct {
+	logger       *zap.SugaredLogger
+	adminFactory ClusterAdminFactory
+	clusterAdmin sarama.ClusterAdmin
+}
+
+func NewAdminClient(ctx context.Context, caFactory ClusterAdminFactory) (AdminClient, error) {
+	logger := logging.FromContext(ctx)
+	logger.Info("Creating a new AdminClient")
+	kafkaClusterAdmin, err := caFactory()
+	if err != nil {
+		logger.Errorw("error while creating ClusterAdmin", zap.Error(err))
+		return nil, err
+	}
+	return &AdminClientManager{
+		logger:       logger,
+		adminFactory: caFactory,
+		clusterAdmin: kafkaClusterAdmin,
+	}, nil
+}
+
+// ListConsumerGroups Returns a list of the consumer groups.
+//
+// In the occasion of errors, there will be a retry with an exponential backoff.
+// Due to a known issue in Sarama ClusterAdmin https://github.com/Shopify/sarama/issues/1162,
+// a new ClusterAdmin will be created with every retry until the call succeeds or
+// the timeout is reached.
+func (c *AdminClientManager) ListConsumerGroups() ([]string, error) {
+	c.logger.Info("Attempting to list consumer group")
+	mutex.Lock()
+	defer mutex.Unlock()
+	r := 0
+	// This gives us around ~13min of exponential backoff
+	max := 13
+	cgsMap, err := c.clusterAdmin.ListConsumerGroups()
+	for err != nil && r <= max {
+		// There's on error, let's retry and presume a new ClusterAdmin can fix it
+
+		// Calculate incremental delay following this https://docs.aws.amazon.com/general/latest/gr/api-retries.html
+		t := int(math.Pow(2, float64(r)) * 100)
+		d := time.Duration(t) * time.Millisecond
+		c.logger.Errorw("listing consumer group failed. Refreshing the ClusterAdmin and retrying.",
+			zap.Error(err),
+			zap.Duration("retry after", d),
+			zap.Int("Retry attempt", r),
+			zap.Int("Max retries", max),
+		)
+		time.Sleep(d)
+
+		// let's reconnect and try again
+		c.clusterAdmin, err = c.adminFactory()
+		r += 1
+		if err != nil {
+			// skip this attempt
+			continue
+		}
+		cgsMap, err = c.clusterAdmin.ListConsumerGroups()
+	}
+
+	if r > max {
+		return nil, fmt.Errorf("failed to refresh the culster admin and retry: %v", err)
+	}
+
+	return sets.StringKeySet(cgsMap).List(), nil
+}

--- a/kafka/channel/pkg/kafka/admin_test.go
+++ b/kafka/channel/pkg/kafka/admin_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kafka
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Shopify/sarama"
+
+	pkgtesting "knative.dev/pkg/logging/testing"
+)
+
+const testCG = "cg1"
+
+var m sync.RWMutex
+
+type FakeClusterAdmin struct {
+	sarama.ClusterAdmin
+	faulty bool
+}
+
+func (f *FakeClusterAdmin) ListConsumerGroups() (map[string]string, error) {
+	cgs := map[string]string{
+		testCG: "cg",
+	}
+	m.RLock()
+	defer m.RUnlock()
+	if f.faulty {
+		return nil, fmt.Errorf("Error")
+	}
+	return cgs, nil
+}
+
+func TestAdminClient(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(10)
+	ctx := pkgtesting.TestContextWithLogger(t)
+	f := &FakeClusterAdmin{}
+	ac, err := NewAdminClient(ctx, func() (sarama.ClusterAdmin, error) {
+		return f, nil
+	})
+	if err != nil {
+		t.Error("failed to obtain new client", err)
+	}
+	for i := 0; i < 10; i += 1 {
+		go func() {
+			doList(t, ac)
+			check := make(chan struct{})
+			go func() {
+				m.Lock()
+				f.faulty = true
+				m.Unlock()
+				check <- struct{}{}
+				time.Sleep(2 * time.Second)
+				m.Lock()
+				f.faulty = false
+				m.Unlock()
+				check <- struct{}{}
+			}()
+			<-check
+			doList(t, ac)
+			<-check
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+}
+
+func doList(t *testing.T, ac AdminClient) {
+	cgs, _ := ac.ListConsumerGroups()
+	if len(cgs) != 1 {
+		t.Fatalf("list consumer group: got %d, want %d", len(cgs), 1)
+	}
+	if cgs[0] != testCG {
+		t.Fatalf("consumer group: got %s, want %s", cgs[0], testCG)
+	}
+}

--- a/kafka/channel/pkg/reconciler/controller/consumer_group_watcher.go
+++ b/kafka/channel/pkg/reconciler/controller/consumer_group_watcher.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"knative.dev/pkg/logging"
+
+	"knative.dev/eventing-contrib/kafka/channel/pkg/kafka"
+)
+
+var (
+	watchersMtx sync.RWMutex
+	cacheMtx    sync.RWMutex
+	// Hooks into the poll logic for testing
+	after = time.After
+	done  = func() {}
+)
+
+type ConsumerGroupHandler func()
+type Matcher func(string) bool
+
+type ConsumerGroupWatcher interface {
+	// Start instructs the watcher to start polling for the consumer groups and
+	// notify any observers on the event of any changes
+	Start() error
+
+	// Terminate instructs the watcher to stop polling and clear the watchers cache
+	Terminate()
+
+	// Watch registers callback on the event of any changes observed
+	// on the consumer groups. watcherID is an arbitrary string the user provides
+	// that will be used to identify his callbacks when provided to Forget(watcherID).
+	//
+	// To ensure this is event-triggered, level-driven,
+	// we don't pass the updates to the callback, instead the observer is expected
+	// to use List() to get the updated list of ConsumerGroups.
+	Watch(watcherID string, callback ConsumerGroupHandler) error
+
+	// Forget removes all callbacks that correspond to the watcherID
+	Forget(watcherID string)
+
+	// List returns all the cached consumer groups that match matcher.
+	// It will return an empty slice if none matched or the cache is empty
+	List(matcher Matcher) []string
+}
+
+type WatcherImpl struct {
+	logger *zap.SugaredLogger
+	//TODO name?
+	watchers             map[string]ConsumerGroupHandler
+	cachedConsumerGroups sets.String
+	adminClient          kafka.AdminClient
+	pollDuration         time.Duration
+	done                 chan struct{}
+}
+
+func NewConsumerGroupWatcher(ctx context.Context, ac kafka.AdminClient, pollDuration time.Duration) ConsumerGroupWatcher {
+	return &WatcherImpl{
+		logger:               logging.FromContext(ctx),
+		adminClient:          ac,
+		pollDuration:         pollDuration,
+		watchers:             make(map[string]ConsumerGroupHandler),
+		cachedConsumerGroups: sets.String{},
+	}
+}
+
+func (w *WatcherImpl) Start() error {
+	w.logger.Infow("ConsumerGroupWatcher starting. Polling for consumer groups", zap.Duration("poll duration", w.pollDuration))
+	go func() {
+		for {
+			select {
+			case <-after(w.pollDuration):
+				// let's get current observed consumer groups
+				observedCGs, err := w.adminClient.ListConsumerGroups()
+				if err != nil {
+					w.logger.Errorw("error while listing consumer groups", zap.Error(err))
+					continue
+				}
+				var notify bool
+				var changedGroup string
+				observedCGsSet := sets.String{}.Insert(observedCGs...)
+				// Look for observed CGs
+				for c := range observedCGsSet {
+					if !w.cachedConsumerGroups.Has(c) {
+						// This is the first appearance.
+						w.logger.Debugw("Consumer group observed. Caching.",
+							zap.String("consumer group", c))
+						changedGroup = c
+						notify = true
+						break
+					}
+				}
+				// Look for disappeared CGs
+				for c := range w.cachedConsumerGroups {
+					if !observedCGsSet.Has(c) {
+						// This CG was cached but it's no longer there.
+						w.logger.Debugw("Consumer group deleted.",
+							zap.String("consumer group", c))
+						changedGroup = c
+						notify = true
+						break
+					}
+				}
+				if notify {
+					cacheMtx.Lock()
+					w.cachedConsumerGroups = observedCGsSet
+					cacheMtx.Unlock()
+					w.notify(changedGroup)
+				}
+				done()
+			case <-w.done:
+				break
+			}
+		}
+	}()
+	return nil
+}
+
+func (w *WatcherImpl) Terminate() {
+	watchersMtx.Lock()
+	cacheMtx.Lock()
+	defer watchersMtx.Unlock()
+	defer cacheMtx.Unlock()
+
+	w.watchers = nil
+	w.cachedConsumerGroups = nil
+	w.done <- struct{}{}
+}
+
+// TODO explore returning a channel instead of a taking callback
+func (w *WatcherImpl) Watch(watcherID string, cb ConsumerGroupHandler) error {
+	w.logger.Debugw("Adding a new watcher", zap.String("watcherID", watcherID))
+	watchersMtx.Lock()
+	defer watchersMtx.Unlock()
+	w.watchers[watcherID] = cb
+
+	// notify at least once to get the current state
+	cb()
+	return nil
+}
+
+func (w *WatcherImpl) Forget(watcherID string) {
+	w.logger.Debugw("Forgetting watcher", zap.String("watcherID", watcherID))
+	watchersMtx.Lock()
+	defer watchersMtx.Unlock()
+	delete(w.watchers, watcherID)
+}
+
+func (w *WatcherImpl) List(matcher Matcher) []string {
+	w.logger.Debug("Listing consumer groups")
+	cacheMtx.RLock()
+	defer cacheMtx.RUnlock()
+	cgs := make([]string, 0)
+	for cg := range w.cachedConsumerGroups {
+		if matcher(cg) {
+			cgs = append(cgs, cg)
+		}
+	}
+	return cgs
+}
+
+func (w *WatcherImpl) notify(cg string) {
+	watchersMtx.RLock()
+	defer watchersMtx.RUnlock()
+
+	for _, cb := range w.watchers {
+		cb()
+	}
+}
+
+func Find(list []string, item string) bool {
+	for _, i := range list {
+		if i == item {
+			return true
+		}
+	}
+	return false
+}

--- a/kafka/channel/pkg/reconciler/controller/consumer_group_watcher_test.go
+++ b/kafka/channel/pkg/reconciler/controller/consumer_group_watcher_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2020 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	pkgtesting "knative.dev/pkg/logging/testing"
+)
+
+//TODO how to mock the sarama AdminClient
+type FakeClusterAdmin struct {
+	mutex sync.RWMutex
+	cgs   sets.String
+}
+
+func (fake *FakeClusterAdmin) ListConsumerGroups() ([]string, error) {
+	fake.mutex.RLock()
+	defer fake.mutex.RUnlock()
+	return fake.cgs.List(), nil
+}
+
+func (fake *FakeClusterAdmin) deleteCG(cg string) {
+	fake.mutex.Lock()
+	defer fake.mutex.Unlock()
+	fake.cgs.Delete(cg)
+}
+
+func TestKafkaWatcher(t *testing.T) {
+	cgname := "kafka.event-example.default-kne-trigger.0d9c4383-1e68-42b5-8c3a-3788274404c5"
+	wid := "channel-abc"
+	cgs := sets.String{}
+	cgs.Insert(cgname)
+	ca := FakeClusterAdmin{
+		cgs: cgs,
+	}
+
+	ch := make(chan sets.String, 1)
+
+	w := NewConsumerGroupWatcher(pkgtesting.TestContextWithLogger(t), &ca, 2*time.Second)
+	w.Watch(wid, func() {
+		cgs := w.List(func(cg string) bool {
+			return cgname == cg
+		})
+		result := sets.String{}
+		result.Insert(cgs...)
+		ch <- result
+	})
+
+	w.Start()
+	<-ch
+	assertSync(t, ch, cgs)
+	ca.deleteCG(cgname)
+	assertSync(t, ch, sets.String{})
+}
+
+func assertSync(t *testing.T, ch chan sets.String, cgs sets.String) {
+	select {
+	case syncedCGs := <-ch:
+		if !syncedCGs.Equal(cgs) {
+			t.Errorf("observed and expected consumer groups do not match. got %v expected %v", syncedCGs, cgs)
+		}
+	case <-time.After(6 * time.Second):
+		t.Errorf("timedout waiting for consumer groups to sync")
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/knative-sandbox/eventing-kafka/pull/182
Fixes #134
Fixes #98 
Fixes knative/eventing-contrib#1556


## Proposed Changes

- Set subscription readiness based on consumer group status in the consolidated Kafka
- Set's KafkaChannel consolidated dispatcher to read-only
- Enables HA in KafkaChannel consolidated dispatcher

**Release Note**

<!--
🗒️ If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->

```release-note
- A bug was fixed in the consolidated KafkaChannel where subscriptions would show up in the channel's `status.subscribers` before the dispatcher becomes ready to dispatch messages for those subscribers.
- Consolidated KafkaChannel dispatcher's horizontal scalability works now seamlessly with reconciler leader election.
```