### PR TITLE
Update OWNERS_ALIASES to match autogen in community

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,31 +1,13 @@
 # In order to be an approver you need to be an approver in the eventing repo
 # or fulfill the requirements in https://github.com/knative/community/blob/master/ROLES.md#approver
 approvers:
-- toc
-- grantr
-- vaikas
-- n3wscott
-- matzew
-- lionelvillard
-- slinkydeveloper
-- lberk
-- pierDipi
-- aliok
+- technical-oversight-committee
+- eventing-writers
 
 # Reviewers are suggested from the reviewers list first, then the approvers
 # list. To add reviewers while spreading the load among existing approvers,
 # copy the approvers to the reviewers list too.
 reviewers:
-- grantr
-- vaikas
-- n3wscott
-- matzew
-- lionelvillard
-- slinkydeveloper
-- lberk
-- pierDipi
-- aliok
-
-# Add reviewers below
-- aslom
+- eventing-writers
+- eventing-reviewers
 

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,7 +27,7 @@ aliases:
   - tayarani
   - tommyreddad
 
-  productivity-approvers:
+  productivity-writers:
   - chizhg
   - n3wscott
   productivity-reviewers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,41 +1,37 @@
 aliases:
-  toc:
+  technical-oversight-committee:
   - evankanderson
   - grantr
   - markusthoemmes
   - mattmoor
-  - tcnghia
+  - rhuss
 
-  # These aliases are for OWNERS of the various Source implementations. These
-  # Are in addition to the repo level OWNERS.
+  eventing-writers:
+  - akashrv
+  - aliok
+  - antoineco
+  - devguyio
+  - grantr
+  - lberk
+  - lionelvillard
+  - matzew
+  - n3wscott
+  - pierDipi
+  - slinkydeveloper
+  - vaikas
+  - zhongduo
 
-  camel-approvers:
-    - nicolaferraro
-    - matzew
-  camel-reviewers:
-    - nicolaferraro
-    - matzew
-
-  kafka-approvers:
-    - lberk
-    - matzew
-  kafka-reviewers:
-    - lberk
-    - matzew
-
-  prometheus-approvers:
-    - syedriko
-    - matzew
-  prometheus-reviewers:
-    - syedriko
-    - matzew
+  eventing-reviewers:
+  - aslom
+  - nlopezgi
+  - tayarani
+  - tommyreddad
 
   productivity-approvers:
-  - chaodaiG
   - chizhg
+  - n3wscott
   productivity-reviewers:
-  - chaodaiG
   - coryrc
-  - chizhg
+  - evankanderson
   - steuhs
   - yt3liu

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
+- productivity-writers
 
 reviewers:
 - productivity-reviewers

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,7 +1,7 @@
 # The OWNERS file is used by prow to automatically merge approved PRs.
 
 approvers:
-- productivity-approvers
+- productivity-writers
 
 reviewers:
 - productivity-reviewers


### PR DESCRIPTION
See https://github.com/knative/community/pull/552 for the addition of groups/full OWNERS_ALIASES that will be synced.

This is a preparatory PR for landing OWNERS_ALIASES automation across the Knative org (alternative to the CODEOWNERS changes in knative-sandbox).

If this seems to be expanding permissions or otherwise likely to cause a problem, `/hold` this PR and comment here or on https://github.com/knative/community/pull/552.
